### PR TITLE
适应国内网络环境和加速docker构建

### DIFF
--- a/activemq/CVE-2016-3088/Dockerfile
+++ b/activemq/CVE-2016-3088/Dockerfile
@@ -2,7 +2,9 @@ FROM vulhub/activemq:5.11.1
 
 MAINTAINER phithon <root@leavesongs.com>
 
-RUN apt-get update \
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y cron rsyslog --no-install-recommends \
     && rm -r /var/lib/apt/lists/*
 

--- a/bash/shellshock/Dockerfile
+++ b/bash/shellshock/Dockerfile
@@ -10,7 +10,9 @@ ENV BUILD_TOOLS \
     bison \
     autoconf
 
-RUN apt-get update \
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get -y install $BUILD_TOOLS \
     && rm -rf /var/lib/apt/lists/*
 

--- a/cgi/httpoxy/Dockerfile
+++ b/cgi/httpoxy/Dockerfile
@@ -5,8 +5,10 @@ MAINTAINER phithon <root@leavesongs.com>
 COPY www /var/www/html
 
 RUN set -ex \
-	&& apt-get update && apt-get install -y zip unzip \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && apt-get update && apt-get install -y zip unzip \
     && wget -qO- https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && cd /var/www/html \
+    && composer config -g repo.packagist composer https://packagist.phpcomposer.com \
     && composer install \
     && apt-get purge -y --auto-remove wget zip unzip

--- a/couchdb/CVE-2017-12635/Dockerfile
+++ b/couchdb/CVE-2017-12635/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER phithon <root@leavesongs.com>
 ADD https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh /wait-for-it.sh
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install curl -y --no-install-recommends \
     && chmod +x /wait-for-it.sh \

--- a/django/CVE-2017-12794/Dockerfile
+++ b/django/CVE-2017-12794/Dockerfile
@@ -9,7 +9,7 @@ ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.s
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN mkdir /app \
-    && pip install -U -r /tmp/requirements.txt \
+    && pip install -i https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com -U -r /tmp/requirements.txt \
     && chmod +x /docker-entrypoint.sh /bin/wait-for-it.sh
 
 EXPOSE 8000

--- a/elasticsearch/CVE-2014-3120/Dockerfile
+++ b/elasticsearch/CVE-2014-3120/Dockerfile
@@ -3,11 +3,15 @@ FROM openjdk:8-jre
 MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y wget \
     && mkdir -p /usr/share/elasticsearch \
-    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.1.1.tar.gz | tar zx \
-        --strip-components 1 -C /usr/share/elasticsearch
+    && wget -q https://gitee.com/leehdsniper/vulhub-package/raw/master/elasticsearch-1.1.1.tar.gz \
+    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.1.1.tar.gz.sha1.txt | sha1sum -c \
+    && tar zvxf elasticsearch-1.1.1.tar.gz --strip-components 1 -C /usr/share/elasticsearch \
+    && rm elasticsearch-1.1.1.tar.gz
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 

--- a/elasticsearch/CVE-2015-1427/Dockerfile
+++ b/elasticsearch/CVE-2015-1427/Dockerfile
@@ -3,11 +3,15 @@ FROM openjdk:8-jre
 MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y wget \
     && mkdir -p /usr/share/elasticsearch \
-    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.4.2.tar.gz | tar zx \
-        --strip-components 1 -C /usr/share/elasticsearch
+    && wget -q https://gitee.com/leehdsniper/vulhub-package/raw/master/elasticsearch-1.4.2.tar.gz \
+    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.4.2.tar.gz.sha1.txt | sha1sum -c \
+    && tar zvxf elasticsearch-1.4.2.tar.gz --strip-components 1 -C /usr/share/elasticsearch \
+    && rm elasticsearch-1.4.2.tar.gz
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 

--- a/elasticsearch/CVE-2015-3337/Dockerfile
+++ b/elasticsearch/CVE-2015-3337/Dockerfile
@@ -3,11 +3,15 @@ FROM openjdk:8-jre
 MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y wget \
     && mkdir -p /usr/share/elasticsearch \
-    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.4.4.tar.gz | tar zx \
-        --strip-components 1 -C /usr/share/elasticsearch
+    && wget -q https://gitee.com/leehdsniper/vulhub-package/raw/master/elasticsearch-1.4.4.tar.gz \
+    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.4.4.tar.gz.sha1.txt | sha1sum -c \
+    && tar zvxf elasticsearch-1.4.4.tar.gz --strip-components 1 -C /usr/share/elasticsearch \
+    && rm elasticsearch-1.4.4.tar.gz
 
 WORKDIR /usr/share/elasticsearch
 

--- a/elasticsearch/CVE-2015-5531/Dockerfile
+++ b/elasticsearch/CVE-2015-5531/Dockerfile
@@ -3,11 +3,15 @@ FROM openjdk:8-jre
 MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y wget \
     && mkdir -p /usr/share/elasticsearch \
-    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz \
-        | tar zx --strip-components 1 -C /usr/share/elasticsearch
+    && wget -q https://gitee.com/leehdsniper/vulhub-package/raw/master/elasticsearch-1.6.0.tar.gz \
+    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz.sha1.txt | sha1sum -c \
+    && tar zvxf elasticsearch-1.6.0.tar.gz --strip-components 1 -C /usr/share/elasticsearch \
+    && rm elasticsearch-1.6.0.tar.gz
 
 WORKDIR /usr/share/elasticsearch
 

--- a/elasticsearch/WooYun-2015-110216/Dockerfile
+++ b/elasticsearch/WooYun-2015-110216/Dockerfile
@@ -7,11 +7,15 @@ RUN set -ex \
     && echo '<% out.println("Hello World! "); %>' | tee $CATALINA_HOME/webapps/ROOT/index.jsp
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y wget \
     && mkdir -p /usr/share/elasticsearch \
-    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.1.tar.gz \
-        | tar zx --strip-components 1 -C /usr/share/elasticsearch
+    && wget -q https://gitee.com/leehdsniper/vulhub-package/raw/master/elasticsearch-1.5.1.tar.gz \
+    && wget -qO- https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.1.tar.gz.sha1.txt | sha1sum -c \
+    && tar zvxf elasticsearch-1.5.1.tar.gz --strip-components 1 -C /usr/share/elasticsearch \
+    && rm elasticsearch-1.5.1.tar.gz
 
 ENV PATH /usr/share/elasticsearch/bin:$PATH
 

--- a/ffmpeg/CVE-2016-1897/Dockerfile
+++ b/ffmpeg/CVE-2016-1897/Dockerfile
@@ -3,6 +3,7 @@ FROM vulhub/ffmpeg:2.8.4
 MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex \
+    && sed -i 's/httpredir.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends php-cli
 

--- a/ffmpeg/phdays/Dockerfile
+++ b/ffmpeg/phdays/Dockerfile
@@ -3,6 +3,7 @@ FROM vulhub/ffmpeg:3.2.4
 MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends php-cli
 

--- a/flask/ssti/Dockerfile
+++ b/flask/ssti/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER phithon <root@leavesongs.com>
 ADD requirements.txt /tmp/requirements.txt
 
 RUN mkdir /app \
-    && pip install -U -r /tmp/requirements.txt
+    && pip install -i  https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com -U -r /tmp/requirements.txt
 
 EXPOSE 8000
 

--- a/git/CVE-2017-8386/Dockerfile
+++ b/git/CVE-2017-8386/Dockerfile
@@ -2,7 +2,8 @@ FROM vulhub/git:2.12.2
 
 MAINTAINER phithon <root@leavesongs.com>
 
-RUN apt-get update \
+RUN sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y man less openssh-server --no-install-recommends \
     && rm -r /var/lib/apt/lists/*
 

--- a/gitlab/CVE-2016-9086/Dockerfile
+++ b/gitlab/CVE-2016-9086/Dockerfile
@@ -11,7 +11,8 @@ ENV GITLAB_VERSION=8.13.1 \
     GITLAB_HOME="/home/git" \
     GITLAB_LOG_DIR="/var/log/gitlab" \
     GITLAB_CACHE_DIR="/etc/docker-gitlab" \
-    RAILS_ENV=production
+    RAILS_ENV=production \
+    LOCALPACKAGES_DIR="/packages"
 
 ENV GITLAB_INSTALL_DIR="${GITLAB_HOME}/gitlab" \
     GITLAB_SHELL_INSTALL_DIR="${GITLAB_HOME}/gitlab-shell" \
@@ -22,20 +23,19 @@ ENV GITLAB_INSTALL_DIR="${GITLAB_HOME}/gitlab" \
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
  && echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends \
+ && sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y vim.tiny wget sudo net-tools ca-certificates unzip apt-transport-https \
- && rm -rf /var/lib/apt/lists/*
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E1DD270288B4E6030699E45FA1715D88E1DF1F24 \
- && echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \
- && echo "deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8B3981E7A6852F782CC4951600A6F0A3C300EE8C \
- && echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" >> /etc/apt/sources.list \
- && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
- && echo 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir ${LOCALPACKAGES_DIR} \
+ && wget -qO- https://gitee.com/leehdsniper/vulhub-package/raw/master/gitlab_packages.tar.gz | tar zx --strip-components 1 -C ${LOCALPACKAGES_DIR} \
+ && echo "deb file://${LOCALPACKAGES_DIR}/ git-core/" >> /etc/apt/sources.list \
+ && echo "deb file://${LOCALPACKAGES_DIR}/ nginx/" >> /etc/apt/sources.list \
+ && echo "deb file://${LOCALPACKAGES_DIR}/ ruby2.3/" >> /etc/apt/sources.list \
+ && echo "deb file://${LOCALPACKAGES_DIR}/ ruby2.3-dev/" >> /etc/apt/sources.list \
+ && echo "deb file://${LOCALPACKAGES_DIR}/ postgresql-client/" >> /etc/apt/sources.list \
  && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y supervisor logrotate locales curl \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes supervisor logrotate locales curl \
       nginx openssh-server mysql-client postgresql-client redis-tools \
       git-core ruby${RUBY_VERSION} python2.7 python-docutils nodejs gettext-base \
       libmysqlclient18 libpq5 zlib1g libyaml-0-2 libssl1.0.0 \
@@ -44,7 +44,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E1DD270288B4E60
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && locale-gen en_US.UTF-8 \
  && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales \
- && gem install --no-document bundler \
+ && gem install --version '1.14.5' --no-document bundler \
  && rm -rf /var/lib/apt/lists/*
 
 COPY assets/build/ ${GITLAB_BUILD_DIR}/

--- a/gitlab/CVE-2016-9086/assets/build/install.sh
+++ b/gitlab/CVE-2016-9086/assets/build/install.sh
@@ -24,7 +24,7 @@ exec_as_git() {
 
 # install build dependencies for gem installation
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y ${BUILD_DEPENDENCIES}
+DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes ${BUILD_DEPENDENCIES}
 
 # https://en.wikibooks.org/wiki/Grsecurity/Application-specific_Settings#Node.js
 paxctl -Cm `which nodejs`
@@ -68,7 +68,7 @@ rm -rf ${GITLAB_BUILD_DIR}/gitlab-workhorse-${GITLAB_WORKHORSE_VERSION}.tar.gz
 chown -R ${GITLAB_USER}: ${GITLAB_WORKHORSE_INSTALL_DIR}
 
 echo "Downloading Go ${GOLANG_VERSION}..."
-wget -cnv https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz -P ${GITLAB_BUILD_DIR}/
+wget -cnv https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz -P ${GITLAB_BUILD_DIR}/
 tar -xf ${GITLAB_BUILD_DIR}/go${GOLANG_VERSION}.linux-amd64.tar.gz -C /tmp/
 
 cd ${GITLAB_WORKHORSE_INSTALL_DIR}
@@ -94,6 +94,9 @@ if [[ -d ${GEM_CACHE_DIR} ]]; then
   mv ${GEM_CACHE_DIR} ${GITLAB_INSTALL_DIR}/vendor/cache
   chown -R ${GITLAB_USER}: ${GITLAB_INSTALL_DIR}/vendor/cache
 fi
+
+echo "change mirrors of buddle"
+exec_as_git bundle config mirror.https://rubygems.org https://gems.ruby-china.org
 exec_as_git bundle install -j$(nproc) --deployment --without development test aws
 
 # make sure everything in ${GITLAB_HOME} is owned by ${GITLAB_USER} user

--- a/jenkins/CVE-2017-1000353/Dockerfile
+++ b/jenkins/CVE-2017-1000353/Dockerfile
@@ -2,7 +2,11 @@ FROM vulhub/openjdk:8-jdk
 
 MAINTAINER phithon <root@leavesongs.com>
 
-RUN apt-get update && apt-get install -y git curl wget && rm -rf /var/lib/apt/lists/*
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+    && echo 'deb http://mirrors.ustc.edu.cn/debian/ jessie-backports main contrib non-free' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y git curl wget && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_HOME /var/jenkins_home
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
@@ -11,14 +15,14 @@ RUN groupadd -g 1000 jenkins \
     && useradd -d "$JENKINS_HOME" -u 1000 -g 1000 -m -s /bin/bash jenkins
 
 ENV TINI_VERSION v0.14.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
+ADD https://gitee.com/leehdsniper/vulhub-package/raw/master/tini-${TINI_VERSION} /bin/tini
 RUN chmod +x /bin/tini
 
 ENV JENKINS_VERSION 2.46.1
 RUN set -ex \
     && [ -e /usr/share/jenkins ] || mkdir -p /usr/share/jenkins \
     && [ -e /usr/share/jenkins/ref ] || mkdir -p /usr/share/jenkins/ref \
-    && wget http://mirrors.jenkins.io/war-stable/${JENKINS_VERSION}/jenkins.war -O /usr/share/jenkins/jenkins.war \
+    && wget https://gitee.com/leehdsniper/vulhub-package/raw/master/jenkins-${JENKINS_VERSION}.war -O /usr/share/jenkins/jenkins.war \
     && chown -R jenkins "$JENKINS_HOME" /usr/share/jenkins/ref
 
 EXPOSE 8080

--- a/joomla/CVE-2015-8562/Dockerfile
+++ b/joomla/CVE-2015-8562/Dockerfile
@@ -6,12 +6,14 @@ MAINTAINER phithon <root@leavesongs.com>
 RUN a2enmod rewrite
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
+RUN sed -i 's/httpredir.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+	&& apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mysqli mcrypt zip
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/3.4.5/Joomla_3.4.5-Stable-Full_Package.zip \
+RUN curl -o joomla.zip -SL https://gitee.com/leehdsniper/vulhub-package/raw/master/Joomla_3.4.5-Stable-Full_Package.zip \
 	&& mkdir /usr/src/joomla \
 	&& unzip joomla.zip -d /usr/src/joomla \
 	&& rm joomla.zip \

--- a/joomla/CVE-2017-8917/Dockerfile
+++ b/joomla/CVE-2017-8917/Dockerfile
@@ -6,7 +6,9 @@ MAINTAINER phithon <root@leavesongs.com>
 RUN a2enmod rewrite
 
 # Install PHP extensions
-RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+	&& apt-get update && apt-get install -y libpng12-dev libjpeg-dev libmcrypt-dev zip unzip && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd
 RUN docker-php-ext-install mysqli
@@ -16,7 +18,7 @@ RUN docker-php-ext-install zip
 VOLUME /var/www/html
 
 # Download package and extract to web volume
-RUN curl -o joomla.zip -SL https://github.com/joomla/joomla-cms/releases/download/3.7.0/Joomla_3.7.0-Stable-Full_Package.zip \
+RUN curl -o joomla.zip -SL https://gitee.com/leehdsniper/vulhub-package/raw/master/Joomla_3.7.0-Stable-Full_Package.zip \
 	&& mkdir /usr/src/joomla \
 	&& unzip joomla.zip -d /usr/src/joomla \
 	&& rm joomla.zip \

--- a/openssl/heartbleed/Dockerfile
+++ b/openssl/heartbleed/Dockerfile
@@ -6,7 +6,9 @@ RUN ln -sf /dev/stdout /var/log/access.log \
 	&& ln -sf /dev/stderr /var/log/error.log \
     && ln -sf /usr/local/nginx/sbin/nginx /usr/sbin/nginx
 
-RUN apt-get update \
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y openssl \
     && mkdir -p /etc/ssl/nginx/ \
     && openssl req -x509 -nodes -days 365 -newkey rsa:2048 \

--- a/php/CVE-2012-1823/Dockerfile
+++ b/php/CVE-2012-1823/Dockerfile
@@ -24,12 +24,16 @@ ENV BUILD_TOOLS \
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN mkdir -p $PHP_INI_DIR/conf.d
 
-RUN apt-get update \
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn|g' /etc/apt/sources.list \
+    && sed -i 's|deb.debian.org|mirrors.ustc.edu.cn|g' /etc/apt/sources.list.d/backports.list \
+    && sed -i 's|deb.debian.org|mirrors.ustc.edu.cn|g' /etc/apt/sources.list.d/stretch.list \
+    && apt-get update \
     && apt-get -y install $BUILD_TOOLS \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/src/php \
-    && wget -qO- http://museum.php.net/php5/php-5.4.1.tar.gz | tar zx -C /usr/src/php --strip-components=1 \
+    && wget -qO- https://gitee.com/leehdsniper/vulhub-package/raw/master/php-5.4.1.tar.gz | tar zx -C /usr/src/php --strip-components=1 \
     && cd /usr/src/php \
     && ./configure \
 		--with-config-file-path="$PHP_INI_DIR" \

--- a/php/php_xxe/Dockerfile
+++ b/php/php_xxe/Dockerfile
@@ -2,7 +2,9 @@ FROM vulhub/php:7.1-apache
 
 MAINTAINER phithon <root@leavesongs.com>
 
-RUN apt-get update && apt-get install -y gcc wget
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn|g' /etc/apt/sources.list \
+	&& apt-get update && apt-get install -y gcc wget
 
 RUN wget http://xmlsoft.org/sources/libxml2-2.8.0.tar.gz -O /home/libxml2-2.8.0.tar.gz
 

--- a/phpmailer/CVE-2017-5223/Dockerfile
+++ b/phpmailer/CVE-2017-5223/Dockerfile
@@ -5,9 +5,12 @@ MAINTAINER phithon <root@leavesongs.com>
 COPY www/* /var/www/html/
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends git \
     && cd /var/www/html/ \
     && curl -sSL https://getcomposer.org/installer | php \
+    && php composer.phar config -g repo.packagist composer https://packagist.phpcomposer.com \
     && php composer.phar install \
     && rm -rf /var/lib/apt/lists/*

--- a/phpunit/CVE-2017-9841/Dockerfile
+++ b/phpunit/CVE-2017-9841/Dockerfile
@@ -2,11 +2,14 @@ FROM php:7.2-apache
 
 LABEL maintainer="phith0n <root@leavesongs.com>"
 
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends unzip; \
-    curl -#sL https://getcomposer.org/download/1.6.5/composer.phar -o /usr/local/bin/composer; \
-    chmod +x /usr/local/bin/composer; \
-    cd /var/www/html; \
-    composer require phpunit/phpunit:5.6.2; \
-    apt-get purge --auto-remove -y unzip; \
-    rm -rf /var/lib/apt/lists/*
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org/debian-security|mirrors.ustc.edu.cn/debian-security|g' /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && curl -#sL https://getcomposer.org/download/1.6.5/composer.phar -o /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer \
+    && cd /var/www/html \
+    && composer config -g repo.packagist composer https://packagist.phpcomposer.com \
+    && composer require phpunit/phpunit:5.6.2 \
+    && apt-get purge --auto-remove -y unzip \
+    && rm -rf /var/lib/apt/lists/*

--- a/python/PIL-CVE-2017-8291/Dockerfile
+++ b/python/PIL-CVE-2017-8291/Dockerfile
@@ -3,14 +3,16 @@ FROM vulhub/python:3.6
 MAINTAINER neargle <nearg1e.com@gmail.com>
 
 RUN set -ex \
+    && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
     && apt-get update \
     && apt-get install --no-install-recommends -y wget  \
-    && pip install -U pip \
-    && pip install "flask==0.12.2" "Pillow==4.2.1" \
+    && pip install -i  https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com -U pip \
+    && pip install -i  https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com "flask==0.12.2" "Pillow==4.2.1" \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
-    && wget -qO- https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs921/ghostscript-9.21-linux-x86_64.tgz \
+    && wget -qO- https://gitee.com/leehdsniper/vulhub-package/raw/master/ghostscript-9.21-linux-x86_64.tgz \
         | tar zx -C /tmp/ \
     && mkdir -p /opt/ghostscript \
     && mv /tmp/ghostscript-9.21-linux-x86_64/gs-921-linux-x86_64 /usr/local/bin/gs

--- a/python/unpickle/Dockerfile
+++ b/python/unpickle/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER phithon <root@leavesongs.com>
 ADD requirements.txt /tmp/requirements.txt
 
 RUN mkdir /app \
-    && pip install -U -r /tmp/requirements.txt
+    && pip install -i  https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com -U -r /tmp/requirements.txt
 
 EXPOSE 8000
 

--- a/rsync/common/Dockerfile
+++ b/rsync/common/Dockerfile
@@ -6,7 +6,9 @@ ADD rsyncd.conf /etc/rsyncd.conf
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 
-RUN apt-get update \
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.ustc.edu.cn/debian-security/|g' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install --no-install-recommends -y cron \
     && mkdir /data/ \
     && chmod +x /docker-entrypoint.sh \

--- a/ruby/CVE-2017-17405/Dockerfile
+++ b/ruby/CVE-2017-17405/Dockerfile
@@ -2,7 +2,8 @@ FROM vulhub/ruby:2.4.1
 
 MAINTAINER phithon <root@leavesongs.com>
 
-RUN gem install sinatra
+RUN gem sources --add https://gems.ruby-china.org/ --remove https://rubygems.org/ \
+    && gem install sinatra
 
 ADD web.rb /usr/src/web.rb
 

--- a/supervisor/CVE-2017-11610/Dockerfile
+++ b/supervisor/CVE-2017-11610/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER phithon <root@leavesongs.com>
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
-RUN pip install -U pip \
-    && pip install "supervisor==3.3.2" \
+RUN pip install -i https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com -U pip \
+    && pip install -i https://pypi.doubanio.com/simple/  --trusted-host pypi.doubanio.com "supervisor==3.3.2" \
     && echo_supervisord_conf | tee /usr/local/etc/supervisord.conf \
     && { \
         echo "[inet_http_server]"; \

--- a/wordpress/pwnscriptum/Dockerfile
+++ b/wordpress/pwnscriptum/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER phithon <root@leavesongs.com>
 
 RUN set -ex; \
     mkdir -p /usr/src/wordpress; \
-    wget -qO- https://github.com/WordPress/WordPress/archive/4.6.tar.gz | \
+    wget -qO- https://gitee.com/leehdsniper/vulhub-package/raw/master/WordPress.4.6.tar.gz | \
         tar zx -C /usr/src/wordpress --strip-components=1; \
 	chown -R www-data:www-data /usr/src/wordpress; \
 	rm -rf /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
1. 在Dockerfile中加入更换linux源为USTC源，加速apt-get
2. 优化gitlab Dockerfile中从ppa下载nginx、git等特定软件包速度太慢问题，将所需deb包打包发布到码云，加速下载并从本地安装
3. 修改pip源为豆瓣源
4. 修改ruby gem和bundler源为https://gems.ruby-china.org/源，加速下载
5. 修改php composer源为https://pkg.phpcomposer.com/
6. 将一些下载速度较慢的软件包发布到码云，修改了下载链接，码云地址https://gitee.com/leehdsniper/vulhub-package
7. 由于各类原因，仅在 elasticsearch 所有环境的Dockerfile中加入了软件包签名验证，所有签名从 elasticsearch官网获取，其他软件包需自行验证签名