### PR TITLE
Added ulimits for solving memoryAborted error

### DIFF
--- a/activemq/CVE-2015-5254/docker-compose.yml
+++ b/activemq/CVE-2015-5254/docker-compose.yml
@@ -2,6 +2,10 @@ version: '2'
 services:
  activemq:
    image: vulhub/activemq:5.11.1
+   ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
    ports:
     - "61616:61616"
     - "8161:8161"

--- a/activemq/CVE-2016-3088/docker-compose.yml
+++ b/activemq/CVE-2016-3088/docker-compose.yml
@@ -2,6 +2,10 @@ version: '2'
 services:
  activemq:
    image: vulhub/activemq:5.11.1-with-cron
+   ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
    ports:
     - "61616:61616"
     - "8161:8161"


### PR DESCRIPTION
It solves the error:
```
[+] Building 0.0s (0/0)                                                                                               
[+] Running 1/0
 ✔ Container cve-2015-5254-activemq-1  Created                                                                   0.0s 
Attaching to cve-2015-5254-activemq-1
cve-2015-5254-activemq-1  | INFO: Loading '/opt/activemq/bin/env'
cve-2015-5254-activemq-1  | INFO: Using java '/opt/jdk/bin/java'
cve-2015-5254-activemq-1  | INFO: Starting in foreground, this is just for debugging purposes (stop process by pressing CTRL+C)
cve-2015-5254-activemq-1  | library initialization failed - unable to allocate file descriptor table - out of memoryAborted (core dumped)
```