### PR TITLE
修改访问路径的错误

### DIFF
--- a/weblogic/CVE-2018-2894/README.md
+++ b/weblogic/CVE-2018-2894/README.md
@@ -28,7 +28,7 @@ docker-compose up -d
 
 ## 漏洞复现
 
-访问`http://your-ip:7001/ws-utc/config.do`，设置Work Home Dir为`/u01/oracle/user_projects/domains/base_domain/servers/AdminServer/tmp/_WL_internal/com.oracle.webservices.wls.ws-testclient-app-wls/4mcj4y/war/css`。我将目录设置为ws-utc应用的静态文件css目录，访问这个目录是无需权限的，这一点很重要。
+访问`http://your-ip:7001/ws_utc/config.do`，设置Work Home Dir为`/u01/oracle/user_projects/domains/base_domain/servers/AdminServer/tmp/_WL_internal/com.oracle.webservices.wls.ws-testclient-app-wls/4mcj4y/war/css`。我将目录设置为ws-utc应用的静态文件css目录，访问这个目录是无需权限的，这一点很重要。
 
 ![](img/2.png)
 


### PR DESCRIPTION
将CVE-2018-2894/ReadMe.md 文件中访问地址由 http://your-ip:7001/ws-utc/config.do改为 http://your-ip:7001/ws_utc/config.do