### PR TITLE
Fixed sinatra error in CVE-2017-17405

### DIFF
--- a/ruby/CVE-2017-17405/Dockerfile
+++ b/ruby/CVE-2017-17405/Dockerfile
@@ -2,7 +2,7 @@ FROM vulhub/ruby:2.4.1
 
 LABEL maintainer="phithon <root@leavesongs.com>"
 
-RUN gem install sinatra
+RUN gem install sinatra -v 2.2.2
 
 COPY web.rb /usr/src/web.rb
 


### PR DESCRIPTION
Fix the following error: 
```   
 => ERROR [2/4] RUN gem install sinatra                                                                                                                                          1.8s
------                                                                                                                                                                                
 > [2/4] RUN gem install sinatra:                                                                                                                                                     
#0 1.227 ERROR:  Error installing sinatra:                                                                                                                                            
#0 1.227        mustermann requires Ruby version >= 2.6.0.
#0 1.228 Successfully installed ruby2_keywords-0.0.5
------
failed to solve: executor failed running [/bin/sh -c gem install sinatra]: exit code: 1


```  

Due to an update of sinatra version that is not installable in older Ruby versions. 