### PR TITLE
Fixed Discuz git repository missing error

### DIFF
--- a/base/discuzx/3.4-20170801/Dockerfile
+++ b/base/discuzx/3.4-20170801/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex \
     && docker-php-ext-install mysql mysqli \
     && apt-get clean \
     && cd /tmp/ \
-    && git clone https://gitee.com/ComsenzDiscuz/DiscuzX.git \
+    && git clone https://gitee.com/Discuz/DiscuzX.git \
     && cd DiscuzX \
     && git checkout d7ec4030d5bcc2be9485a2543bab85b9757e3c14 \
     # d7ec4030d5bcc2be9485a2543bab85b9757e3c14 is discuzx(Release 20170801)


### PR DESCRIPTION
DiscuzX Gitee repository project is moved to <https://gitee.com/Discuz/DiscuzX.git>.