### PR TITLE
fix PHP xdebug-2.5.5 installation failed

### DIFF
--- a/php/xdebug-rce/Dockerfile
+++ b/php/xdebug-rce/Dockerfile
@@ -3,7 +3,9 @@ FROM vulhub/php:7.1.12-apache
 LABEL maintainer="phithon <root@leavesongs.com>"
 
 RUN a2enmod rewrite && \
-    pecl install xdebug-2.5.5 && \
+    curl -Ok https://pecl.php.net/get/xdebug-2.5.5.tgz && \
+    pecl install xdebug-2.5.5.tgz && \
+    rm xdebug-2.5.5.tgz && \
     docker-php-ext-enable xdebug && \
     echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/xdebug.ini && \
     echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/xdebug.ini && \


### PR DESCRIPTION
构建 Docker 镜像过程中报如下错误：

```text
usr/local/etc/php/conf.d/timezone.ini
 ---> Running in a93937de2fad
Enabling module rewrite.
To activate the new configuration, you need to run:
  service apache2 restart
No releases available for package "pecl.php.net/xdebug"
install failed
The command '/bin/sh -c a2enmod rewrite &&     pecl install xdebug-2.5.5 && ...
ERROR: Service 'php' failed to build : Build failed
```

浏览器与终端 `curl` 工具都可正常访问 `https://pecl.php.net/xdebug` 站点。但一运行 `pecl install xdebug-2.5.5` 就会出现如下错误：

```text
No releases available for package "pecl.php.net/xdebug"
install failed
```

尝试多次无果。最终通过 `curl` 工具下载官方 `xdebug-2.5.5.tgz` 文件，使用 `pecl` 工具本地安装解决该问题。关键命令如下：

```text
curl -Ok https://pecl.php.net/get/xdebug-2.5.5.tgz && \
pecl install xdebug-2.5.5.tgz && \
rm xdebug-2.5.5.tgz && \
```