### PR TITLE
Update docker-compose.yml

### DIFF
--- a/discuz/x3.4-arbitrary-file-deletion/docker-compose.yml
+++ b/discuz/x3.4-arbitrary-file-deletion/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     ports:
       - "80:80"
   db:
-    image: mariadb
-    restart: always
+    image: mysql:5.5
     environment: 
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: ultrax


### PR DESCRIPTION
使用原始的mariadb作为数据库会导致discuz安装失败，报错内容：数据库连接错误php_network_getaddresses: getaddrinfo failed: Name or service not known您必须解决以上问题，安装才可以继续，我在ubuntu16和18下都进行了实验。
<img width="700" alt="屏幕快照 2022-09-08 下午5 08 02" src="https://user-images.githubusercontent.com/32240394/189082894-75673234-2a07-4a44-8e5b-2267f795f677.png">
我将其修改为了mysql，discuz可以正常安装，并且可以复现漏洞