### PR TITLE
fix elasticsearch-head/1.x plugin installation error

### DIFF
--- a/elasticsearch/CVE-2015-3337/Dockerfile
+++ b/elasticsearch/CVE-2015-3337/Dockerfile
@@ -3,4 +3,4 @@ FROM vulhub/elasticsearch:1.4.4
 LABEL maintainer="phithon <root@leavesongs.com>"
 
 RUN set -ex \
-    && plugin -install mobz/elasticsearch-head/1.x
+    && plugin -install mobz/elasticsearch-head


### PR DESCRIPTION
构建 Docker 镜像时会出现如下错误：

```text
Step 3/3 : RUN set -ex     && plugin -install mobz/elasticsearch-head/1.x
 ---> Running in 21b61119eec7
+ plugin -install mobz/elasticsearch-head/1.x
-> Installing mobz/elasticsearch-head/1.x...
Trying http://download.elasticsearch.org/mobz/elasticsearch-head/elasticsearch-head-1.x.zip...
Downloading DONE
failed to extract plugin [/usr/share/elasticsearch/plugins/head.zip]: ZipException[zip file is empty]
```

插件地址响应404，可直接安装 `mobz/elasticsearch-head` 版本（经测试，插件版本不影响漏洞复现结果）