### PR TITLE
Fix typo of "erray"

### DIFF
--- a/ghostscript/CVE-2019-6116/poc.png
+++ b/ghostscript/CVE-2019-6116/poc.png
@@ -33,7 +33,7 @@ errordict /typecheck {
 } put
 
 % The pseudo-operator .actual_pdfpaintproc from pdf_draw.ps pushes some
-% executable errays onto the operand stack that contain .forceput, but are not
+% executable arrays onto the operand stack that contain .forceput, but are not
 % marked as executeonly or pseudo-operators.
 %
 % The routine was attempting to pass them to ifelse, but we can cause that to


### PR DESCRIPTION
There is no such a word as "erray". 