### PR TITLE
Create environments.toml

### DIFF
--- a/environments.toml
+++ b/environments.toml
@@ -780,7 +780,7 @@ path = "gitlab/CVE-2021-22205"
 
 [[container]]
 app = "gitlist"
-path = "gitlist/0.6.0-rce"
+path = "gitlist/CVE-2018-1000533"
 
   [[container.name]]
   en = "gitlist 0.6.0 Remote Command Execution"

--- a/environments.toml
+++ b/environments.toml
@@ -2328,6 +2328,7 @@ path = "struts2/s2-013"
 
 [[container]]
 app = "Struts2"
+path = "struts2/s2-015"
 
   [[container.name]]
   en = "S2-015 Remote Code Execution"
@@ -2336,6 +2337,7 @@ app = "Struts2"
   [[container.cve]]
   id = "CVE-2013-2134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2134"
+  
   [[container.cve]]
   id = "CVE-2013-2135"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2135"

--- a/environments.toml
+++ b/environments.toml
@@ -44,6 +44,7 @@ path = "apache-druid/CVE-2021-25646"
 name_en = "Apereo CAS 4.1 Deserialization Command Execution"
 name_zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
 app = "Apereo CAS"
+cve = ""
 path = "apereo-cas/4.1-rce"
 
 [[containers]]
@@ -71,6 +72,7 @@ path = "appweb/CVE-2018-8715"
 name_en = "Aria2 Arbitrary File Write"
 name_zh = "Aria2 任意文件写入漏洞"
 app = "Aria2"
+cve = ""
 path = "aria2/rce"
 
 [[containers]]
@@ -91,6 +93,7 @@ path = "cacti/CVE-2022-46169"
 name_en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
 name_zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
 app = "celery"
+cve = ""
 path = "celery/celery3_redis_unauth"
 
 [[containers]]
@@ -160,12 +163,14 @@ path = "couchdb/CVE-2022-24706"
 name_en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
 name_zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
 app = "Discuz"
+cve = ""
 path = "discuz/wooyun-2010-080723"
 
 [[containers]]
 name_en = "Discuz!X ≤3.4 Arbitrary File Deletion"
 name_zh = "Discuz!X ≤3.4 任意文件删除漏洞"
 app = "Discuz"
+cve = ""
 path = "discuz/x3.4-arbitrary-file-deletion"
 
 [[containers]]
@@ -214,12 +219,14 @@ path = "django/CVE-2022-34265"
 name_en = "DNS Domain Transfer"
 name_zh = "DNS域传送漏洞"
 app = "dns"
+cve = ""
 path = "dns/dns-zone-transfer"
 
 [[containers]]
 name_en = "Docker Daemon API Unauthorized Access"
 name_zh = "Docker Daemon API 未授权访问漏洞"
 app = "docker"
+cve = ""
 path = "docker/unauthorized-rce"
 
 [[containers]]
@@ -275,12 +282,14 @@ path = "dubbo/CVE-2019-17564"
 name_en = "ECShop 4.x collection_list SQL Injection"
 name_zh = "ECShop 4.x collection_list SQL注入"
 app = "ecshop"
+cve = ""
 path = "ecshop/collection_list-sqli"
 
 [[containers]]
 name_en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
 name_zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
 app = "ecshop"
+cve = ""
 path = "ecshop/xianzhi-2017-02-82239600"
 
 [[containers]]
@@ -315,6 +324,7 @@ path = "elasticsearch/CVE-2015-5531"
 name_en = "Elasticsearch Webshell"
 name_zh = "Elasticsearch 写入webshell漏洞"
 app = "ElasticSearch"
+cve = ""
 path = "elasticsearch/WooYun-2015-110216"
 
 [[containers]]
@@ -349,6 +359,7 @@ path = "fastjson/1.2.24-rce"
 name_en = "Fastjson 1.2.47 Remote Command Execution"
 name_zh = "Fastjson 1.2.47 远程命令执行漏洞"
 app = "Fastjson"
+cve = ""
 path = "fastjson/1.2.47-rce"
 
 [[containers]]
@@ -369,6 +380,7 @@ path = "ffmpeg/phdays"
 name_en = "Jinja2 SSTI Template Injection"
 name_zh = "Jinja2 SSTI模板注入"
 app = "Jinja2"
+cve = ""
 path = "flask/ssti"
 
 [[containers]]
@@ -424,6 +436,7 @@ path = "git/CVE-2017-8386"
 name_en = "Gitea 1.4.0 Directory Traversal to Command Execution"
 name_zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
 app = "gitea"
+cve = ""
 path = "gitea/1.4-rce"
 
 [[containers]]
@@ -444,12 +457,14 @@ path = "gitlab/CVE-2021-22205"
 name_en = "gitlist 0.6.0 Remote Command Execution"
 name_zh = "gitlist 0.6.0 远程命令执行漏洞"
 app = "gitlist"
+cve = ""
 path = "gitlist/0.6.0-rce"
 
 [[containers]]
 name_en = "GlassFish Arbitrary File Read"
 name_zh = "GlassFish 任意文件读取漏洞"
 app = "GlassFish"
+cve = ""
 path = "glassfish/4.1.0"
 
 [[containers]]
@@ -484,18 +499,21 @@ path = "grafana/CVE-2021-43798"
 name_en = "Grafana Management Background SSRF"
 name_zh = "Grafana管理后台SSRF"
 app = "Grafana"
+cve = ""
 path = "grafana/admin-ssrf"
 
 [[containers]]
 name_en = "H2 Database Console Unauthorized Access"
 name_zh = "H2 Database Console 未授权访问"
 app = "Springboot H2 Database"
+cve = ""
 path = "h2database/h2-console-unacc"
 
 [[containers]]
 name_en = "Hadoop YARN ResourceManager Unauthorized Access"
 name_zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
 app = "Hadoop YARN"
+cve = ""
 path = "hadoop/unauthorized-yarn"
 
 [[containers]]
@@ -530,12 +548,14 @@ path = "httpd/CVE-2021-42013"
 name_en = "Apache HTTPD Unknown Suffix Parsing"
 name_zh = "Apache HTTPD 未知后缀解析漏洞"
 app = "Apache HTTP Server"
+cve = ""
 path = "httpd/apache_parsing_vulnerability"
 
 [[containers]]
 name_en = "Apache SSI Remote Command Execution"
 name_zh = "Apache SSI 远程命令执行漏洞"
 app = "Apache HTTP Server"
+cve = ""
 path = "httpd/ssi-rce"
 
 [[containers]]
@@ -577,18 +597,21 @@ path = "jackson/CVE-2017-7525"
 name_en = "Java RMI codebase Remote Code Execution"
 name_zh = "Java RMI codebase 远程代码执行漏洞"
 app = "java rmi"
+cve = ""
 path = "java/rmi-codebase"
 
 [[containers]]
 name_en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
 name_zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
 app = "java rmi"
+cve = ""
 path = "java/rmi-registry-bind-deserialization"
 
 [[containers]]
 name_en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
 name_zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
 app = "java rmi"
+cve = ""
 path = "java/rmi-registry-bind-deserialization-bypass"
 
 [[containers]]
@@ -609,6 +632,7 @@ path = "jboss/CVE-2017-7504"
 name_en = "JBoss JMXInvokerServlet Deserialization"
 name_zh = "JBoss JMXInvokerServlet 反序列化漏洞"
 app = "jboss"
+cve = ""
 path = "jboss/JMXInvokerServlet-deserialization"
 
 [[containers]]
@@ -685,6 +709,7 @@ path = "joomla/CVE-2023-23752"
 name_en = "Jupyter Notebook Unauthorized Access"
 name_zh = "Jupyter Notebook 未授权访问漏洞"
 app = "Jupyter"
+cve = ""
 path = "jupyter/notebook-rce"
 
 [[containers]]
@@ -747,6 +772,7 @@ path = "log4j/CVE-2021-44228"
 name_en = "Magento 2.2 SQL Injection"
 name_zh = "Magento 2.2 SQL注入漏洞"
 app = "Magento"
+cve = ""
 path = "magento/2.2-sqli"
 
 [[containers]]
@@ -774,6 +800,7 @@ path = "minio/CVE-2023-28432"
 name_en = "Mojarra JSF ViewState Deserialization"
 name_zh = "Mojarra JSF ViewState 反序列化漏洞"
 app = "Mojarra JSF"
+cve = ""
 path = "mojarra/jsf-viewstate-deserialization"
 
 [[containers]]
@@ -843,12 +870,14 @@ path = "nginx/CVE-2017-7529"
 name_en = "Nginx Configuration Errors"
 name_zh = "Nginx 配置错误三例"
 app = "Nginx"
+cve = ""
 path = "nginx/insecure-configuration"
 
 [[containers]]
 name_en = "Nginx Parsing"
 name_zh = "Nginx 解析漏洞"
 app = "Nginx"
+cve = ""
 path = "nginx/nginx_parsing_vulnerability"
 
 [[containers]]
@@ -925,6 +954,7 @@ path = "opentsdb/CVE-2020-35476"
 name_en = "PHP 8.1.0-dev Development Version Backdoor Event"
 name_zh = "PHP 8.1.0-dev 开发版本后门事件"
 app = "PHP"
+cve = ""
 path = "php/8.1-backdoor"
 
 [[containers]]
@@ -952,24 +982,28 @@ path = "php/CVE-2019-11043"
 name_en = "PHP-FPM FastCGI Unauthorized Access"
 name_zh = "PHP-FPM FastCGI 未授权访问漏洞"
 app = "PHP-FPM"
+cve = ""
 path = "php/fpm"
 
 [[containers]]
 name_en = "PHP Files Vulnerabilities (by phpinfo())"
 name_zh = "PHP文件包含漏洞 (利用phpinfo())"
 app = "PHP"
+cve = ""
 path = "php/inclusion"
 
 [[containers]]
 name_en = "PHP XML Entity Injection"
 name_zh = "PHP XML实体注入"
 app = "PHP"
+cve = ""
 path = "php/php_xxe"
 
 [[containers]]
 name_en = "XDebug Remote Debugging Code Execution"
 name_zh = "XDebug 远程调试漏洞 (代码执行)"
 app = "PHP"
+cve = ""
 path = "php/xdebug-rce"
 
 [[containers]]
@@ -997,6 +1031,7 @@ path = "phpmyadmin/CVE-2018-12613"
 name_en = "phpmyadmin scripts/setup.php Deserialization"
 name_zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
 app = "phpmyadmin"
+cve = ""
 path = "phpmyadmin/WooYun-2016-199433"
 
 [[containers]]
@@ -1045,6 +1080,7 @@ path = "python/PIL-CVE-2018-16509"
 name_en = "Python Unpickle Deserialization"
 name_zh = "Python Unpickle 反序列化漏洞"
 app = "Python"
+cve = ""
 path = "python/unpickle"
 
 [[containers]]
@@ -1065,6 +1101,7 @@ path = "rails/CVE-2019-5418"
 name_en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
 name_zh = "Redis 4.x/5.x 主从复制导致的命令执行"
 app = "redis"
+cve = ""
 path = "redis/4-unacc"
 
 [[containers]]
@@ -1092,6 +1129,7 @@ path = "rocketmq/CVE-2023-33246"
 name_en = "rsync Unauthorized Access"
 name_zh = "rsync 未授权访问漏洞"
 app = "rsync"
+cve = ""
 path = "rsync/common"
 
 [[containers]]
@@ -1133,6 +1171,7 @@ path = "samba/CVE-2017-7494"
 name_en = "Scrapyd Unauthorized Access"
 name_zh = "Scrapyd 未授权访问漏洞"
 app = "Scrapyd"
+cve = ""
 path = "scrapy/scrapyd-unacc"
 
 [[containers]]
@@ -1160,6 +1199,7 @@ path = "shiro/CVE-2020-1957"
 name_en = "Apache Skywalking 8.3.0 SQL Injection"
 name_zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
 app = "skywalking"
+cve = ""
 path = "skywalking/8.3.0-sqli"
 
 [[containers]]
@@ -1194,12 +1234,14 @@ path = "solr/CVE-2019-17558"
 name_en = "Apache Solr RemoteStreaming File Reading and SSRF"
 name_zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
 app = "solr"
+cve = ""
 path = "solr/Remote-Streaming-Fileread"
 
 [[containers]]
 name_en = "Apache Spark Unauthorized Access Leak"
 name_zh = "Apache Spark 未授权访问漏"
 app = "spark"
+cve = ""
 path = "spark/unacc"
 
 [[containers]]
@@ -1269,6 +1311,7 @@ path = "spring/CVE-2022-22978"
 name_en = "S2-001 Remote Code Execution"
 name_zh = "S2-001 远程代码执行漏洞"
 app = "Struts2"
+cve = ""
 path = "struts2/s2-001"
 
 [[containers]]
@@ -1282,6 +1325,7 @@ path = "struts2/s2-005"
 name_en = "S2-007 Remote Code Execution"
 name_zh = "S2-007 远程代码执行漏洞"
 app = "Struts2"
+cve = ""
 path = "struts2/s2-007"
 
 [[containers]]
@@ -1400,30 +1444,35 @@ path = "supervisor/CVE-2017-11610"
 name_en = "ThinkPHP 2.x Arbitrary Code Execution"
 name_zh = "ThinkPHP 2.x 任意代码执行漏洞"
 app = "ThinkPHP"
+cve = ""
 path = "thinkphp/2-rce"
 
 [[containers]]
 name_en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
 name_zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
 app = "ThinkPHP"
+cve = ""
 path = "thinkphp/5-rce"
 
 [[containers]]
 name_en = "ThinkPHP5 5.0.23 Remote Code Execution"
 name_zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
 app = "ThinkPHP"
+cve = ""
 path = "thinkphp/5.0.23-rce"
 
 [[containers]]
 name_en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
 name_zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
 app = "ThinkPHP"
+cve = ""
 path = "thinkphp/in-sqlinjection"
 
 [[containers]]
 name_en = "ThinkPHP Multilingual Local File Inclusion"
 name_zh = "ThinkPHP 多语言本地文件包含漏洞"
 app = "ThinkPHP"
+cve = ""
 path = "thinkphp/lang-rce"
 
 [[containers]]
@@ -1451,6 +1500,7 @@ path = "tomcat/CVE-2020-1938"
 name_en = "Tomcat Weak Password"
 name_zh = "Tomcat弱口令"
 app = "Tomcat"
+cve = ""
 path = "tomcat/tomcat8"
 
 [[containers]]
@@ -1471,12 +1521,14 @@ path = "uwsgi/CVE-2018-7490"
 name_en = "uWSGI Unauthorized Access"
 name_zh = "uWSGI 未授权访问漏洞"
 app = "uWSGI"
+cve = ""
 path = "uwsgi/unacc"
 
 [[containers]]
 name_en = "V2board 1.6.1 Privilege Escalation"
 name_zh = "V2board 1.6.1 提权漏洞"
 app = "V2board"
+cve = ""
 path = "v2board/1.6-privilege-escalation"
 
 [[containers]]
@@ -1518,12 +1570,14 @@ path = "weblogic/CVE-2023-21839"
 name_en = "WebLogic SSRF"
 name_zh = "WebLogic SSRF漏洞"
 app = "WebLogic"
+cve = ""
 path = "weblogic/ssrf"
 
 [[containers]]
 name_en = "WebLogic File Read"
 name_zh = "WebLogic 文件读取漏洞"
 app = "WebLogic"
+cve = ""
 path = "weblogic/weak_password"
 
 [[containers]]
@@ -1537,6 +1591,7 @@ path = "webmin/CVE-2019-15107"
 name_en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
 name_zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
 app = "Wordpress"
+cve = ""
 path = "wordpress/pwnscriptum"
 
 [[containers]]
@@ -1557,18 +1612,21 @@ path = "xstream/CVE-2021-29505"
 name_en = "XXL-JOB Executor Unauthorized Access"
 name_zh = "XXL-JOB Executor 未授权访问漏洞"
 app = "xxl-job"
+cve = ""
 path = "xxl-job/unacc"
 
 [[containers]]
 name_en = "YApi NoSQL Injection to Remote Command Execution"
 name_zh = "YApi NoSQL注入导致远程命令执行漏洞"
 app = "YApi"
+cve = ""
 path = "yapi/mongodb-inj"
 
 [[containers]]
 name_en = "YApi Open Registration due to RCE"
 name_zh = "YApi开放注册导致RCE"
 app = "YApi"
+cve = ""
 path = "yapi/unacc"
 
 [[containers]]

--- a/environments.toml
+++ b/environments.toml
@@ -1,6 +1,7 @@
 [[container]]
-name_en = "Apache ActiveMQ Deserialization"
-name_zh = "Apache ActiveMQ 反序列化漏洞"
+  [[container.name]]
+  en = "Apache ActiveMQ Deserialization"
+  zh = "Apache ActiveMQ 反序列化漏洞"
 app = "ActiveMQ"
   [[container.cve]]
   name = "CVE-2015-5254"
@@ -8,8 +9,9 @@ app = "ActiveMQ"
 path = "activemq/CVE-2015-5254"
 
 [[container]]
-name_en = "Apache ActiveMQ Arbitrary File Write"
-name_zh = "Apache ActiveMQ 任意文件写入漏洞"
+  [[container.name]]
+  en = "Apache ActiveMQ Arbitrary File Write"
+  zh = "Apache ActiveMQ 任意文件写入漏洞"
 app = "ActiveMQ"
   [[container.cve]]
   name = "CVE-2016-3088"
@@ -17,8 +19,9 @@ app = "ActiveMQ"
 path = "activemq/CVE-2016-3088"
 
 [[container]]
-name_en = "Apache Airflow Command Injection"
-name_zh = "Apache Airflow 示例dag中的命令注入"
+  [[container.name]]
+  en = "Apache Airflow Command Injection"
+  zh = "Apache Airflow 示例dag中的命令注入"
 app = "Airflow"
   [[container.cve]]
   name = "CVE-2020-11978"
@@ -26,8 +29,9 @@ app = "Airflow"
 path = "airflow/CVE-2020-11978"
 
 [[container]]
-name_en = "Apache Airflow Celery Message Middleware Command Execution"
-name_zh = "Apache Airflow Celery 消息中间件命令执行"
+  [[container.name]]
+  en = "Apache Airflow Celery Message Middleware Command Execution"
+  zh = "Apache Airflow Celery 消息中间件命令执行"
 app = "Airflow"
   [[container.cve]]
   name = "CVE-2020-11981"
@@ -35,8 +39,9 @@ app = "Airflow"
 path = "airflow/CVE-2020-11981"
 
 [[container]]
-name_en = "Apache Airflow Permission Bypass"
-name_zh = "Apache Airflow 默认密钥导致的权限绕过"
+  [[container.name]]
+  en = "Apache Airflow Permission Bypass"
+  zh = "Apache Airflow 默认密钥导致的权限绕过"
 app = "Airflow"
   [[container.cve]]
   name = "CVE-2020-17526"
@@ -44,8 +49,9 @@ app = "Airflow"
 path = "airflow/CVE-2020-17526"
 
 [[container]]
-name_en = "Apache Druid Code Execution"
-name_zh = "Apache Druid 代码执行漏洞"
+  [[container.name]]
+  en = "Apache Druid Code Execution"
+  zh = "Apache Druid 代码执行漏洞"
 app = "Apache Druid"
   [[container.cve]]
   name = "CVE-2021-25646"
@@ -53,8 +59,9 @@ app = "Apache Druid"
 path = "apache-druid/CVE-2021-25646"
 
 [[container]]
-name_en = "Apereo CAS 4.1 Deserialization Command Execution"
-name_zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "Apereo CAS 4.1 Deserialization Command Execution"
+  zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
 app = "Apereo CAS"
   [[container.cve]]
   name = ""
@@ -62,8 +69,9 @@ app = "Apereo CAS"
 path = "apereo-cas/4.1-rce"
 
 [[container]]
-name_en = "Apache APISIX Default Key"
-name_zh = "Apache APISIX 默认密钥漏洞"
+  [[container.name]]
+  en = "Apache APISIX Default Key"
+  zh = "Apache APISIX 默认密钥漏洞"
 app = "Apache APISIX"
   [[container.cve]]
   name = "CVE-2020-13945"
@@ -71,8 +79,9 @@ app = "Apache APISIX"
 path = "apisix/CVE-2020-13945"
 
 [[container]]
-name_en = "Apache APISIX Dashboard API Permission Bypass to RCE"
-name_zh = "Apache APISIX Dashboard API权限绕过导致RCE"
+  [[container.name]]
+  en = "Apache APISIX Dashboard API Permission Bypass to RCE"
+  zh = "Apache APISIX Dashboard API权限绕过导致RCE"
 app = "Apache APISIX"
   [[container.cve]]
   name = "CVE-2021-45232"
@@ -80,8 +89,9 @@ app = "Apache APISIX"
 path = "apisix/CVE-2021-45232"
 
 [[container]]
-name_en = "AppWeb Authentication Bypass"
-name_zh = "AppWeb 认证绕过漏洞"
+  [[container.name]]
+  en = "AppWeb Authentication Bypass"
+  zh = "AppWeb 认证绕过漏洞"
 app = "AppWeb"
   [[container.cve]]
   name = "CVE-2018-8715"
@@ -89,8 +99,9 @@ app = "AppWeb"
 path = "appweb/CVE-2018-8715"
 
 [[container]]
-name_en = "Aria2 Arbitrary File Write"
-name_zh = "Aria2 任意文件写入漏洞"
+  [[container.name]]
+  en = "Aria2 Arbitrary File Write"
+  zh = "Aria2 任意文件写入漏洞"
 app = "Aria2"
   [[container.cve]]
   name = ""
@@ -98,8 +109,9 @@ app = "Aria2"
 path = "aria2/rce"
 
 [[container]]
-name_en = "Bash Shellshock Shell Exploit"
-name_zh = "Bash Shellshock 破壳漏洞"
+  [[container.name]]
+  en = "Bash Shellshock Shell Exploit"
+  zh = "Bash Shellshock 破壳漏洞"
 app = "bash"
   [[container.cve]]
   name = "CVE-2014-6271"
@@ -107,8 +119,9 @@ app = "bash"
 path = "bash/CVE-2014-6271"
 
 [[container]]
-name_en = "Cacti Foreground Command Injection"
-name_zh = "Cacti 前台命令注入漏洞"
+  [[container.name]]
+  en = "Cacti Foreground Command Injection"
+  zh = "Cacti 前台命令注入漏洞"
 app = "cacti"
   [[container.cve]]
   name = "CVE-2022-46169"
@@ -116,8 +129,9 @@ app = "cacti"
 path = "cacti/CVE-2022-46169"
 
 [[container]]
-name_en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
-name_zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
+  [[container.name]]
+  en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
+  zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
 app = "celery"
   [[container.cve]]
   name = ""
@@ -125,8 +139,9 @@ app = "celery"
 path = "celery/celery3_redis_unauth"
 
 [[container]]
-name_en = "CGI HTTPoxy Flaw"
-name_zh = "CGI HTTPoxy 漏洞"
+  [[container.name]]
+  en = "CGI HTTPoxy Flaw"
+  zh = "CGI HTTPoxy 漏洞"
 app = "cgi"
   [[container.cve]]
   name = "CVE-2016-5385"
@@ -134,8 +149,9 @@ app = "cgi"
 path = "cgi/CVE-2016-5385"
 
 [[container]]
-name_en = "Adobe ColdFusion File Read"
-name_zh = "Adobe ColdFusion 文件读取漏洞"
+  [[container.name]]
+  en = "Adobe ColdFusion File Read"
+  zh = "Adobe ColdFusion 文件读取漏洞"
 app = "Adobe ColdFusion"
   [[container.cve]]
   name = "CVE-2010-2861"
@@ -143,8 +159,9 @@ app = "Adobe ColdFusion"
 path = "coldfusion/CVE-2010-2861"
 
 [[container]]
-name_en = "Adobe ColdFusion Deserialization"
-name_zh = "Adobe ColdFusion 反序列化漏洞"
+  [[container.name]]
+  en = "Adobe ColdFusion Deserialization"
+  zh = "Adobe ColdFusion 反序列化漏洞"
 app = "Adobe ColdFusion"
   [[container.cve]]
   name = "CVE-2017-3066"
@@ -152,8 +169,9 @@ app = "Adobe ColdFusion"
 path = "coldfusion/CVE-2017-3066"
 
 [[container]]
-name_en = "Atlassian Confluence Path Traversal and Command Execution"
-name_zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
+  [[container.name]]
+  en = "Atlassian Confluence Path Traversal and Command Execution"
+  zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
 app = "Atlassian Confluence"
   [[container.cve]]
   name = "CVE-2019-3396"
@@ -161,8 +179,9 @@ app = "Atlassian Confluence"
 path = "confluence/CVE-2019-3396"
 
 [[container]]
-name_en = "Atlassian Confluence OGNL Expression Injection Code Execution"
-name_zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
+  [[container.name]]
+  en = "Atlassian Confluence OGNL Expression Injection Code Execution"
+  zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
 app = "Atlassian Confluence"
   [[container.cve]]
   name = "CVE-2021-26084"
@@ -170,8 +189,9 @@ app = "Atlassian Confluence"
 path = "confluence/CVE-2021-26084"
 
 [[container]]
-name_en = "Atlassian Confluence OGNL Expression Injection Command Execution"
-name_zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
+  [[container.name]]
+  en = "Atlassian Confluence OGNL Expression Injection Command Execution"
+  zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
 app = "Atlassian Confluence"
   [[container.cve]]
   name = "CVE-2022-26134"
@@ -179,8 +199,9 @@ app = "Atlassian Confluence"
 path = "confluence/CVE-2022-26134"
 
 [[container]]
-name_en = "CouchDB Vertical Permission Bypass"
-name_zh = "CouchDB 垂直权限绕过漏洞"
+  [[container.name]]
+  en = "CouchDB Vertical Permission Bypass"
+  zh = "CouchDB 垂直权限绕过漏洞"
 app = "CouchDB"
   [[container.cve]]
   name = "CVE-2017-12635"
@@ -188,8 +209,9 @@ app = "CouchDB"
 path = "couchdb/CVE-2017-12635"
 
 [[container]]
-name_en = "CouchDB Arbitrary Command Execution"
-name_zh = "CouchDB 任意命令执行漏洞"
+  [[container.name]]
+  en = "CouchDB Arbitrary Command Execution"
+  zh = "CouchDB 任意命令执行漏洞"
 app = "CouchDB"
   [[container.cve]]
   name = "CVE-2017-12636"
@@ -197,8 +219,9 @@ app = "CouchDB"
 path = "couchdb/CVE-2017-12636"
 
 [[container]]
-name_en = "CouchDB Erlang Distributed Protocol Code Execution"
-name_zh = "CouchDB Erlang 分布式协议代码执行"
+  [[container.name]]
+  en = "CouchDB Erlang Distributed Protocol Code Execution"
+  zh = "CouchDB Erlang 分布式协议代码执行"
 app = "CouchDB"
   [[container.cve]]
   name = "CVE-2022-24706"
@@ -206,8 +229,9 @@ app = "CouchDB"
 path = "couchdb/CVE-2022-24706"
 
 [[container]]
-name_en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
-name_zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
+  [[container.name]]
+  en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
+  zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
 app = "Discuz"
   [[container.cve]]
   name = ""
@@ -215,8 +239,9 @@ app = "Discuz"
 path = "discuz/wooyun-2010-080723"
 
 [[container]]
-name_en = "Discuz!X ≤3.4 Arbitrary File Deletion"
-name_zh = "Discuz!X ≤3.4 任意文件删除漏洞"
+  [[container.name]]
+  en = "Discuz!X ≤3.4 Arbitrary File Deletion"
+  zh = "Discuz!X ≤3.4 任意文件删除漏洞"
 app = "Discuz"
   [[container.cve]]
   name = ""
@@ -224,8 +249,9 @@ app = "Discuz"
 path = "discuz/x3.4-arbitrary-file-deletion"
 
 [[container]]
-name_en = "Django debug page XSS Flaw"
-name_zh = "Django debug page XSS 漏洞"
+  [[container.name]]
+  en = "Django debug page XSS Flaw"
+  zh = "Django debug page XSS 漏洞"
 app = "Django"
   [[container.cve]]
   name = "CVE-2017-12794"
@@ -233,8 +259,9 @@ app = "Django"
 path = "django/CVE-2017-12794"
 
 [[container]]
-name_en = "Django < 2.0.8 Arbitrary URL Redirection"
-name_zh = "Django < 2.0.8 任意URL跳转漏洞"
+  [[container.name]]
+  en = "Django < 2.0.8 Arbitrary URL Redirection"
+  zh = "Django < 2.0.8 任意URL跳转漏洞"
 app = "Django"
   [[container.cve]]
   name = "CVE-2018-14574"
@@ -242,8 +269,9 @@ app = "Django"
 path = "django/CVE-2018-14574"
 
 [[container]]
-name_en = "Django JSONField/HStoreField SQL Injection"
-name_zh = "Django JSONField/HStoreField SQL注入漏洞"
+  [[container.name]]
+  en = "Django JSONField/HStoreField SQL Injection"
+  zh = "Django JSONField/HStoreField SQL注入漏洞"
 app = "Django"
   [[container.cve]]
   name = "CVE-2019-14234"
@@ -251,8 +279,9 @@ app = "Django"
 path = "django/CVE-2019-14234"
 
 [[container]]
-name_en = "Django GIS SQL Injection"
-name_zh = "Django GIS SQL注入漏洞"
+  [[container.name]]
+  en = "Django GIS SQL Injection"
+  zh = "Django GIS SQL注入漏洞"
 app = "Django"
   [[container.cve]]
   name = "CVE-2020-9402"
@@ -260,8 +289,9 @@ app = "Django"
 path = "django/CVE-2020-9402"
 
 [[container]]
-name_en = "Django QuerySet.order_by() SQL Injection"
-name_zh = "Django QuerySet.order_by() SQL注入漏洞"
+  [[container.name]]
+  en = "Django QuerySet.order_by() SQL Injection"
+  zh = "Django QuerySet.order_by() SQL注入漏洞"
 app = "Django"
   [[container.cve]]
   name = "CVE-2021-35042"
@@ -269,8 +299,9 @@ app = "Django"
 path = "django/CVE-2021-35042"
 
 [[container]]
-name_en = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
-name_zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
+  [[container.name]]
+  en = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
+  zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
 app = "Django"
   [[container.cve]]
   name = "CVE-2022-34265"
@@ -278,8 +309,9 @@ app = "Django"
 path = "django/CVE-2022-34265"
 
 [[container]]
-name_en = "DNS Domain Transfer"
-name_zh = "DNS域传送漏洞"
+  [[container.name]]
+  en = "DNS Domain Transfer"
+  zh = "DNS域传送漏洞"
 app = "dns"
   [[container.cve]]
   name = ""
@@ -287,8 +319,9 @@ app = "dns"
 path = "dns/dns-zone-transfer"
 
 [[container]]
-name_en = "Docker Daemon API Unauthorized Access"
-name_zh = "Docker Daemon API 未授权访问漏洞"
+  [[container.name]]
+  en = "Docker Daemon API Unauthorized Access"
+  zh = "Docker Daemon API 未授权访问漏洞"
 app = "docker"
   [[container.cve]]
   name = ""
@@ -296,8 +329,9 @@ app = "docker"
 path = "docker/unauthorized-rce"
 
 [[container]]
-name_en = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
-name_zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
+  [[container.name]]
+  en = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
+  zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
 app = "drupal"
   [[container.cve]]
   name = "CVE-2014-3704"
@@ -305,8 +339,9 @@ app = "drupal"
 path = "drupal/CVE-2014-3704"
 
 [[container]]
-name_en = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
-name_zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
+  [[container.name]]
+  en = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
+  zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
 app = "drupal"
   [[container.cve]]
   name = "CVE-2017-6920"
@@ -314,8 +349,9 @@ app = "drupal"
 path = "drupal/CVE-2017-6920"
 
 [[container]]
-name_en = "Drupal Drupalgeddon 2 Remote Code Execution"
-name_zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
+  [[container.name]]
+  en = "Drupal Drupalgeddon 2 Remote Code Execution"
+  zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
 app = "drupal"
   [[container.cve]]
   name = "CVE-2018-7600"
@@ -323,8 +359,9 @@ app = "drupal"
 path = "drupal/CVE-2018-7600"
 
 [[container]]
-name_en = "Drupal Remote Code Execution"
-name_zh = "Drupal 远程代码执行漏洞"
+  [[container.name]]
+  en = "Drupal Remote Code Execution"
+  zh = "Drupal 远程代码执行漏洞"
 app = "drupal"
   [[container.cve]]
   name = "CVE-2018-7602"
@@ -332,8 +369,9 @@ app = "drupal"
 path = "drupal/CVE-2018-7602"
 
 [[container]]
-name_en = "Drupal Remote Code Execution"
-name_zh = "Drupal 远程代码执行漏洞"
+  [[container.name]]
+  en = "Drupal Remote Code Execution"
+  zh = "Drupal 远程代码执行漏洞"
 app = "drupal"
   [[container.cve]]
   name = "CVE-2019-6339"
@@ -341,8 +379,9 @@ app = "drupal"
 path = "drupal/CVE-2019-6339"
 
 [[container]]
-name_en = "Drupal XSS"
-name_zh = "Drupal XSS漏洞"
+  [[container.name]]
+  en = "Drupal XSS"
+  zh = "Drupal XSS漏洞"
 app = "drupal"
   [[container.cve]]
   name = "CVE-2019-6341"
@@ -350,8 +389,9 @@ app = "drupal"
 path = "drupal/CVE-2019-6341"
 
 [[container]]
-name_en = "Apache Dubbo Java Deserialization"
-name_zh = "Apache Dubbo Java反序列化漏洞"
+  [[container.name]]
+  en = "Apache Dubbo Java Deserialization"
+  zh = "Apache Dubbo Java反序列化漏洞"
 app = "dubbo"
   [[container.cve]]
   name = "CVE-2019-17564"
@@ -359,8 +399,9 @@ app = "dubbo"
 path = "dubbo/CVE-2019-17564"
 
 [[container]]
-name_en = "ECShop 4.x collection_list SQL Injection"
-name_zh = "ECShop 4.x collection_list SQL注入"
+  [[container.name]]
+  en = "ECShop 4.x collection_list SQL Injection"
+  zh = "ECShop 4.x collection_list SQL注入"
 app = "ecshop"
   [[container.cve]]
   name = ""
@@ -368,8 +409,9 @@ app = "ecshop"
 path = "ecshop/collection_list-sqli"
 
 [[container]]
-name_en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
-name_zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
+  [[container.name]]
+  en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
+  zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
 app = "ecshop"
   [[container.cve]]
   name = ""
@@ -377,8 +419,9 @@ app = "ecshop"
 path = "ecshop/xianzhi-2017-02-82239600"
 
 [[container]]
-name_en = "ElasticSearch Command Execution"
-name_zh = "ElasticSearch 命令执行漏洞"
+  [[container.name]]
+  en = "ElasticSearch Command Execution"
+  zh = "ElasticSearch 命令执行漏洞"
 app = "ElasticSearch"
   [[container.cve]]
   name = "CVE-2014-3120"
@@ -386,8 +429,9 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2014-3120"
 
 [[container]]
-name_en = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
-name_zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
+  [[container.name]]
+  en = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
+  zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
 app = "ElasticSearch"
   [[container.cve]]
   name = "CVE-2015-1427"
@@ -395,8 +439,9 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-1427"
 
 [[container]]
-name_en = "ElasticSearch Plug-in Directory Traversal"
-name_zh = "ElasticSearch 插件目录穿越漏洞"
+  [[container.name]]
+  en = "ElasticSearch Plug-in Directory Traversal"
+  zh = "ElasticSearch 插件目录穿越漏洞"
 app = "ElasticSearch"
   [[container.cve]]
   name = "CVE-2015-3337"
@@ -404,8 +449,9 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-3337"
 
 [[container]]
-name_en = "ElasticSearch Directory Traversal"
-name_zh = "ElasticSearch 目录穿越漏洞"
+  [[container.name]]
+  en = "ElasticSearch Directory Traversal"
+  zh = "ElasticSearch 目录穿越漏洞"
 app = "ElasticSearch"
   [[container.cve]]
   name = "CVE-2015-5531"
@@ -413,8 +459,9 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-5531"
 
 [[container]]
-name_en = "Elasticsearch Webshell"
-name_zh = "Elasticsearch 写入webshell漏洞"
+  [[container.name]]
+  en = "Elasticsearch Webshell"
+  zh = "Elasticsearch 写入webshell漏洞"
 app = "ElasticSearch"
   [[container.cve]]
   name = ""
@@ -422,8 +469,9 @@ app = "ElasticSearch"
 path = "elasticsearch/WooYun-2015-110216"
 
 [[container]]
-name_en = "Electron Remote Command Execution"
-name_zh = "Electron 远程命令执行漏洞"
+  [[container.name]]
+  en = "Electron Remote Command Execution"
+  zh = "Electron 远程命令执行漏洞"
 app = "electron"
   [[container.cve]]
   name = "CVE-2018-1000006"
@@ -431,8 +479,9 @@ app = "electron"
 path = "electron/CVE-2018-1000006"
 
 [[container]]
-name_en = "Electron WebPreferences Remote Command Execution"
-name_zh = "Electron WebPreferences 远程命令执行漏洞"
+  [[container.name]]
+  en = "Electron WebPreferences Remote Command Execution"
+  zh = "Electron WebPreferences 远程命令执行漏洞"
 app = "electron"
   [[container.cve]]
   name = "CVE-2018-15685"
@@ -440,8 +489,9 @@ app = "electron"
 path = "electron/CVE-2018-15685"
 
 [[container]]
-name_en = "elFinder ZIP Parameter and Arbitrary Command Injection"
-name_zh = "elFinder ZIP 参数与任意命令注入"
+  [[container.name]]
+  en = "elFinder ZIP Parameter and Arbitrary Command Injection"
+  zh = "elFinder ZIP 参数与任意命令注入"
 app = "elFinder"
   [[container.cve]]
   name = "CVE-2021-32682"
@@ -449,8 +499,9 @@ app = "elFinder"
 path = "elfinder/CVE-2021-32682"
 
 [[container]]
-name_en = "Fastjson Deserialization to Arbitrary Command Execution"
-name_zh = "Fastjson 反序列化导致任意命令执行漏洞"
+  [[container.name]]
+  en = "Fastjson Deserialization to Arbitrary Command Execution"
+  zh = "Fastjson 反序列化导致任意命令执行漏洞"
 app = "Fastjson"
   [[container.cve]]
   name = "CVE-2017-18349"
@@ -458,8 +509,9 @@ app = "Fastjson"
 path = "fastjson/1.2.24-rce"
 
 [[container]]
-name_en = "Fastjson 1.2.47 Remote Command Execution"
-name_zh = "Fastjson 1.2.47 远程命令执行漏洞"
+  [[container.name]]
+  en = "Fastjson 1.2.47 Remote Command Execution"
+  zh = "Fastjson 1.2.47 远程命令执行漏洞"
 app = "Fastjson"
   [[container.cve]]
   name = ""
@@ -467,8 +519,9 @@ app = "Fastjson"
 path = "fastjson/1.2.47-rce"
 
 [[container]]
-name_en = "FFmpeg Arbitrary File Read/SSRF"
-name_zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
+  [[container.name]]
+  en = "FFmpeg Arbitrary File Read/SSRF"
+  zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
 app = "ffmpeg"
   [[container.cve]]
   name = "CVE-2016-1897,CVE-2016-1898"
@@ -476,8 +529,9 @@ app = "ffmpeg"
 path = "ffmpeg/CVE-2016-1897"
 
 [[container]]
-name_en = "FFmpeg Arbitrary File Read"
-name_zh = "FFmpeg 任意文件读取漏洞"
+  [[container.name]]
+  en = "FFmpeg Arbitrary File Read"
+  zh = "FFmpeg 任意文件读取漏洞"
 app = "ffmpeg"
   [[container.cve]]
   name = "CVE-2017-9993"
@@ -485,8 +539,9 @@ app = "ffmpeg"
 path = "ffmpeg/phdays"
 
 [[container]]
-name_en = "Jinja2 SSTI Template Injection"
-name_zh = "Jinja2 SSTI模板注入"
+  [[container.name]]
+  en = "Jinja2 SSTI Template Injection"
+  zh = "Jinja2 SSTI模板注入"
 app = "Jinja2"
   [[container.cve]]
   name = ""
@@ -494,8 +549,9 @@ app = "Jinja2"
 path = "flask/ssti"
 
 [[container]]
-name_en = "Apache Flink File Upload"
-name_zh = "Apache Flink 文件上传漏洞"
+  [[container.name]]
+  en = "Apache Flink File Upload"
+  zh = "Apache Flink 文件上传漏洞"
 app = "flink"
   [[container.cve]]
   name = "CVE-2020-17518"
@@ -503,8 +559,9 @@ app = "flink"
 path = "flink/CVE-2020-17518"
 
 [[container]]
-name_en = "Apache Flink Jobmanager/Logs Directory Traversal"
-name_zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
+  [[container.name]]
+  en = "Apache Flink Jobmanager/Logs Directory Traversal"
+  zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
 app = "flink"
   [[container.cve]]
   name = "CVE-2020-17519"
@@ -512,8 +569,9 @@ app = "flink"
 path = "flink/CVE-2020-17519"
 
 [[container]]
-name_en = "GeoServer OGC Filter SQL Injection"
-name_zh = "GeoServer OGC Filter SQL注入漏洞"
+  [[container.name]]
+  en = "GeoServer OGC Filter SQL Injection"
+  zh = "GeoServer OGC Filter SQL注入漏洞"
 app = "GeoServer"
   [[container.cve]]
   name = "CVE-2023-25157"
@@ -521,8 +579,9 @@ app = "GeoServer"
 path = "geoserver/CVE-2023-25157"
 
 [[container]]
-name_en = "GhostScript Sandbox Bypass (Command Execution)"
-name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
+  [[container.name]]
+  en = "GhostScript Sandbox Bypass (Command Execution)"
+  zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
   [[container.cve]]
   name = "CVE-2018-16509"
@@ -530,8 +589,9 @@ app = "ghostscript"
 path = "ghostscript/CVE-2018-16509"
 
 [[container]]
-name_en = "GhostScript Sandbox Bypass (Command Execution)"
-name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
+  [[container.name]]
+  en = "GhostScript Sandbox Bypass (Command Execution)"
+  zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
   [[container.cve]]
   name = "CVE-2018-19475"
@@ -539,8 +599,9 @@ app = "ghostscript"
 path = "ghostscript/CVE-2018-19475"
 
 [[container]]
-name_en = "GhostScript Sandbox Bypass (Command Execution)"
-name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
+  [[container.name]]
+  en = "GhostScript Sandbox Bypass (Command Execution)"
+  zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
   [[container.cve]]
   name = "CVE-2019-6116"
@@ -548,8 +609,9 @@ app = "ghostscript"
 path = "ghostscript/CVE-2019-6116"
 
 [[container]]
-name_en = "GIT-SHELL Sandbox Bypass"
-name_zh = "GIT-SHELL 沙盒绕过"
+  [[container.name]]
+  en = "GIT-SHELL Sandbox Bypass"
+  zh = "GIT-SHELL 沙盒绕过"
 app = "git"
   [[container.cve]]
   name = "CVE-2017-8386"
@@ -557,8 +619,9 @@ app = "git"
 path = "git/CVE-2017-8386"
 
 [[container]]
-name_en = "Gitea 1.4.0 Directory Traversal to Command Execution"
-name_zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
+  [[container.name]]
+  en = "Gitea 1.4.0 Directory Traversal to Command Execution"
+  zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
 app = "gitea"
   [[container.cve]]
   name = ""
@@ -566,8 +629,9 @@ app = "gitea"
 path = "gitea/1.4-rce"
 
 [[container]]
-name_en = "GitLab Arbitrary File Read"
-name_zh = "GitLab 任意文件读取漏洞"
+  [[container.name]]
+  en = "GitLab Arbitrary File Read"
+  zh = "GitLab 任意文件读取漏洞"
 app = "gitlab"
   [[container.cve]]
   name = "CVE-2016-9086"
@@ -575,8 +639,9 @@ app = "gitlab"
 path = "gitlab/CVE-2016-9086"
 
 [[container]]
-name_en = "GitLab Remote Command Execution"
-name_zh = "GitLab 远程命令执行漏洞"
+  [[container.name]]
+  en = "GitLab Remote Command Execution"
+  zh = "GitLab 远程命令执行漏洞"
 app = "gitlab"
   [[container.cve]]
   name = "CVE-2021-22205"
@@ -584,8 +649,9 @@ app = "gitlab"
 path = "gitlab/CVE-2021-22205"
 
 [[container]]
-name_en = "gitlist 0.6.0 Remote Command Execution"
-name_zh = "gitlist 0.6.0 远程命令执行漏洞"
+  [[container.name]]
+  en = "gitlist 0.6.0 Remote Command Execution"
+  zh = "gitlist 0.6.0 远程命令执行漏洞"
 app = "gitlist"
   [[container.cve]]
   name = ""
@@ -593,8 +659,9 @@ app = "gitlist"
 path = "gitlist/0.6.0-rce"
 
 [[container]]
-name_en = "GlassFish Arbitrary File Read"
-name_zh = "GlassFish 任意文件读取漏洞"
+  [[container.name]]
+  en = "GlassFish Arbitrary File Read"
+  zh = "GlassFish 任意文件读取漏洞"
 app = "GlassFish"
   [[container.cve]]
   name = ""
@@ -602,8 +669,9 @@ app = "GlassFish"
 path = "glassfish/4.1.0"
 
 [[container]]
-name_en = "GoAhead Remote Command Execution"
-name_zh = "GoAhead 远程命令执行漏洞"
+  [[container.name]]
+  en = "GoAhead Remote Command Execution"
+  zh = "GoAhead 远程命令执行漏洞"
 app = "GoAhead"
   [[container.cve]]
   name = "CVE-2017-17562"
@@ -611,8 +679,9 @@ app = "GoAhead"
 path = "goahead/CVE-2017-17562"
 
 [[container]]
-name_en = "GoAhead Server Environment Variable Injection"
-name_zh = "GoAhead Server 环境变量注入"
+  [[container.name]]
+  en = "GoAhead Server Environment Variable Injection"
+  zh = "GoAhead Server 环境变量注入"
 app = "GoAhead"
   [[container.cve]]
   name = "CVE-2021-42342"
@@ -620,8 +689,9 @@ app = "GoAhead"
 path = "goahead/CVE-2021-42342"
 
 [[container]]
-name_en = "Gogs Arbitrary User Login"
-name_zh = "Gogs 任意用户登录漏洞"
+  [[container.name]]
+  en = "Gogs Arbitrary User Login"
+  zh = "Gogs 任意用户登录漏洞"
 app = "Gogs"
   [[container.cve]]
   name = "CVE-2018-18925"
@@ -629,8 +699,9 @@ app = "Gogs"
 path = "gogs/CVE-2018-18925"
 
 [[container]]
-name_en = "Grafana 8.x Plug-in Module Directory Traversal"
-name_zh = "Grafana 8.x 插件模块目录穿越漏洞"
+  [[container.name]]
+  en = "Grafana 8.x Plug-in Module Directory Traversal"
+  zh = "Grafana 8.x 插件模块目录穿越漏洞"
 app = "Grafana"
   [[container.cve]]
   name = "CVE-2021-43798"
@@ -638,8 +709,9 @@ app = "Grafana"
 path = "grafana/CVE-2021-43798"
 
 [[container]]
-name_en = "Grafana Management Background SSRF"
-name_zh = "Grafana管理后台SSRF"
+  [[container.name]]
+  en = "Grafana Management Background SSRF"
+  zh = "Grafana管理后台SSRF"
 app = "Grafana"
   [[container.cve]]
   name = ""
@@ -647,8 +719,9 @@ app = "Grafana"
 path = "grafana/admin-ssrf"
 
 [[container]]
-name_en = "H2 Database Console Unauthorized Access"
-name_zh = "H2 Database Console 未授权访问"
+  [[container.name]]
+  en = "H2 Database Console Unauthorized Access"
+  zh = "H2 Database Console 未授权访问"
 app = "Springboot H2 Database"
   [[container.cve]]
   name = ""
@@ -656,8 +729,9 @@ app = "Springboot H2 Database"
 path = "h2database/h2-console-unacc"
 
 [[container]]
-name_en = "Hadoop YARN ResourceManager Unauthorized Access"
-name_zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
+  [[container.name]]
+  en = "Hadoop YARN ResourceManager Unauthorized Access"
+  zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
 app = "Hadoop YARN"
   [[container.cve]]
   name = ""
@@ -665,8 +739,9 @@ app = "Hadoop YARN"
 path = "hadoop/unauthorized-yarn"
 
 [[container]]
-name_en = "Apache HTTPD Newline Parsing"
-name_zh = "Apache HTTPD 换行解析漏洞"
+  [[container.name]]
+  en = "Apache HTTPD Newline Parsing"
+  zh = "Apache HTTPD 换行解析漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
   name = "CVE-2017-15715"
@@ -674,8 +749,9 @@ app = "Apache HTTP Server"
 path = "httpd/CVE-2017-15715"
 
 [[container]]
-name_en = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
-name_zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
+  [[container.name]]
+  en = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
+  zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
   name = "CVE-2021-40438"
@@ -683,8 +759,9 @@ app = "Apache HTTP Server"
 path = "httpd/CVE-2021-40438"
 
 [[container]]
-name_en = "Apache HTTP Server 2.4.49 Path Traversal"
-name_zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
+  [[container.name]]
+  en = "Apache HTTP Server 2.4.49 Path Traversal"
+  zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
   name = "CVE-2021-41773"
@@ -692,8 +769,9 @@ app = "Apache HTTP Server"
 path = "httpd/CVE-2021-41773"
 
 [[container]]
-name_en = "Apache HTTP Server 2.4.50 Path Traversal"
-name_zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
+  [[container.name]]
+  en = "Apache HTTP Server 2.4.50 Path Traversal"
+  zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
   name = "CVE-2021-42013"
@@ -701,8 +779,9 @@ app = "Apache HTTP Server"
 path = "httpd/CVE-2021-42013"
 
 [[container]]
-name_en = "Apache HTTPD Unknown Suffix Parsing"
-name_zh = "Apache HTTPD 未知后缀解析漏洞"
+  [[container.name]]
+  en = "Apache HTTPD Unknown Suffix Parsing"
+  zh = "Apache HTTPD 未知后缀解析漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
   name = ""
@@ -710,8 +789,9 @@ app = "Apache HTTP Server"
 path = "httpd/apache_parsing_vulnerability"
 
 [[container]]
-name_en = "Apache SSI Remote Command Execution"
-name_zh = "Apache SSI 远程命令执行漏洞"
+  [[container.name]]
+  en = "Apache SSI Remote Command Execution"
+  zh = "Apache SSI 远程命令执行漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
   name = ""
@@ -719,8 +799,9 @@ app = "Apache HTTP Server"
 path = "httpd/ssi-rce"
 
 [[container]]
-name_en = "Imagetragick Command Execution"
-name_zh = "Imagetragick 命令执行漏洞"
+  [[container.name]]
+  en = "Imagetragick Command Execution"
+  zh = "Imagetragick 命令执行漏洞"
 app = "ImageMagick"
   [[container.cve]]
   name = "CVE-2016-3714"
@@ -728,8 +809,9 @@ app = "ImageMagick"
 path = "imagemagick/imagetragick"
 
 [[container]]
-name_en = "ImageMagick PDF Password Location Command Injection"
-name_zh = "ImageMagick PDF密码位置命令注入漏洞"
+  [[container.name]]
+  en = "ImageMagick PDF Password Location Command Injection"
+  zh = "ImageMagick PDF密码位置命令注入漏洞"
 app = "imagemagick"
   [[container.cve]]
   name = "CVE-2020-29599"
@@ -737,8 +819,9 @@ app = "imagemagick"
 path = "imagemagick/CVE-2020-29599"
 
 [[container]]
-name_en = "ImageMagick Arbitrary File Read"
-name_zh = "ImageMagick任意文件读取漏洞"
+  [[container.name]]
+  en = "ImageMagick Arbitrary File Read"
+  zh = "ImageMagick任意文件读取漏洞"
 app = "imagemagick"
   [[container.cve]]
   name = "CVE-2022-44268"
@@ -746,8 +829,9 @@ app = "imagemagick"
 path = "imagemagick/CVE-2022-44268"
 
 [[container]]
-name_en = "InfluxDB Empty JWT Secret Key Authentication Bypass"
-name_zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
+  [[container.name]]
+  en = "InfluxDB Empty JWT Secret Key Authentication Bypass"
+  zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
 app = "InfluxDB"
   [[container.cve]]
   name = "CVE-2019-20933"
@@ -755,8 +839,9 @@ app = "InfluxDB"
 path = "influxdb/CVE-2019-20933"
 
 [[container]]
-name_en = "Jackson-databind Deserialization"
-name_zh = "Jackson-databind 反序列化漏洞"
+  [[container.name]]
+  en = "Jackson-databind Deserialization"
+  zh = "Jackson-databind 反序列化漏洞"
 app = "Jackson-databind"
   [[container.cve]]
   name = "CVE-2017-7525"
@@ -764,8 +849,9 @@ app = "Jackson-databind"
 path = "jackson/CVE-2017-7525"
 
 [[container]]
-name_en = "Java RMI codebase Remote Code Execution"
-name_zh = "Java RMI codebase 远程代码执行漏洞"
+  [[container.name]]
+  en = "Java RMI codebase Remote Code Execution"
+  zh = "Java RMI codebase 远程代码执行漏洞"
 app = "java rmi"
   [[container.cve]]
   name = ""
@@ -773,8 +859,9 @@ app = "java rmi"
 path = "java/rmi-codebase"
 
 [[container]]
-name_en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
-name_zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
+  [[container.name]]
+  en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
+  zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
 app = "java rmi"
   [[container.cve]]
   name = ""
@@ -782,8 +869,9 @@ app = "java rmi"
 path = "java/rmi-registry-bind-deserialization"
 
 [[container]]
-name_en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
-name_zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
+  [[container.name]]
+  en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
+  zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
 app = "java rmi"
   [[container.cve]]
   name = ""
@@ -791,8 +879,9 @@ app = "java rmi"
 path = "java/rmi-registry-bind-deserialization-bypass"
 
 [[container]]
-name_en = "JBoss 5.x/6.x Deserialization"
-name_zh = "JBoss 5.x/6.x 反序列化漏洞"
+  [[container.name]]
+  en = "JBoss 5.x/6.x Deserialization"
+  zh = "JBoss 5.x/6.x 反序列化漏洞"
 app = "jboss"
   [[container.cve]]
   name = "CVE-2017-12149"
@@ -800,8 +889,9 @@ app = "jboss"
 path = "jboss/CVE-2017-12149"
 
 [[container]]
-name_en = "JBoss 4.x JBossMQ JMS Deserialization"
-name_zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
+  [[container.name]]
+  en = "JBoss 4.x JBossMQ JMS Deserialization"
+  zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
 app = "jboss"
   [[container.cve]]
   name = "CVE-2017-7504"
@@ -809,8 +899,9 @@ app = "jboss"
 path = "jboss/CVE-2017-7504"
 
 [[container]]
-name_en = "JBoss JMXInvokerServlet Deserialization"
-name_zh = "JBoss JMXInvokerServlet 反序列化漏洞"
+  [[container.name]]
+  en = "JBoss JMXInvokerServlet Deserialization"
+  zh = "JBoss JMXInvokerServlet 反序列化漏洞"
 app = "jboss"
   [[container.cve]]
   name = ""
@@ -818,8 +909,9 @@ app = "jboss"
 path = "jboss/JMXInvokerServlet-deserialization"
 
 [[container]]
-name_en = "Jenkins-CI Remote Code Execution"
-name_zh = "Jenkins-CI 远程代码执行漏洞"
+  [[container.name]]
+  en = "Jenkins-CI Remote Code Execution"
+  zh = "Jenkins-CI 远程代码执行漏洞"
 app = "Jenkins"
   [[container.cve]]
   name = "CVE-2017-1000353"
@@ -827,8 +919,9 @@ app = "Jenkins"
 path = "jenkins/CVE-2017-1000353"
 
 [[container]]
-name_en = "Jenkins Remote Command Execution"
-name_zh = "Jenkins远程命令执行漏洞"
+  [[container.name]]
+  en = "Jenkins Remote Command Execution"
+  zh = "Jenkins远程命令执行漏洞"
 app = "Jenkins"
   [[container.cve]]
   name = "CVE-2018-1000861"
@@ -836,8 +929,9 @@ app = "Jenkins"
 path = "jenkins/CVE-2018-1000861"
 
 [[container]]
-name_en = "Jetty WEB-INF Sensitive Information Disclosure"
-name_zh = "Jetty WEB-INF 敏感信息泄露漏洞"
+  [[container.name]]
+  en = "Jetty WEB-INF Sensitive Information Disclosure"
+  zh = "Jetty WEB-INF 敏感信息泄露漏洞"
 app = "jetty"
   [[container.cve]]
   name = "CVE-2021-28164"
@@ -845,8 +939,9 @@ app = "jetty"
 path = "jetty/CVE-2021-28164"
 
 [[container]]
-name_en = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
-name_zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
+  [[container.name]]
+  en = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
+  zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
 app = "jetty"
   [[container.cve]]
   name = "CVE-2021-28169"
@@ -854,8 +949,9 @@ app = "jetty"
 path = "jetty/CVE-2021-28169"
 
 [[container]]
-name_en = "Jetty WEB-INF Sensitive Information Disclosure"
-name_zh = "Jetty WEB-INF 敏感信息泄露漏洞"
+  [[container.name]]
+  en = "Jetty WEB-INF Sensitive Information Disclosure"
+  zh = "Jetty WEB-INF 敏感信息泄露漏洞"
 app = "jetty"
   [[container.cve]]
   name = "CVE-2021-34429"
@@ -863,8 +959,9 @@ app = "jetty"
 path = "jetty/CVE-2021-34429"
 
 [[container]]
-name_en = "Atlassian Jira Template Injection"
-name_zh = "Atlassian Jira 模板注入漏洞"
+  [[container.name]]
+  en = "Atlassian Jira Template Injection"
+  zh = "Atlassian Jira 模板注入漏洞"
 app = "jira"
   [[container.cve]]
   name = "CVE-2019-11581"
@@ -872,8 +969,9 @@ app = "jira"
 path = "jira/CVE-2019-11581"
 
 [[container]]
-name_en = "Jmeter RMI Deserialization Command Execution"
-name_zh = "Jmeter RMI 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "Jmeter RMI Deserialization Command Execution"
+  zh = "Jmeter RMI 反序列化命令执行漏洞"
 app = "Apache Jmeter"
   [[container.cve]]
   name = "CVE-2018-1297"
@@ -881,8 +979,9 @@ app = "Apache Jmeter"
 path = "jmeter/CVE-2018-1297"
 
 [[container]]
-name_en = "Joomla 3.4.5 Deserialization"
-name_zh = "Joomla 3.4.5 反序列化漏洞"
+  [[container.name]]
+  en = "Joomla 3.4.5 Deserialization"
+  zh = "Joomla 3.4.5 反序列化漏洞"
 app = "Joomla"
   [[container.cve]]
   name = "CVE-2015-8562"
@@ -890,8 +989,9 @@ app = "Joomla"
 path = "joomla/CVE-2015-8562"
 
 [[container]]
-name_en = "Joomla 3.7.0 SQL Injection"
-name_zh = "Joomla 3.7.0 SQL注入漏洞"
+  [[container.name]]
+  en = "Joomla 3.7.0 SQL Injection"
+  zh = "Joomla 3.7.0 SQL注入漏洞"
 app = "Joomla"
   [[container.cve]]
   name = "CVE-2017-8917"
@@ -899,8 +999,9 @@ app = "Joomla"
 path = "joomla/CVE-2017-8917"
 
 [[container]]
-name_en = "Joomla 4.2.7 Permission Bypass"
-name_zh = "Joomla 4.2.7 权限绕过漏洞"
+  [[container.name]]
+  en = "Joomla 4.2.7 Permission Bypass"
+  zh = "Joomla 4.2.7 权限绕过漏洞"
 app = "Joomla"
   [[container.cve]]
   name = "CVE-2023-23752"
@@ -908,8 +1009,9 @@ app = "Joomla"
 path = "joomla/CVE-2023-23752"
 
 [[container]]
-name_en = "Jupyter Notebook Unauthorized Access"
-name_zh = "Jupyter Notebook 未授权访问漏洞"
+  [[container.name]]
+  en = "Jupyter Notebook Unauthorized Access"
+  zh = "Jupyter Notebook 未授权访问漏洞"
 app = "Jupyter"
   [[container.cve]]
   name = ""
@@ -917,8 +1019,9 @@ app = "Jupyter"
 path = "jupyter/notebook-rce"
 
 [[container]]
-name_en = "Apache Kafka Clients JNDI Injection"
-name_zh = "Apache Kafka Clients JNDI注入漏洞"
+  [[container.name]]
+  en = "Apache Kafka Clients JNDI Injection"
+  zh = "Apache Kafka Clients JNDI注入漏洞"
 app = "Apache Kafka"
   [[container.cve]]
   name = "CVE-2023-25194"
@@ -926,8 +1029,9 @@ app = "Apache Kafka"
 path = "kafka/CVE-2023-25194"
 
 [[container]]
-name_en = "Kibana Local File Inclusion"
-name_zh = "Kibana 本地文件包含漏洞"
+  [[container.name]]
+  en = "Kibana Local File Inclusion"
+  zh = "Kibana 本地文件包含漏洞"
 app = "kibana"
   [[container.cve]]
   name = "CVE-2018-17246"
@@ -935,8 +1039,9 @@ app = "kibana"
 path = "kibana/CVE-2018-17246"
 
 [[container]]
-name_en = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
-name_zh = "Kibana 原型链污染导致任意代码执行漏洞"
+  [[container.name]]
+  en = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
+  zh = "Kibana 原型链污染导致任意代码执行漏洞"
 app = "kibana"
   [[container.cve]]
   name = "CVE-2019-7609"
@@ -944,8 +1049,9 @@ app = "kibana"
 path = "kibana/CVE-2019-7609"
 
 [[container]]
-name_en = "Laravel Ignition 2.5.1 Code Execution"
-name_zh = "Laravel Ignition 2.5.1 代码执行漏洞"
+  [[container.name]]
+  en = "Laravel Ignition 2.5.1 Code Execution"
+  zh = "Laravel Ignition 2.5.1 代码执行漏洞"
 app = "laravel"
   [[container.cve]]
   name = "CVE-2021-3129"
@@ -953,8 +1059,9 @@ app = "laravel"
 path = "kibana/CVE-2021-3129"
 
 [[container]]
-name_en = "libssh Server-side Authentication Bypass"
-name_zh = "libssh 服务端权限认证绕过漏洞"
+  [[container.name]]
+  en = "libssh Server-side Authentication Bypass"
+  zh = "libssh 服务端权限认证绕过漏洞"
 app = "libssh"
   [[container.cve]]
   name = "CVE-2018-10933"
@@ -962,8 +1069,9 @@ app = "libssh"
 path = "libssh/CVE-2018-10933"
 
 [[container]]
-name_en = "Liferay Portal CE Deserialization Command Execution"
-name_zh = "Liferay Portal CE 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "Liferay Portal CE Deserialization Command Execution"
+  zh = "Liferay Portal CE 反序列化命令执行漏洞"
 app = "Liferay Portal"
   [[container.cve]]
   name = "CVE-2020-7961"
@@ -971,8 +1079,9 @@ app = "Liferay Portal"
 path = "liferay-portal/CVE-2020-7961"
 
 [[container]]
-name_en = "Apache Log4j Server Deserialization Command Execution"
-name_zh = "Apache Log4j Server 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "Apache Log4j Server Deserialization Command Execution"
+  zh = "Apache Log4j Server 反序列化命令执行漏洞"
 app = "Apache Log4j"
   [[container.cve]]
   name = "CVE-2017-5645"
@@ -980,8 +1089,9 @@ app = "Apache Log4j"
 path = "log4j/CVE-2017-5645"
 
 [[container]]
-name_en = "Apache Log4j2 lookup JNDI Injection"
-name_zh = "Apache Log4j2 lookup JNDI 注入漏洞"
+  [[container.name]]
+  en = "Apache Log4j2 lookup JNDI Injection"
+  zh = "Apache Log4j2 lookup JNDI 注入漏洞"
 app = "Apache Log4j"
   [[container.cve]]
   name = "CVE-2021-44228"
@@ -989,8 +1099,9 @@ app = "Apache Log4j"
 path = "log4j/CVE-2021-44228"
 
 [[container]]
-name_en = "Magento 2.2 SQL Injection"
-name_zh = "Magento 2.2 SQL注入漏洞"
+  [[container.name]]
+  en = "Magento 2.2 SQL Injection"
+  zh = "Magento 2.2 SQL注入漏洞"
 app = "Magento"
   [[container.cve]]
   name = ""
@@ -998,8 +1109,9 @@ app = "Magento"
 path = "magento/2.2-sqli"
 
 [[container]]
-name_en = "Metabase Arbitrary File Read"
-name_zh = "Metabase任意文件读取漏洞"
+  [[container.name]]
+  en = "Metabase Arbitrary File Read"
+  zh = "Metabase任意文件读取漏洞"
 app = "metabase"
   [[container.cve]]
   name = "CVE-2021-41277"
@@ -1007,8 +1119,9 @@ app = "metabase"
 path = "metabase/CVE-2021-41277"
 
 [[container]]
-name_en = "mini_httpd Arbitrary File Read"
-name_zh = "mini_httpd任意文件读取漏洞"
+  [[container.name]]
+  en = "mini_httpd Arbitrary File Read"
+  zh = "mini_httpd任意文件读取漏洞"
 app = "mini_httpd"
   [[container.cve]]
   name = "CVE-2018-18778"
@@ -1016,8 +1129,9 @@ app = "mini_httpd"
 path = "mini_httpd/CVE-2018-18778"
 
 [[container]]
-name_en = "MinIO Cluster Mode Information Disclosure"
-name_zh = "MinIO集群模式信息泄露漏洞"
+  [[container.name]]
+  en = "MinIO Cluster Mode Information Disclosure"
+  zh = "MinIO集群模式信息泄露漏洞"
 app = "MinIO"
   [[container.cve]]
   name = "CVE-2023-28432"
@@ -1025,8 +1139,9 @@ app = "MinIO"
 path = "minio/CVE-2023-28432"
 
 [[container]]
-name_en = "Mojarra JSF ViewState Deserialization"
-name_zh = "Mojarra JSF ViewState 反序列化漏洞"
+  [[container.name]]
+  en = "Mojarra JSF ViewState Deserialization"
+  zh = "Mojarra JSF ViewState 反序列化漏洞"
 app = "Mojarra JSF"
   [[container.cve]]
   name = ""
@@ -1034,8 +1149,9 @@ app = "Mojarra JSF"
 path = "mojarra/jsf-viewstate-deserialization"
 
 [[container]]
-name_en = "Mongo Express Remote Code Execution"
-name_zh = "Mongo Express 远程代码执行漏洞"
+  [[container.name]]
+  en = "Mongo Express Remote Code Execution"
+  zh = "Mongo Express 远程代码执行漏洞"
 app = "mongo-express"
   [[container.cve]]
   name = "CVE-2019-10758"
@@ -1043,8 +1159,9 @@ app = "mongo-express"
 path = "mongo-express/CVE-2019-10758"
 
 [[container]]
-name_en = "MySQL Authentication Bypass"
-name_zh = "MySQL 身份认证绕过漏洞"
+  [[container.name]]
+  en = "MySQL Authentication Bypass"
+  zh = "MySQL 身份认证绕过漏洞"
 app = "MySQL"
   [[container.cve]]
   name = "CVE-2012-2122"
@@ -1052,8 +1169,9 @@ app = "MySQL"
 path = "mysql/CVE-2012-2122"
 
 [[container]]
-name_en = "Nacos Authentication Bypass"
-name_zh = "Nacos 认证绕过漏洞"
+  [[container.name]]
+  en = "Nacos Authentication Bypass"
+  zh = "Nacos 认证绕过漏洞"
 app = "Nacos"
   [[container.cve]]
   name = "CVE-2021-29441"
@@ -1061,8 +1179,9 @@ app = "Nacos"
 path = "nacos/CVE-2021-29441"
 
 [[container]]
-name_en = "Neo4j Shell Server Deserialization"
-name_zh = "Neo4j Shell Server 反序列化漏洞"
+  [[container.name]]
+  en = "Neo4j Shell Server Deserialization"
+  zh = "Neo4j Shell Server 反序列化漏洞"
 app = "Neo4j"
   [[container.cve]]
   name = "CVE-2021-34371"
@@ -1070,8 +1189,9 @@ app = "Neo4j"
 path = "neo4j/CVE-2021-34371"
 
 [[container]]
-name_en = "Nexus Repository Manager 3 Remote Command Execution"
-name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
+  [[container.name]]
+  en = "Nexus Repository Manager 3 Remote Command Execution"
+  zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
   [[container.cve]]
   name = "CVE-2019-7238"
@@ -1079,8 +1199,9 @@ app = "Nexus Repository Manager"
 path = "nexus/CVE-2019-7238"
 
 [[container]]
-name_en = "Nexus Repository Manager 3 Remote Command Execution"
-name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
+  [[container.name]]
+  en = "Nexus Repository Manager 3 Remote Command Execution"
+  zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
   [[container.cve]]
   name = "CVE-2020-10199"
@@ -1088,8 +1209,9 @@ app = "Nexus Repository Manager"
 path = "nexus/CVE-2020-10199"
 
 [[container]]
-name_en = "Nexus Repository Manager 3 Remote Command Execution"
-name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
+  [[container.name]]
+  en = "Nexus Repository Manager 3 Remote Command Execution"
+  zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
   [[container.cve]]
   name = "CVE-2020-10204"
@@ -1097,8 +1219,9 @@ app = "Nexus Repository Manager"
 path = "nexus/CVE-2020-10204"
 
 [[container]]
-name_en = "Nginx Filename Logic"
-name_zh = "Nginx 文件名逻辑漏洞"
+  [[container.name]]
+  en = "Nginx Filename Logic"
+  zh = "Nginx 文件名逻辑漏洞"
 app = "Nginx"
   [[container.cve]]
   name = "CVE-2013-4547"
@@ -1106,8 +1229,9 @@ app = "Nginx"
 path = "nginx/CVE-2013-4547"
 
 [[container]]
-name_en = "Nginx Out-of-Bounds Read Cache"
-name_zh = "Nginx越界读取缓存漏洞"
+  [[container.name]]
+  en = "Nginx Out-of-Bounds Read Cache"
+  zh = "Nginx越界读取缓存漏洞"
 app = "Nginx"
   [[container.cve]]
   name = "CVE-2017-7529"
@@ -1115,8 +1239,9 @@ app = "Nginx"
 path = "nginx/CVE-2017-7529"
 
 [[container]]
-name_en = "Nginx Configuration Errors"
-name_zh = "Nginx 配置错误三例"
+  [[container.name]]
+  en = "Nginx Configuration Errors"
+  zh = "Nginx 配置错误三例"
 app = "Nginx"
   [[container.cve]]
   name = ""
@@ -1124,8 +1249,9 @@ app = "Nginx"
 path = "nginx/insecure-configuration"
 
 [[container]]
-name_en = "Nginx Parsing"
-name_zh = "Nginx 解析漏洞"
+  [[container.name]]
+  en = "Nginx Parsing"
+  zh = "Nginx 解析漏洞"
 app = "Nginx"
   [[container.cve]]
   name = ""
@@ -1133,8 +1259,9 @@ app = "Nginx"
 path = "nginx/nginx_parsing_vulnerability"
 
 [[container]]
-name_en = "NodeJS Directory Traversal"
-name_zh = "NodeJS 目录穿越漏洞"
+  [[container.name]]
+  en = "NodeJS Directory Traversal"
+  zh = "NodeJS 目录穿越漏洞"
 app = "node"
   [[container.cve]]
   name = "CVE-2017-14849"
@@ -1142,8 +1269,9 @@ app = "node"
 path = "node/CVE-2017-14849"
 
 [[container]]
-name_en = "node-postgres Code Execution"
-name_zh = "node-postgres 代码执行漏洞分析"
+  [[container.name]]
+  en = "node-postgres Code Execution"
+  zh = "node-postgres 代码执行漏洞分析"
 app = "node-postgres"
   [[container.cve]]
   name = "CVE-2017-16082"
@@ -1151,8 +1279,9 @@ app = "node-postgres"
 path = "node/CVE-2017-16082"
 
 [[container]]
-name_en = "ntopng Permission Bypass"
-name_zh = "ntopng权限绕过漏洞"
+  [[container.name]]
+  en = "ntopng Permission Bypass"
+  zh = "ntopng权限绕过漏洞"
 app = "ntopng"
   [[container.cve]]
   name = "CVE-2021-28073"
@@ -1160,8 +1289,9 @@ app = "ntopng"
 path = "ntopng/CVE-2021-28073"
 
 [[container]]
-name_en = "Apache OfBiz Deserialization Command Execution"
-name_zh = "Apache OfBiz 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "Apache OfBiz Deserialization Command Execution"
+  zh = "Apache OfBiz 反序列化命令执行漏洞"
 app = "Apache OfBiz"
   [[container.cve]]
   name = "CVE-2020-9496"
@@ -1169,8 +1299,9 @@ app = "Apache OfBiz"
 path = "ofbiz/CVE-2020-9496"
 
 [[container]]
-name_en = "Openfire Management Background Authentication Bypass"
-name_zh = "Openfire管理后台认证绕过漏洞"
+  [[container.name]]
+  en = "Openfire Management Background Authentication Bypass"
+  zh = "Openfire管理后台认证绕过漏洞"
 app = "Openfire"
   [[container.cve]]
   name = "CVE-2023-32315"
@@ -1178,8 +1309,9 @@ app = "Openfire"
 path = "openfire/CVE-2023-32315"
 
 [[container]]
-name_en = "OpenSMTPD Remote Command Execution"
-name_zh = "OpenSMTPD 远程命令执行漏洞"
+  [[container.name]]
+  en = "OpenSMTPD Remote Command Execution"
+  zh = "OpenSMTPD 远程命令执行漏洞"
 app = "OpenSMTPD"
   [[container.cve]]
   name = "CVE-2020-7247"
@@ -1187,8 +1319,9 @@ app = "OpenSMTPD"
 path = "opensmtpd/CVE-2020-7247"
 
 [[container]]
-name_en = "OpenSSH Username Enumeration"
-name_zh = "OpenSSH 用户名枚举漏洞"
+  [[container.name]]
+  en = "OpenSSH Username Enumeration"
+  zh = "OpenSSH 用户名枚举漏洞"
 app = "OpenSSH"
   [[container.cve]]
   name = "CVE-2018-15473"
@@ -1196,8 +1329,9 @@ app = "OpenSSH"
 path = "openssh/CVE-2018-15473"
 
 [[container]]
-name_en = "OpenSSL Heartbleed"
-name_zh = "OpenSSL 心脏出血漏洞"
+  [[container.name]]
+  en = "OpenSSL Heartbleed"
+  zh = "OpenSSL 心脏出血漏洞"
 app = "OpenSSL"
   [[container.cve]]
   name = "CVE-2014-0160"
@@ -1205,8 +1339,9 @@ app = "OpenSSL"
 path = "openssl/CVE-2014-0160"
 
 [[container]]
-name_en = "OpenSSL Infinite Loop DoS"
-name_zh = "OpenSSL无限循环DoS漏洞"
+  [[container.name]]
+  en = "OpenSSL Infinite Loop DoS"
+  zh = "OpenSSL无限循环DoS漏洞"
 app = "OpenSSL"
   [[container.cve]]
   name = "CVE-2022-0778"
@@ -1214,8 +1349,9 @@ app = "OpenSSL"
 path = "openssl/CVE-2022-0778"
 
 [[container]]
-name_en = "OpenTSDB Command Injection"
-name_zh = "OpenTSDB 命令注入漏洞"
+  [[container.name]]
+  en = "OpenTSDB Command Injection"
+  zh = "OpenTSDB 命令注入漏洞"
 app = "OpenTSDB"
   [[container.cve]]
   name = "CVE-2020-35476"
@@ -1223,8 +1359,9 @@ app = "OpenTSDB"
 path = "opentsdb/CVE-2020-35476"
 
 [[container]]
-name_en = "PHP 8.1.0-dev Development Version Backdoor Event"
-name_zh = "PHP 8.1.0-dev 开发版本后门事件"
+  [[container.name]]
+  en = "PHP 8.1.0-dev Development Version Backdoor Event"
+  zh = "PHP 8.1.0-dev 开发版本后门事件"
 app = "PHP"
   [[container.cve]]
   name = ""
@@ -1232,8 +1369,9 @@ app = "PHP"
 path = "php/8.1-backdoor"
 
 [[container]]
-name_en = "PHP-CGI Remote Code Execution"
-name_zh = "PHP-CGI远程代码执行漏洞"
+  [[container.name]]
+  en = "PHP-CGI Remote Code Execution"
+  zh = "PHP-CGI远程代码执行漏洞"
 app = "PHP-CGI"
   [[container.cve]]
   name = "CVE-2012-1823"
@@ -1241,8 +1379,9 @@ app = "PHP-CGI"
 path = "php/CVE-2012-1823"
 
 [[container]]
-name_en = "PHP-IMAP Remote Command Execution"
-name_zh = "PHP-IMAP 远程命令执行漏洞"
+  [[container.name]]
+  en = "PHP-IMAP Remote Command Execution"
+  zh = "PHP-IMAP 远程命令执行漏洞"
 app = "PHP-IMAP"
   [[container.cve]]
   name = "CVE-2018-19518"
@@ -1250,8 +1389,9 @@ app = "PHP-IMAP"
 path = "php/CVE-2018-19518"
 
 [[container]]
-name_en = "PHP-FPM Remote Command Execution"
-name_zh = "PHP-FPM 远程代码执行漏洞"
+  [[container.name]]
+  en = "PHP-FPM Remote Command Execution"
+  zh = "PHP-FPM 远程代码执行漏洞"
 app = "PHP-FPM"
   [[container.cve]]
   name = "CVE-2019-11043"
@@ -1259,8 +1399,9 @@ app = "PHP-FPM"
 path = "php/CVE-2019-11043"
 
 [[container]]
-name_en = "PHP-FPM FastCGI Unauthorized Access"
-name_zh = "PHP-FPM FastCGI 未授权访问漏洞"
+  [[container.name]]
+  en = "PHP-FPM FastCGI Unauthorized Access"
+  zh = "PHP-FPM FastCGI 未授权访问漏洞"
 app = "PHP-FPM"
   [[container.cve]]
   name = ""
@@ -1268,8 +1409,9 @@ app = "PHP-FPM"
 path = "php/fpm"
 
 [[container]]
-name_en = "PHP Files Vulnerabilities (by phpinfo())"
-name_zh = "PHP文件包含漏洞 (利用phpinfo())"
+  [[container.name]]
+  en = "PHP Files Vulnerabilities (by phpinfo())"
+  zh = "PHP文件包含漏洞 (利用phpinfo())"
 app = "PHP"
   [[container.cve]]
   name = ""
@@ -1277,8 +1419,9 @@ app = "PHP"
 path = "php/inclusion"
 
 [[container]]
-name_en = "PHP XML Entity Injection"
-name_zh = "PHP XML实体注入"
+  [[container.name]]
+  en = "PHP XML Entity Injection"
+  zh = "PHP XML实体注入"
 app = "PHP"
   [[container.cve]]
   name = ""
@@ -1286,8 +1429,9 @@ app = "PHP"
 path = "php/php_xxe"
 
 [[container]]
-name_en = "XDebug Remote Debugging Code Execution"
-name_zh = "XDebug 远程调试漏洞 (代码执行)"
+  [[container.name]]
+  en = "XDebug Remote Debugging Code Execution"
+  zh = "XDebug 远程调试漏洞 (代码执行)"
 app = "PHP"
   [[container.cve]]
   name = ""
@@ -1295,8 +1439,9 @@ app = "PHP"
 path = "php/xdebug-rce"
 
 [[container]]
-name_en = "PHPMailer Arbitrary File Read"
-name_zh = "PHPMailer 任意文件读取漏洞"
+  [[container.name]]
+  en = "PHPMailer Arbitrary File Read"
+  zh = "PHPMailer 任意文件读取漏洞"
 app = "PHPMailer"
   [[container.cve]]
   name = "CVE-2017-5223"
@@ -1304,8 +1449,9 @@ app = "PHPMailer"
 path = "phpmailer/CVE-2017-5223"
 
 [[container]]
-name_en = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
-name_zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
+  [[container.name]]
+  en = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
+  zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
 app = "phpmyadmin"
   [[container.cve]]
   name = "CVE-2016-5734"
@@ -1313,8 +1459,9 @@ app = "phpmyadmin"
 path = "phpmyadmin/CVE-2016-5734"
 
 [[container]]
-name_en = "phpmyadmin 4.8.1 Remote File Inclusion"
-name_zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
+  [[container.name]]
+  en = "phpmyadmin 4.8.1 Remote File Inclusion"
+  zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
 app = "phpmyadmin"
   [[container.cve]]
   name = "CVE-2018-12613"
@@ -1322,8 +1469,9 @@ app = "phpmyadmin"
 path = "phpmyadmin/CVE-2018-12613"
 
 [[container]]
-name_en = "phpmyadmin scripts/setup.php Deserialization"
-name_zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
+  [[container.name]]
+  en = "phpmyadmin scripts/setup.php Deserialization"
+  zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
 app = "phpmyadmin"
   [[container.cve]]
   name = ""
@@ -1331,8 +1479,9 @@ app = "phpmyadmin"
 path = "phpmyadmin/WooYun-2016-199433"
 
 [[container]]
-name_en = "phpunit Remote Code Execution"
-name_zh = "phpunit 远程代码执行漏洞"
+  [[container.name]]
+  en = "phpunit Remote Code Execution"
+  zh = "phpunit 远程代码执行漏洞"
 app = "phpunit"
   [[container.cve]]
   name = "CVE-2017-9841"
@@ -1340,8 +1489,9 @@ app = "phpunit"
 path = "phpunit/CVE-2017-9841"
 
 [[container]]
-name_en = "Polkit pkexec Privilege Escalation"
-name_zh = "Polkit pkexec 权限提升漏洞"
+  [[container.name]]
+  en = "Polkit pkexec Privilege Escalation"
+  zh = "Polkit pkexec 权限提升漏洞"
 app = "Polkit Pkexec"
   [[container.cve]]
   name = "CVE-2021-4034"
@@ -1349,8 +1499,9 @@ app = "Polkit Pkexec"
 path = "polkit/CVE-2021-4034"
 
 [[container]]
-name_en = "PostgreSQL Privilege Escalation"
-name_zh = "PostgreSQL 提权漏洞"
+  [[container.name]]
+  en = "PostgreSQL Privilege Escalation"
+  zh = "PostgreSQL 提权漏洞"
 app = "PostgreSQL"
   [[container.cve]]
   name = "CVE-2018-1058"
@@ -1358,8 +1509,9 @@ app = "PostgreSQL"
 path = "postgres/CVE-2018-1058"
 
 [[container]]
-name_en = "PostgreSQL High Privilege Command Execution"
-name_zh = "PostgreSQL 高权限命令执行漏洞"
+  [[container.name]]
+  en = "PostgreSQL High Privilege Command Execution"
+  zh = "PostgreSQL 高权限命令执行漏洞"
 app = "PostgreSQL"
   [[container.cve]]
   name = "CVE-2019-9193"
@@ -1367,8 +1519,9 @@ app = "PostgreSQL"
 path = "postgres/CVE-2019-9193"
 
 [[container]]
-name_en = "Python PIL Remote Command Execution (GhostButt)"
-name_zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
+  [[container.name]]
+  en = "Python PIL Remote Command Execution (GhostButt)"
+  zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
 app = "Python"
   [[container.cve]]
   name = "CVE-2017-8291"
@@ -1376,8 +1529,9 @@ app = "Python"
 path = "python/PIL-CVE-2017-8291"
 
 [[container]]
-name_en = "Python PIL Remote Command Execution (via Ghostscript)"
-name_zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
+  [[container.name]]
+  en = "Python PIL Remote Command Execution (via Ghostscript)"
+  zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
 app = "Python"
   [[container.cve]]
   name = "CVE-2018-16509"
@@ -1385,8 +1539,9 @@ app = "Python"
 path = "python/PIL-CVE-2018-16509"
 
 [[container]]
-name_en = "Python Unpickle Deserialization"
-name_zh = "Python Unpickle 反序列化漏洞"
+  [[container.name]]
+  en = "Python Unpickle Deserialization"
+  zh = "Python Unpickle 反序列化漏洞"
 app = "Python"
   [[container.cve]]
   name = ""
@@ -1394,8 +1549,9 @@ app = "Python"
 path = "python/unpickle"
 
 [[container]]
-name_en = "Ruby on Rails Path Traversal"
-name_zh = "Ruby on Rails 路径穿越漏洞"
+  [[container.name]]
+  en = "Ruby on Rails Path Traversal"
+  zh = "Ruby on Rails 路径穿越漏洞"
 app = "Ruby on Rails"
   [[container.cve]]
   name = "CVE-2018-3760"
@@ -1403,8 +1559,9 @@ app = "Ruby on Rails"
 path = "rails/CVE-2018-3760"
 
 [[container]]
-name_en = "Ruby on Rails Path Traversal and Arbitrary File Read"
-name_zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
+  [[container.name]]
+  en = "Ruby on Rails Path Traversal and Arbitrary File Read"
+  zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
 app = "Ruby on Rails"
   [[container.cve]]
   name = "CVE-2019-5418"
@@ -1412,8 +1569,9 @@ app = "Ruby on Rails"
 path = "rails/CVE-2019-5418"
 
 [[container]]
-name_en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
-name_zh = "Redis 4.x/5.x 主从复制导致的命令执行"
+  [[container.name]]
+  en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
+  zh = "Redis 4.x/5.x 主从复制导致的命令执行"
 app = "redis"
   [[container.cve]]
   name = ""
@@ -1421,8 +1579,9 @@ app = "redis"
 path = "redis/4-unacc"
 
 [[container]]
-name_en = "Redis Lua Sandbox Bypass Command Execution"
-name_zh = "Redis Lua沙盒绕过命令执行"
+  [[container.name]]
+  en = "Redis Lua Sandbox Bypass Command Execution"
+  zh = "Redis Lua沙盒绕过命令执行"
 app = "redis"
   [[container.cve]]
   name = "CVE-2022-0543"
@@ -1430,8 +1589,9 @@ app = "redis"
 path = "redis/CVE-2022-0543"
 
 [[container]]
-name_en = "Rocket Chat MongoDB Injection"
-name_zh = "Rocket Chat MongoDB 注入漏洞"
+  [[container.name]]
+  en = "Rocket Chat MongoDB Injection"
+  zh = "Rocket Chat MongoDB 注入漏洞"
 app = "rocket chat"
   [[container.cve]]
   name = "CVE-2021-22911"
@@ -1439,8 +1599,9 @@ app = "rocket chat"
 path = "rocketchat/CVE-2021-22911"
 
 [[container]]
-name_en = "Apache RocketMQ Remote Command Execution"
-name_zh = "Apache RocketMQ 远程命令执行漏洞"
+  [[container.name]]
+  en = "Apache RocketMQ Remote Command Execution"
+  zh = "Apache RocketMQ 远程命令执行漏洞"
 app = "Apache RocketMQ"
   [[container.cve]]
   name = "CVE-2023-33246"
@@ -1448,8 +1609,9 @@ app = "Apache RocketMQ"
 path = "rocketmq/CVE-2023-33246"
 
 [[container]]
-name_en = "rsync Unauthorized Access"
-name_zh = "rsync 未授权访问漏洞"
+  [[container.name]]
+  en = "rsync Unauthorized Access"
+  zh = "rsync 未授权访问漏洞"
 app = "rsync"
   [[container.cve]]
   name = ""
@@ -1457,8 +1619,9 @@ app = "rsync"
 path = "rsync/common"
 
 [[container]]
-name_en = "Ruby Net::FTP Module Command Injection"
-name_zh = "Ruby Net::FTP 模块命令注入漏洞"
+  [[container.name]]
+  en = "Ruby Net::FTP Module Command Injection"
+  zh = "Ruby Net::FTP 模块命令注入漏洞"
 app = "ruby"
   [[container.cve]]
   name = "CVE-2017-17405"
@@ -1466,8 +1629,9 @@ app = "ruby"
 path = "ruby/CVE-2017-17405"
 
 [[container]]
-name_en = "SaltStack Horizontal Privilege Bypass"
-name_zh = "SaltStack 水平权限绕过漏洞"
+  [[container.name]]
+  en = "SaltStack Horizontal Privilege Bypass"
+  zh = "SaltStack 水平权限绕过漏洞"
 app = "SaltStack"
   [[container.cve]]
   name = "CVE-2020-11651"
@@ -1475,8 +1639,9 @@ app = "SaltStack"
 path = "saltstack/CVE-2020-11651"
 
 [[container]]
-name_en = "SaltStack Arbitrary File Read and Write"
-name_zh = "SaltStack 任意文件读写漏洞"
+  [[container.name]]
+  en = "SaltStack Arbitrary File Read and Write"
+  zh = "SaltStack 任意文件读写漏洞"
 app = "SaltStack"
   [[container.cve]]
   name = "CVE-2020-11652"
@@ -1484,8 +1649,9 @@ app = "SaltStack"
 path = "saltstack/CVE-2020-11652"
 
 [[container]]
-name_en = "SaltStack Command Injection"
-name_zh = "SaltStack 命令注入漏洞"
+  [[container.name]]
+  en = "SaltStack Command Injection"
+  zh = "SaltStack 命令注入漏洞"
 app = "SaltStack"
   [[container.cve]]
   name = "CVE-2020-16846"
@@ -1493,8 +1659,9 @@ app = "SaltStack"
 path = "saltstack/CVE-2020-16846"
 
 [[container]]
-name_en = "Samba Remote Command Execution"
-name_zh = "Samba 远程命令执行漏洞"
+  [[container.name]]
+  en = "Samba Remote Command Execution"
+  zh = "Samba 远程命令执行漏洞"
 app = "Samba"
   [[container.cve]]
   name = "CVE-2017-7494"
@@ -1502,8 +1669,9 @@ app = "Samba"
 path = "samba/CVE-2017-7494"
 
 [[container]]
-name_en = "Scrapyd Unauthorized Access"
-name_zh = "Scrapyd 未授权访问漏洞"
+  [[container.name]]
+  en = "Scrapyd Unauthorized Access"
+  zh = "Scrapyd 未授权访问漏洞"
 app = "Scrapyd"
   [[container.cve]]
   name = ""
@@ -1511,8 +1679,9 @@ app = "Scrapyd"
 path = "scrapy/scrapyd-unacc"
 
 [[container]]
-name_en = "Apache Shiro Authentication Bypass"
-name_zh = "Apache Shiro 认证绕过漏洞"
+  [[container.name]]
+  en = "Apache Shiro Authentication Bypass"
+  zh = "Apache Shiro 认证绕过漏洞"
 app = "shiro"
   [[container.cve]]
   name = "CVE-2010-3863"
@@ -1520,8 +1689,9 @@ app = "shiro"
 path = "shiro/CVE-2010-3863"
 
 [[container]]
-name_en = "Apache Shiro 1.2.4 Deserialization"
-name_zh = "Apache Shiro 1.2.4反序列化漏洞"
+  [[container.name]]
+  en = "Apache Shiro 1.2.4 Deserialization"
+  zh = "Apache Shiro 1.2.4反序列化漏洞"
 app = "shiro"
   [[container.cve]]
   name = "CVE-2016-4437"
@@ -1529,8 +1699,9 @@ app = "shiro"
 path = "shiro/CVE-2016-4437"
 
 [[container]]
-name_en = "Apache Shiro Authentication Bypass"
-name_zh = "Apache Shiro 认证绕过漏洞"
+  [[container.name]]
+  en = "Apache Shiro Authentication Bypass"
+  zh = "Apache Shiro 认证绕过漏洞"
 app = "shiro"
   [[container.cve]]
   name = "CVE-2020-1957"
@@ -1538,8 +1709,9 @@ app = "shiro"
 path = "shiro/CVE-2020-1957"
 
 [[container]]
-name_en = "Apache Skywalking 8.3.0 SQL Injection"
-name_zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
+  [[container.name]]
+  en = "Apache Skywalking 8.3.0 SQL Injection"
+  zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
 app = "skywalking"
   [[container.cve]]
   name = ""
@@ -1547,8 +1719,9 @@ app = "skywalking"
 path = "skywalking/8.3.0-sqli"
 
 [[container]]
-name_en = "Apache Solr Remote Command Execution"
-name_zh = "Apache Solr 远程命令执行漏洞"
+  [[container.name]]
+  en = "Apache Solr Remote Command Execution"
+  zh = "Apache Solr 远程命令执行漏洞"
 app = "solr"
   [[container.cve]]
   name = "CVE-2017-12629"
@@ -1556,8 +1729,9 @@ app = "solr"
 path = "solr/CVE-2017-12629-RCE"
 
 [[container]]
-name_en = "Apache Solr XML Entity Injection"
-name_zh = "Apache Solr XML 实体注入漏洞"
+  [[container.name]]
+  en = "Apache Solr XML Entity Injection"
+  zh = "Apache Solr XML 实体注入漏洞"
 app = "solr"
   [[container.cve]]
   name = "CVE-2017-12629"
@@ -1565,8 +1739,9 @@ app = "solr"
 path = "solr/CVE-2017-12629-XXE"
 
 [[container]]
-name_en = "Apache Solr Remote Command Execution"
-name_zh = "Apache Solr 远程命令执行漏洞"
+  [[container.name]]
+  en = "Apache Solr Remote Command Execution"
+  zh = "Apache Solr 远程命令执行漏洞"
 app = "solr"
   [[container.cve]]
   name = "CVE-2019-0193"
@@ -1574,8 +1749,9 @@ app = "solr"
 path = "solr/CVE-2019-0193"
 
 [[container]]
-name_en = "Apache Solr Velocity Inject Remote Command Execution"
-name_zh = "Apache Solr Velocity 注入远程命令执行漏洞"
+  [[container.name]]
+  en = "Apache Solr Velocity Inject Remote Command Execution"
+  zh = "Apache Solr Velocity 注入远程命令执行漏洞"
 app = "solr"
   [[container.cve]]
   name = "CVE-2019-17558"
@@ -1583,8 +1759,9 @@ app = "solr"
 path = "solr/CVE-2019-17558"
 
 [[container]]
-name_en = "Apache Solr RemoteStreaming File Reading and SSRF"
-name_zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
+  [[container.name]]
+  en = "Apache Solr RemoteStreaming File Reading and SSRF"
+  zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
 app = "solr"
   [[container.cve]]
   name = ""
@@ -1592,8 +1769,9 @@ app = "solr"
 path = "solr/Remote-Streaming-Fileread"
 
 [[container]]
-name_en = "Apache Spark Unauthorized Access Leak"
-name_zh = "Apache Spark 未授权访问漏"
+  [[container.name]]
+  en = "Apache Spark Unauthorized Access Leak"
+  zh = "Apache Spark 未授权访问漏"
 app = "spark"
   [[container.cve]]
   name = ""
@@ -1601,8 +1779,9 @@ app = "spark"
 path = "spark/unacc"
 
 [[container]]
-name_en = "Spring Security Oauth2 Remote Command Execution"
-name_zh = "Spring Security Oauth2 远程命令执行漏洞"
+  [[container.name]]
+  en = "Spring Security Oauth2 Remote Command Execution"
+  zh = "Spring Security Oauth2 远程命令执行漏洞"
 app = "spring security oauth2"
   [[container.cve]]
   name = "CVE-2016-4977"
@@ -1610,8 +1789,9 @@ app = "spring security oauth2"
 path = "spring/CVE-2016-4977"
 
 [[container]]
-name_en = "Spring WebFlow Remote Code Execution"
-name_zh = "Spring WebFlow 远程代码执行漏洞"
+  [[container.name]]
+  en = "Spring WebFlow Remote Code Execution"
+  zh = "Spring WebFlow 远程代码执行漏洞"
 app = "spring webflow"
   [[container.cve]]
   name = "CVE-2017-4971"
@@ -1619,8 +1799,9 @@ app = "spring webflow"
 path = "spring/CVE-2017-4971"
 
 [[container]]
-name_en = "Spring Data Rest Remote Command Execution"
-name_zh = "Spring Data Rest 远程命令执行漏洞"
+  [[container.name]]
+  en = "Spring Data Rest Remote Command Execution"
+  zh = "Spring Data Rest 远程命令执行漏洞"
 app = "spring data rest"
   [[container.cve]]
   name = "CVE-2017-8046"
@@ -1628,8 +1809,9 @@ app = "spring data rest"
 path = "spring/CVE-2017-8046"
 
 [[container]]
-name_en = "Spring Messaging Remote Command Execution"
-name_zh = "Spring Messaging 远程命令执行漏洞"
+  [[container.name]]
+  en = "Spring Messaging Remote Command Execution"
+  zh = "Spring Messaging 远程命令执行漏洞"
 app = "spring messaging"
   [[container.cve]]
   name = "CVE-2018-1270"
@@ -1637,8 +1819,9 @@ app = "spring messaging"
 path = "spring/CVE-2018-1270"
 
 [[container]]
-name_en = "Spring Data Commons Remote Command Execution"
-name_zh = "Spring Data Commons 远程命令执行漏洞"
+  [[container.name]]
+  en = "Spring Data Commons Remote Command Execution"
+  zh = "Spring Data Commons 远程命令执行漏洞"
 app = "spring data commons"
   [[container.cve]]
   name = "CVE-2018-1273"
@@ -1646,8 +1829,9 @@ app = "spring data commons"
 path = "spring/CVE-2018-1273"
 
 [[container]]
-name_en = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
-name_zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
+  [[container.name]]
+  en = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
+  zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
 app = "spring cloud gateway"
   [[container.cve]]
   name = "CVE-2022-22947"
@@ -1655,8 +1839,9 @@ app = "spring cloud gateway"
 path = "spring/CVE-2022-22947"
 
 [[container]]
-name_en = "Spring Cloud Function SpEL Expression Command Injection"
-name_zh = "Spring Cloud Function SpEL表达式命令注入"
+  [[container.name]]
+  en = "Spring Cloud Function SpEL Expression Command Injection"
+  zh = "Spring Cloud Function SpEL表达式命令注入"
 app = "spring cloud function"
   [[container.cve]]
   name = "CVE-2022-22963"
@@ -1664,8 +1849,9 @@ app = "spring cloud function"
 path = "spring/CVE-2022-22963"
 
 [[container]]
-name_en = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
-name_zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
+  [[container.name]]
+  en = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
+  zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
 app = "Spring"
   [[container.cve]]
   name = "CVE-2022-22965"
@@ -1673,8 +1859,9 @@ app = "Spring"
 path = "spring/CVE-2022-22965"
 
 [[container]]
-name_en = "Spring Security Authorization Bypass in RegexRequestMatcher"
-name_zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
+  [[container.name]]
+  en = "Spring Security Authorization Bypass in RegexRequestMatcher"
+  zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
 app = "Spring"
   [[container.cve]]
   name = "CVE-2022-22978"
@@ -1682,8 +1869,9 @@ app = "Spring"
 path = "spring/CVE-2022-22978"
 
 [[container]]
-name_en = "S2-001 Remote Code Execution"
-name_zh = "S2-001 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-001 Remote Code Execution"
+  zh = "S2-001 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = ""
@@ -1691,8 +1879,9 @@ app = "Struts2"
 path = "struts2/s2-001"
 
 [[container]]
-name_en = "S2-005 Remote Code Execution"
-name_zh = "S2-005 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-005 Remote Code Execution"
+  zh = "S2-005 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2010-1870"
@@ -1700,8 +1889,9 @@ app = "Struts2"
 path = "struts2/s2-005"
 
 [[container]]
-name_en = "S2-007 Remote Code Execution"
-name_zh = "S2-007 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-007 Remote Code Execution"
+  zh = "S2-007 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = ""
@@ -1709,8 +1899,9 @@ app = "Struts2"
 path = "struts2/s2-007"
 
 [[container]]
-name_en = "S2-008 Remote Code Execution"
-name_zh = "S2-008 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-008 Remote Code Execution"
+  zh = "S2-008 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2012-0391"
@@ -1718,8 +1909,9 @@ app = "Struts2"
 path = "struts2/s2-008"
 
 [[container]]
-name_en = "S2-009 Remote Code Execution"
-name_zh = "S2-009 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-009 Remote Code Execution"
+  zh = "S2-009 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2011-3923"
@@ -1727,8 +1919,9 @@ app = "Struts2"
 path = "struts2/s2-009"
 
 [[container]]
-name_en = "S2-012 Remote Code Execution"
-name_zh = "S2-012 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-012 Remote Code Execution"
+  zh = "S2-012 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2013-1965"
@@ -1736,8 +1929,9 @@ app = "Struts2"
 path = "struts2/s2-012"
 
 [[container]]
-name_en = "S2-013 Remote Code Execution"
-name_zh = "S2-013 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-013 Remote Code Execution"
+  zh = "S2-013 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2013-1966"
@@ -1745,8 +1939,9 @@ app = "Struts2"
 path = "struts2/s2-013"
 
 [[container]]
-name_en = "S2-015 Remote Code Execution"
-name_zh = "S2-015 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-015 Remote Code Execution"
+  zh = "S2-015 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2013-2134"
@@ -1758,8 +1953,9 @@ app = "Struts2"
 path = "struts2/s2-015"
 
 [[container]]
-name_en = "S2-016 Remote Code Execution"
-name_zh = "S2-016 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-016 Remote Code Execution"
+  zh = "S2-016 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2013-2251"
@@ -1767,8 +1963,9 @@ app = "Struts2"
 path = "struts2/s2-016"
 
 [[container]]
-name_en = "S2-032 Remote Code Execution"
-name_zh = "S2-032 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-032 Remote Code Execution"
+  zh = "S2-032 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2016-3081"
@@ -1776,8 +1973,9 @@ app = "Struts2"
 path = "struts2/s2-032"
 
 [[container]]
-name_en = "S2-045 Remote Code Execution"
-name_zh = "S2-045 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-045 Remote Code Execution"
+  zh = "S2-045 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2017-5638"
@@ -1785,8 +1983,9 @@ app = "Struts2"
 path = "struts2/s2-045"
 
 [[container]]
-name_en = "S2-046 Remote Code Execution"
-name_zh = "S2-046 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-046 Remote Code Execution"
+  zh = "S2-046 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2017-5638"
@@ -1794,8 +1993,9 @@ app = "Struts2"
 path = "struts2/s2-046"
 
 [[container]]
-name_en = "S2-048 Remote Code Execution"
-name_zh = "S2-048 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-048 Remote Code Execution"
+  zh = "S2-048 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2017-9791"
@@ -1803,8 +2003,9 @@ app = "Struts2"
 path = "struts2/s2-048"
 
 [[container]]
-name_en = "S2-052 Remote Code Execution"
-name_zh = "S2-052 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-052 Remote Code Execution"
+  zh = "S2-052 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2017-9805"
@@ -1812,8 +2013,9 @@ app = "Struts2"
 path = "struts2/s2-052"
 
 [[container]]
-name_en = "S2-053 Remote Code Execution"
-name_zh = "S2-053 远程代码执行漏洞"
+  [[container.name]]
+  en = "S2-053 Remote Code Execution"
+  zh = "S2-053 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2017-12611"
@@ -1821,8 +2023,9 @@ app = "Struts2"
 path = "struts2/s2-053"
 
 [[container]]
-name_en = "Struts2 S2-057 Remote Command Execution"
-name_zh = "Struts2 S2-057 远程命令执行漏洞"
+  [[container.name]]
+  en = "Struts2 S2-057 Remote Command Execution"
+  zh = "Struts2 S2-057 远程命令执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2018-11776"
@@ -1830,8 +2033,9 @@ app = "Struts2"
 path = "struts2/s2-057"
 
 [[container]]
-name_en = "Struts2 S2-059 Remote Command Execution"
-name_zh = "Struts2 S2-059 远程命令执行漏洞"
+  [[container.name]]
+  en = "Struts2 S2-059 Remote Command Execution"
+  zh = "Struts2 S2-059 远程命令执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2019-0230"
@@ -1839,8 +2043,9 @@ app = "Struts2"
 path = "struts2/s2-059"
 
 [[container]]
-name_en = "Struts2 S2-061 Remote Command Execution"
-name_zh = "Struts2 S2-061 远程命令执行漏洞"
+  [[container.name]]
+  en = "Struts2 S2-061 Remote Command Execution"
+  zh = "Struts2 S2-061 远程命令执行漏洞"
 app = "Struts2"
   [[container.cve]]
   name = "CVE-2020-17530"
@@ -1848,8 +2053,9 @@ app = "Struts2"
 path = "struts2/s2-061"
 
 [[container]]
-name_en = "Supervisord Remote Command Execution"
-name_zh = "Supervisord 远程命令执行漏洞"
+  [[container.name]]
+  en = "Supervisord Remote Command Execution"
+  zh = "Supervisord 远程命令执行漏洞"
 app = "Supervisor"
   [[container.cve]]
   name = "CVE-2017-11610"
@@ -1857,8 +2063,9 @@ app = "Supervisor"
 path = "supervisor/CVE-2017-11610"
 
 [[container]]
-name_en = "ThinkPHP 2.x Arbitrary Code Execution"
-name_zh = "ThinkPHP 2.x 任意代码执行漏洞"
+  [[container.name]]
+  en = "ThinkPHP 2.x Arbitrary Code Execution"
+  zh = "ThinkPHP 2.x 任意代码执行漏洞"
 app = "ThinkPHP"
   [[container.cve]]
   name = ""
@@ -1866,8 +2073,9 @@ app = "ThinkPHP"
 path = "thinkphp/2-rce"
 
 [[container]]
-name_en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
-name_zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
+  [[container.name]]
+  en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
+  zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
 app = "ThinkPHP"
   [[container.cve]]
   name = ""
@@ -1875,8 +2083,9 @@ app = "ThinkPHP"
 path = "thinkphp/5-rce"
 
 [[container]]
-name_en = "ThinkPHP5 5.0.23 Remote Code Execution"
-name_zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
+  [[container.name]]
+  en = "ThinkPHP5 5.0.23 Remote Code Execution"
+  zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
 app = "ThinkPHP"
   [[container.cve]]
   name = ""
@@ -1884,8 +2093,9 @@ app = "ThinkPHP"
 path = "thinkphp/5.0.23-rce"
 
 [[container]]
-name_en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
-name_zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
+  [[container.name]]
+  en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
+  zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
 app = "ThinkPHP"
   [[container.cve]]
   name = ""
@@ -1893,8 +2103,9 @@ app = "ThinkPHP"
 path = "thinkphp/in-sqlinjection"
 
 [[container]]
-name_en = "ThinkPHP Multilingual Local File Inclusion"
-name_zh = "ThinkPHP 多语言本地文件包含漏洞"
+  [[container.name]]
+  en = "ThinkPHP Multilingual Local File Inclusion"
+  zh = "ThinkPHP 多语言本地文件包含漏洞"
 app = "ThinkPHP"
   [[container.cve]]
   name = ""
@@ -1902,8 +2113,9 @@ app = "ThinkPHP"
 path = "thinkphp/lang-rce"
 
 [[container]]
-name_en = "Tiki Wiki CMS Groupware Authentication Bypass"
-name_zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
+  [[container.name]]
+  en = "Tiki Wiki CMS Groupware Authentication Bypass"
+  zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
 app = "Tiki Wiki"
   [[container.cve]]
   name = "CVE-2020-15906"
@@ -1911,8 +2123,9 @@ app = "Tiki Wiki"
 path = "tikiwiki/CVE-2020-15906"
 
 [[container]]
-name_en = "Tomcat Arbitrary Writing of Files in the PUT Method"
-name_zh = "Tomcat PUT方法任意写文件漏洞"
+  [[container.name]]
+  en = "Tomcat Arbitrary Writing of Files in the PUT Method"
+  zh = "Tomcat PUT方法任意写文件漏洞"
 app = "Tomcat"
   [[container.cve]]
   name = "CVE-2017-12615"
@@ -1920,8 +2133,9 @@ app = "Tomcat"
 path = "tomcat/CVE-2017-12615"
 
 [[container]]
-name_en = "Apache Tomcat AJP Bug"
-name_zh = "Apache Tomcat AJP 文件包含漏洞"
+  [[container.name]]
+  en = "Apache Tomcat AJP Bug"
+  zh = "Apache Tomcat AJP 文件包含漏洞"
 app = "Tomcat"
   [[container.cve]]
   name = "CVE-2020-1938"
@@ -1929,8 +2143,9 @@ app = "Tomcat"
 path = "tomcat/CVE-2020-1938"
 
 [[container]]
-name_en = "Tomcat Weak Password"
-name_zh = "Tomcat弱口令"
+  [[container.name]]
+  en = "Tomcat Weak Password"
+  zh = "Tomcat弱口令"
 app = "Tomcat"
   [[container.cve]]
   name = ""
@@ -1938,8 +2153,9 @@ app = "Tomcat"
 path = "tomcat/tomcat8"
 
 [[container]]
-name_en = "Apache Unomi Remote Expression Code Execution"
-name_zh = "Apache Unomi 远程表达式代码执行漏洞"
+  [[container.name]]
+  en = "Apache Unomi Remote Expression Code Execution"
+  zh = "Apache Unomi 远程表达式代码执行漏洞"
 app = "unomi"
   [[container.cve]]
   name = "CVE-2020-13942"
@@ -1947,8 +2163,9 @@ app = "unomi"
 path = "unomi/CVE-2020-13942"
 
 [[container]]
-name_en = "uWSGI PHP Directory Traversal"
-name_zh = "uWSGI PHP目录穿越漏洞"
+  [[container.name]]
+  en = "uWSGI PHP Directory Traversal"
+  zh = "uWSGI PHP目录穿越漏洞"
 app = "uWSGI"
   [[container.cve]]
   name = "CVE-2018-7490"
@@ -1956,8 +2173,9 @@ app = "uWSGI"
 path = "uwsgi/CVE-2018-7490"
 
 [[container]]
-name_en = "uWSGI Unauthorized Access"
-name_zh = "uWSGI 未授权访问漏洞"
+  [[container.name]]
+  en = "uWSGI Unauthorized Access"
+  zh = "uWSGI 未授权访问漏洞"
 app = "uWSGI"
   [[container.cve]]
   name = ""
@@ -1965,8 +2183,9 @@ app = "uWSGI"
 path = "uwsgi/unacc"
 
 [[container]]
-name_en = "V2board 1.6.1 Privilege Escalation"
-name_zh = "V2board 1.6.1 提权漏洞"
+  [[container.name]]
+  en = "V2board 1.6.1 Privilege Escalation"
+  zh = "V2board 1.6.1 提权漏洞"
 app = "V2board"
   [[container.cve]]
   name = ""
@@ -1974,8 +2193,9 @@ app = "V2board"
 path = "v2board/1.6-privilege-escalation"
 
 [[container]]
-name_en = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
-name_zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
+  [[container.name]]
+  en = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
+  zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = "CVE-2017-10271"
@@ -1983,8 +2203,9 @@ app = "WebLogic"
 path = "weblogic/CVE-2017-10271"
 
 [[container]]
-name_en = "WebLogic WLS Core Components Deserialization Command Execution"
-name_zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "WebLogic WLS Core Components Deserialization Command Execution"
+  zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = "CVE-2018-2628"
@@ -1992,8 +2213,9 @@ app = "WebLogic"
 path = "weblogic/CVE-2018-2628"
 
 [[container]]
-name_en = "WebLogic Arbitrary File Upload"
-name_zh = "WebLogic 任意文件上传漏洞"
+  [[container.name]]
+  en = "WebLogic Arbitrary File Upload"
+  zh = "WebLogic 任意文件上传漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = "CVE-2018-2894"
@@ -2001,8 +2223,9 @@ app = "WebLogic"
 path = "weblogic/CVE-2018-2894"
 
 [[container]]
-name_en = "WebLogic Management Console Unauthorized Remote Command Execution"
-name_zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
+  [[container.name]]
+  en = "WebLogic Management Console Unauthorized Remote Command Execution"
+  zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = "CVE-2020-14882"
@@ -2010,8 +2233,9 @@ app = "WebLogic"
 path = "weblogic/CVE-2020-14882"
 
 [[container]]
-name_en = "WebLogic Unauthorized Remote Code Execution"
-name_zh = "WebLogic未授权远程代码执行漏洞"
+  [[container.name]]
+  en = "WebLogic Unauthorized Remote Code Execution"
+  zh = "WebLogic未授权远程代码执行漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = "CVE-2023-21839"
@@ -2019,8 +2243,9 @@ app = "WebLogic"
 path = "weblogic/CVE-2023-21839"
 
 [[container]]
-name_en = "WebLogic SSRF"
-name_zh = "WebLogic SSRF漏洞"
+  [[container.name]]
+  en = "WebLogic SSRF"
+  zh = "WebLogic SSRF漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = ""
@@ -2028,8 +2253,9 @@ app = "WebLogic"
 path = "weblogic/ssrf"
 
 [[container]]
-name_en = "WebLogic File Read"
-name_zh = "WebLogic 文件读取漏洞"
+  [[container.name]]
+  en = "WebLogic File Read"
+  zh = "WebLogic 文件读取漏洞"
 app = "WebLogic"
   [[container.cve]]
   name = ""
@@ -2037,8 +2263,9 @@ app = "WebLogic"
 path = "weblogic/weak_password"
 
 [[container]]
-name_en = "Webmin Remote Command Execution"
-name_zh = "Webmin 远程命令执行漏洞"
+  [[container.name]]
+  en = "Webmin Remote Command Execution"
+  zh = "Webmin 远程命令执行漏洞"
 app = "Webmin"
   [[container.cve]]
   name = "CVE-2019-15107"
@@ -2046,8 +2273,9 @@ app = "Webmin"
 path = "webmin/CVE-2019-15107"
 
 [[container]]
-name_en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
-name_zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
+  [[container.name]]
+  en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
+  zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
 app = "Wordpress"
   [[container.cve]]
   name = ""
@@ -2055,8 +2283,9 @@ app = "Wordpress"
 path = "wordpress/pwnscriptum"
 
 [[container]]
-name_en = "XStream Deserialization Command Execution"
-name_zh = "XStream 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "XStream Deserialization Command Execution"
+  zh = "XStream 反序列化命令执行漏洞"
 app = "XStream"
   [[container.cve]]
   name = "CVE-2021-21351"
@@ -2064,8 +2293,9 @@ app = "XStream"
 path = "xstream/CVE-2021-21351"
 
 [[container]]
-name_en = "XStream Deserialization Command Execution"
-name_zh = "XStream 反序列化命令执行漏洞"
+  [[container.name]]
+  en = "XStream Deserialization Command Execution"
+  zh = "XStream 反序列化命令执行漏洞"
 app = "XStream"
   [[container.cve]]
   name = "CVE-2021-29505"
@@ -2073,8 +2303,9 @@ app = "XStream"
 path = "xstream/CVE-2021-29505"
 
 [[container]]
-name_en = "XXL-JOB Executor Unauthorized Access"
-name_zh = "XXL-JOB Executor 未授权访问漏洞"
+  [[container.name]]
+  en = "XXL-JOB Executor Unauthorized Access"
+  zh = "XXL-JOB Executor 未授权访问漏洞"
 app = "xxl-job"
   [[container.cve]]
   name = ""
@@ -2082,8 +2313,9 @@ app = "xxl-job"
 path = "xxl-job/unacc"
 
 [[container]]
-name_en = "YApi NoSQL Injection to Remote Command Execution"
-name_zh = "YApi NoSQL注入导致远程命令执行漏洞"
+  [[container.name]]
+  en = "YApi NoSQL Injection to Remote Command Execution"
+  zh = "YApi NoSQL注入导致远程命令执行漏洞"
 app = "YApi"
   [[container.cve]]
   name = ""
@@ -2091,8 +2323,9 @@ app = "YApi"
 path = "yapi/mongodb-inj"
 
 [[container]]
-name_en = "YApi Open Registration due to RCE"
-name_zh = "YApi开放注册导致RCE"
+  [[container.name]]
+  en = "YApi Open Registration due to RCE"
+  zh = "YApi开放注册导致RCE"
 app = "YApi"
   [[container.cve]]
   name = ""
@@ -2100,8 +2333,9 @@ app = "YApi"
 path = "yapi/unacc"
 
 [[container]]
-name_en = "Zabbix latest.php SQL Injection"
-name_zh = "Zabbix latest.php SQL注入漏洞"
+  [[container.name]]
+  en = "Zabbix latest.php SQL Injection"
+  zh = "Zabbix latest.php SQL注入漏洞"
 app = "Zabbix"
   [[container.cve]]
   name = "CVE-2016-10134"
@@ -2109,8 +2343,9 @@ app = "Zabbix"
 path = "zabbix/CVE-2016-10134"
 
 [[container]]
-name_en = "Zabbix Server Trapper Command Injection"
-name_zh = "Zabbix Server Trapper命令注入漏洞"
+  [[container.name]]
+  en = "Zabbix Server Trapper Command Injection"
+  zh = "Zabbix Server Trapper命令注入漏洞"
 app = "Zabbix"
   [[container.cve]]
   name = "CVE-2020-11800"

--- a/environments.toml
+++ b/environments.toml
@@ -1,1644 +1,2118 @@
-[[containers]]
+[[container]]
 name_en = "Apache ActiveMQ Deserialization"
 name_zh = "Apache ActiveMQ 反序列化漏洞"
 app = "ActiveMQ"
-cve = "CVE-2015-5254"
+  [[container.cve]]
+  name = "CVE-2015-5254"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5254"
 path = "activemq/CVE-2015-5254"
 
-[[containers]]
+[[container]]
 name_en = "Apache ActiveMQ Arbitrary File Write"
 name_zh = "Apache ActiveMQ 任意文件写入漏洞"
 app = "ActiveMQ"
-cve = "CVE-2016-3088"
+  [[container.cve]]
+  name = "CVE-2016-3088"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3088"
 path = "activemq/CVE-2016-3088"
 
-[[containers]]
+[[container]]
 name_en = "Apache Airflow Command Injection"
 name_zh = "Apache Airflow 示例dag中的命令注入"
 app = "Airflow"
-cve = "CVE-2020-11978"
+  [[container.cve]]
+  name = "CVE-2020-11978"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11978"
 path = "airflow/CVE-2020-11978"
 
-[[containers]]
+[[container]]
 name_en = "Apache Airflow Celery Message Middleware Command Execution"
 name_zh = "Apache Airflow Celery 消息中间件命令执行"
 app = "Airflow"
-cve = "CVE-2020-11981"
+  [[container.cve]]
+  name = "CVE-2020-11981"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11981"
 path = "airflow/CVE-2020-11981"
 
-[[containers]]
+[[container]]
 name_en = "Apache Airflow Permission Bypass"
 name_zh = "Apache Airflow 默认密钥导致的权限绕过"
 app = "Airflow"
-cve = "CVE-2020-17526"
+  [[container.cve]]
+  name = "CVE-2020-17526"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17526"
 path = "airflow/CVE-2020-17526"
 
-[[containers]]
+[[container]]
 name_en = "Apache Druid Code Execution"
 name_zh = "Apache Druid 代码执行漏洞"
 app = "Apache Druid"
-cve = "CVE-2021-25646"
+  [[container.cve]]
+  name = "CVE-2021-25646"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-25646"
 path = "apache-druid/CVE-2021-25646"
 
-[[containers]]
+[[container]]
 name_en = "Apereo CAS 4.1 Deserialization Command Execution"
 name_zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
 app = "Apereo CAS"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "apereo-cas/4.1-rce"
 
-[[containers]]
+[[container]]
 name_en = "Apache APISIX Default Key"
 name_zh = "Apache APISIX 默认密钥漏洞"
 app = "Apache APISIX"
-cve = "CVE-2020-13945"
+  [[container.cve]]
+  name = "CVE-2020-13945"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13945"
 path = "apisix/CVE-2020-13945"
 
-[[containers]]
+[[container]]
 name_en = "Apache APISIX Dashboard API Permission Bypass to RCE"
 name_zh = "Apache APISIX Dashboard API权限绕过导致RCE"
 app = "Apache APISIX"
-cve = "CVE-2021-45232"
+  [[container.cve]]
+  name = "CVE-2021-45232"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-45232"
 path = "apisix/CVE-2021-45232"
 
-[[containers]]
+[[container]]
 name_en = "AppWeb Authentication Bypass"
 name_zh = "AppWeb 认证绕过漏洞"
 app = "AppWeb"
-cve = "CVE-2018-8715"
+  [[container.cve]]
+  name = "CVE-2018-8715"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-8715"
 path = "appweb/CVE-2018-8715"
 
-[[containers]]
+[[container]]
 name_en = "Aria2 Arbitrary File Write"
 name_zh = "Aria2 任意文件写入漏洞"
 app = "Aria2"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "aria2/rce"
 
-[[containers]]
+[[container]]
 name_en = "Bash Shellshock Shell Exploit"
 name_zh = "Bash Shellshock 破壳漏洞"
 app = "bash"
-cve = "CVE-2014-6271"
+  [[container.cve]]
+  name = "CVE-2014-6271"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-6271"
 path = "bash/CVE-2014-6271"
 
-[[containers]]
+[[container]]
 name_en = "Cacti Foreground Command Injection"
 name_zh = "Cacti 前台命令注入漏洞"
 app = "cacti"
-cve = "CVE-2022-46169"
+  [[container.cve]]
+  name = "CVE-2022-46169"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-46169"
 path = "cacti/CVE-2022-46169"
 
-[[containers]]
+[[container]]
 name_en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
 name_zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
 app = "celery"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "celery/celery3_redis_unauth"
 
-[[containers]]
+[[container]]
 name_en = "CGI HTTPoxy Flaw"
 name_zh = "CGI HTTPoxy 漏洞"
 app = "cgi"
-cve = "CVE-2016-5385"
+  [[container.cve]]
+  name = "CVE-2016-5385"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5385"
 path = "cgi/CVE-2016-5385"
 
-[[containers]]
+[[container]]
 name_en = "Adobe ColdFusion File Read"
 name_zh = "Adobe ColdFusion 文件读取漏洞"
 app = "Adobe ColdFusion"
-cve = "CVE-2010-2861"
+  [[container.cve]]
+  name = "CVE-2010-2861"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-2861"
 path = "coldfusion/CVE-2010-2861"
 
-[[containers]]
+[[container]]
 name_en = "Adobe ColdFusion Deserialization"
 name_zh = "Adobe ColdFusion 反序列化漏洞"
 app = "Adobe ColdFusion"
-cve = "CVE-2017-3066"
+  [[container.cve]]
+  name = "CVE-2017-3066"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-3066"
 path = "coldfusion/CVE-2017-3066"
 
-[[containers]]
+[[container]]
 name_en = "Atlassian Confluence Path Traversal and Command Execution"
 name_zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
 app = "Atlassian Confluence"
-cve = "CVE-2019-3396"
+  [[container.cve]]
+  name = "CVE-2019-3396"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-3396"
 path = "confluence/CVE-2019-3396"
 
-[[containers]]
+[[container]]
 name_en = "Atlassian Confluence OGNL Expression Injection Code Execution"
 name_zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
 app = "Atlassian Confluence"
-cve = "CVE-2021-26084"
+  [[container.cve]]
+  name = "CVE-2021-26084"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-26084"
 path = "confluence/CVE-2021-26084"
 
-[[containers]]
+[[container]]
 name_en = "Atlassian Confluence OGNL Expression Injection Command Execution"
 name_zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
 app = "Atlassian Confluence"
-cve = "CVE-2022-26134"
+  [[container.cve]]
+  name = "CVE-2022-26134"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-26134"
 path = "confluence/CVE-2022-26134"
 
-[[containers]]
+[[container]]
 name_en = "CouchDB Vertical Permission Bypass"
 name_zh = "CouchDB 垂直权限绕过漏洞"
 app = "CouchDB"
-cve = "CVE-2017-12635"
+  [[container.cve]]
+  name = "CVE-2017-12635"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12635"
 path = "couchdb/CVE-2017-12635"
 
-[[containers]]
+[[container]]
 name_en = "CouchDB Arbitrary Command Execution"
 name_zh = "CouchDB 任意命令执行漏洞"
 app = "CouchDB"
-cve = "CVE-2017-12636"
+  [[container.cve]]
+  name = "CVE-2017-12636"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12636"
 path = "couchdb/CVE-2017-12636"
 
-[[containers]]
+[[container]]
 name_en = "CouchDB Erlang Distributed Protocol Code Execution"
 name_zh = "CouchDB Erlang 分布式协议代码执行"
 app = "CouchDB"
-cve = "CVE-2022-24706"
+  [[container.cve]]
+  name = "CVE-2022-24706"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-24706"
 path = "couchdb/CVE-2022-24706"
 
-[[containers]]
+[[container]]
 name_en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
 name_zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
 app = "Discuz"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "discuz/wooyun-2010-080723"
 
-[[containers]]
+[[container]]
 name_en = "Discuz!X ≤3.4 Arbitrary File Deletion"
 name_zh = "Discuz!X ≤3.4 任意文件删除漏洞"
 app = "Discuz"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "discuz/x3.4-arbitrary-file-deletion"
 
-[[containers]]
+[[container]]
 name_en = "Django debug page XSS Flaw"
 name_zh = "Django debug page XSS 漏洞"
 app = "Django"
-cve = "CVE-2017-12794"
+  [[container.cve]]
+  name = "CVE-2017-12794"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12794"
 path = "django/CVE-2017-12794"
 
-[[containers]]
+[[container]]
 name_en = "Django < 2.0.8 Arbitrary URL Redirection"
 name_zh = "Django < 2.0.8 任意URL跳转漏洞"
 app = "Django"
-cve = "CVE-2018-14574"
+  [[container.cve]]
+  name = "CVE-2018-14574"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-14574"
 path = "django/CVE-2018-14574"
 
-[[containers]]
+[[container]]
 name_en = "Django JSONField/HStoreField SQL Injection"
 name_zh = "Django JSONField/HStoreField SQL注入漏洞"
 app = "Django"
-cve = "CVE-2019-14234"
+  [[container.cve]]
+  name = "CVE-2019-14234"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-14234"
 path = "django/CVE-2019-14234"
 
-[[containers]]
+[[container]]
 name_en = "Django GIS SQL Injection"
 name_zh = "Django GIS SQL注入漏洞"
 app = "Django"
-cve = "CVE-2020-9402"
+  [[container.cve]]
+  name = "CVE-2020-9402"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9402"
 path = "django/CVE-2020-9402"
 
-[[containers]]
+[[container]]
 name_en = "Django QuerySet.order_by() SQL Injection"
 name_zh = "Django QuerySet.order_by() SQL注入漏洞"
 app = "Django"
-cve = "CVE-2021-35042"
+  [[container.cve]]
+  name = "CVE-2021-35042"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-35042"
 path = "django/CVE-2021-35042"
 
-[[containers]]
+[[container]]
 name_en = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
 name_zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
 app = "Django"
-cve = "CVE-2022-34265"
+  [[container.cve]]
+  name = "CVE-2022-34265"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-34265"
 path = "django/CVE-2022-34265"
 
-[[containers]]
+[[container]]
 name_en = "DNS Domain Transfer"
 name_zh = "DNS域传送漏洞"
 app = "dns"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "dns/dns-zone-transfer"
 
-[[containers]]
+[[container]]
 name_en = "Docker Daemon API Unauthorized Access"
 name_zh = "Docker Daemon API 未授权访问漏洞"
 app = "docker"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "docker/unauthorized-rce"
 
-[[containers]]
+[[container]]
 name_en = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
 name_zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
 app = "drupal"
-cve = "CVE-2014-3704"
+  [[container.cve]]
+  name = "CVE-2014-3704"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3704"
 path = "drupal/CVE-2014-3704"
 
-[[containers]]
+[[container]]
 name_en = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
 name_zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
 app = "drupal"
-cve = "CVE-2017-6920"
+  [[container.cve]]
+  name = "CVE-2017-6920"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-6920"
 path = "drupal/CVE-2017-6920"
 
-[[containers]]
+[[container]]
 name_en = "Drupal Drupalgeddon 2 Remote Code Execution"
 name_zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
 app = "drupal"
-cve = "CVE-2018-7600"
+  [[container.cve]]
+  name = "CVE-2018-7600"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7600"
 path = "drupal/CVE-2018-7600"
 
-[[containers]]
+[[container]]
 name_en = "Drupal Remote Code Execution"
 name_zh = "Drupal 远程代码执行漏洞"
 app = "drupal"
-cve = "CVE-2018-7602"
+  [[container.cve]]
+  name = "CVE-2018-7602"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7602"
 path = "drupal/CVE-2018-7602"
 
-[[containers]]
+[[container]]
 name_en = "Drupal Remote Code Execution"
 name_zh = "Drupal 远程代码执行漏洞"
 app = "drupal"
-cve = "CVE-2019-6339"
+  [[container.cve]]
+  name = "CVE-2019-6339"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6339"
 path = "drupal/CVE-2019-6339"
 
-[[containers]]
+[[container]]
 name_en = "Drupal XSS"
 name_zh = "Drupal XSS漏洞"
 app = "drupal"
-cve = "CVE-2019-6341"
+  [[container.cve]]
+  name = "CVE-2019-6341"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6341"
 path = "drupal/CVE-2019-6341"
 
-[[containers]]
+[[container]]
 name_en = "Apache Dubbo Java Deserialization"
 name_zh = "Apache Dubbo Java反序列化漏洞"
 app = "dubbo"
-cve = "CVE-2019-17564"
+  [[container.cve]]
+  name = "CVE-2019-17564"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17564"
 path = "dubbo/CVE-2019-17564"
 
-[[containers]]
+[[container]]
 name_en = "ECShop 4.x collection_list SQL Injection"
 name_zh = "ECShop 4.x collection_list SQL注入"
 app = "ecshop"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "ecshop/collection_list-sqli"
 
-[[containers]]
+[[container]]
 name_en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
 name_zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
 app = "ecshop"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "ecshop/xianzhi-2017-02-82239600"
 
-[[containers]]
+[[container]]
 name_en = "ElasticSearch Command Execution"
 name_zh = "ElasticSearch 命令执行漏洞"
 app = "ElasticSearch"
-cve = "CVE-2014-3120"
+  [[container.cve]]
+  name = "CVE-2014-3120"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3120"
 path = "elasticsearch/CVE-2014-3120"
 
-[[containers]]
+[[container]]
 name_en = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
 name_zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
 app = "ElasticSearch"
-cve = "CVE-2015-1427"
+  [[container.cve]]
+  name = "CVE-2015-1427"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-1427"
 path = "elasticsearch/CVE-2015-1427"
 
-[[containers]]
+[[container]]
 name_en = "ElasticSearch Plug-in Directory Traversal"
 name_zh = "ElasticSearch 插件目录穿越漏洞"
 app = "ElasticSearch"
-cve = "CVE-2015-3337"
+  [[container.cve]]
+  name = "CVE-2015-3337"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-3337"
 path = "elasticsearch/CVE-2015-3337"
 
-[[containers]]
+[[container]]
 name_en = "ElasticSearch Directory Traversal"
 name_zh = "ElasticSearch 目录穿越漏洞"
 app = "ElasticSearch"
-cve = "CVE-2015-5531"
+  [[container.cve]]
+  name = "CVE-2015-5531"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5531"
 path = "elasticsearch/CVE-2015-5531"
 
-[[containers]]
+[[container]]
 name_en = "Elasticsearch Webshell"
 name_zh = "Elasticsearch 写入webshell漏洞"
 app = "ElasticSearch"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "elasticsearch/WooYun-2015-110216"
 
-[[containers]]
+[[container]]
 name_en = "Electron Remote Command Execution"
 name_zh = "Electron 远程命令执行漏洞"
 app = "electron"
-cve = "CVE-2018-1000006"
+  [[container.cve]]
+  name = "CVE-2018-1000006"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000006"
 path = "electron/CVE-2018-1000006"
 
-[[containers]]
+[[container]]
 name_en = "Electron WebPreferences Remote Command Execution"
 name_zh = "Electron WebPreferences 远程命令执行漏洞"
 app = "electron"
-cve = "CVE-2018-15685"
+  [[container.cve]]
+  name = "CVE-2018-15685"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15685"
 path = "electron/CVE-2018-15685"
 
-[[containers]]
+[[container]]
 name_en = "elFinder ZIP Parameter and Arbitrary Command Injection"
 name_zh = "elFinder ZIP 参数与任意命令注入"
 app = "elFinder"
-cve = "CVE-2021-32682"
+  [[container.cve]]
+  name = "CVE-2021-32682"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-32682"
 path = "elfinder/CVE-2021-32682"
 
-[[containers]]
+[[container]]
 name_en = "Fastjson Deserialization to Arbitrary Command Execution"
 name_zh = "Fastjson 反序列化导致任意命令执行漏洞"
 app = "Fastjson"
-cve = "CVE-2017-18349"
+  [[container.cve]]
+  name = "CVE-2017-18349"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-18349"
 path = "fastjson/1.2.24-rce"
 
-[[containers]]
+[[container]]
 name_en = "Fastjson 1.2.47 Remote Command Execution"
 name_zh = "Fastjson 1.2.47 远程命令执行漏洞"
 app = "Fastjson"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "fastjson/1.2.47-rce"
 
-[[containers]]
+[[container]]
 name_en = "FFmpeg Arbitrary File Read/SSRF"
 name_zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
 app = "ffmpeg"
-cve = "CVE-2016-1897,CVE-2016-1898"
+  [[container.cve]]
+  name = "CVE-2016-1897,CVE-2016-1898"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-1897,CVE-2016-1898"
 path = "ffmpeg/CVE-2016-1897"
 
-[[containers]]
+[[container]]
 name_en = "FFmpeg Arbitrary File Read"
 name_zh = "FFmpeg 任意文件读取漏洞"
 app = "ffmpeg"
-cve = "CVE-2017-9993"
+  [[container.cve]]
+  name = "CVE-2017-9993"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9993"
 path = "ffmpeg/phdays"
 
-[[containers]]
+[[container]]
 name_en = "Jinja2 SSTI Template Injection"
 name_zh = "Jinja2 SSTI模板注入"
 app = "Jinja2"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "flask/ssti"
 
-[[containers]]
+[[container]]
 name_en = "Apache Flink File Upload"
 name_zh = "Apache Flink 文件上传漏洞"
 app = "flink"
-cve = "CVE-2020-17518"
+  [[container.cve]]
+  name = "CVE-2020-17518"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17518"
 path = "flink/CVE-2020-17518"
 
-[[containers]]
+[[container]]
 name_en = "Apache Flink Jobmanager/Logs Directory Traversal"
 name_zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
 app = "flink"
-cve = "CVE-2020-17519"
+  [[container.cve]]
+  name = "CVE-2020-17519"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17519"
 path = "flink/CVE-2020-17519"
 
-[[containers]]
+[[container]]
 name_en = "GeoServer OGC Filter SQL Injection"
 name_zh = "GeoServer OGC Filter SQL注入漏洞"
 app = "GeoServer"
-cve = "CVE-2023-25157"
+  [[container.cve]]
+  name = "CVE-2023-25157"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25157"
 path = "geoserver/CVE-2023-25157"
 
-[[containers]]
+[[container]]
 name_en = "GhostScript Sandbox Bypass (Command Execution)"
 name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
-cve = "CVE-2018-16509"
+  [[container.cve]]
+  name = "CVE-2018-16509"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
 path = "ghostscript/CVE-2018-16509"
 
-[[containers]]
+[[container]]
 name_en = "GhostScript Sandbox Bypass (Command Execution)"
 name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
-cve = "CVE-2018-19475"
+  [[container.cve]]
+  name = "CVE-2018-19475"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19475"
 path = "ghostscript/CVE-2018-19475"
 
-[[containers]]
+[[container]]
 name_en = "GhostScript Sandbox Bypass (Command Execution)"
 name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
-cve = "CVE-2019-6116"
+  [[container.cve]]
+  name = "CVE-2019-6116"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6116"
 path = "ghostscript/CVE-2019-6116"
 
-[[containers]]
+[[container]]
 name_en = "GIT-SHELL Sandbox Bypass"
 name_zh = "GIT-SHELL 沙盒绕过"
 app = "git"
-cve = "CVE-2017-8386"
+  [[container.cve]]
+  name = "CVE-2017-8386"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8386"
 path = "git/CVE-2017-8386"
 
-[[containers]]
+[[container]]
 name_en = "Gitea 1.4.0 Directory Traversal to Command Execution"
 name_zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
 app = "gitea"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "gitea/1.4-rce"
 
-[[containers]]
+[[container]]
 name_en = "GitLab Arbitrary File Read"
 name_zh = "GitLab 任意文件读取漏洞"
 app = "gitlab"
-cve = "CVE-2016-9086"
+  [[container.cve]]
+  name = "CVE-2016-9086"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-9086"
 path = "gitlab/CVE-2016-9086"
 
-[[containers]]
+[[container]]
 name_en = "GitLab Remote Command Execution"
 name_zh = "GitLab 远程命令执行漏洞"
 app = "gitlab"
-cve = "CVE-2021-22205"
+  [[container.cve]]
+  name = "CVE-2021-22205"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22205"
 path = "gitlab/CVE-2021-22205"
 
-[[containers]]
+[[container]]
 name_en = "gitlist 0.6.0 Remote Command Execution"
 name_zh = "gitlist 0.6.0 远程命令执行漏洞"
 app = "gitlist"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "gitlist/0.6.0-rce"
 
-[[containers]]
+[[container]]
 name_en = "GlassFish Arbitrary File Read"
 name_zh = "GlassFish 任意文件读取漏洞"
 app = "GlassFish"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "glassfish/4.1.0"
 
-[[containers]]
+[[container]]
 name_en = "GoAhead Remote Command Execution"
 name_zh = "GoAhead 远程命令执行漏洞"
 app = "GoAhead"
-cve = "CVE-2017-17562"
+  [[container.cve]]
+  name = "CVE-2017-17562"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17562"
 path = "goahead/CVE-2017-17562"
 
-[[containers]]
+[[container]]
 name_en = "GoAhead Server Environment Variable Injection"
 name_zh = "GoAhead Server 环境变量注入"
 app = "GoAhead"
-cve = "CVE-2021-42342"
+  [[container.cve]]
+  name = "CVE-2021-42342"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42342"
 path = "goahead/CVE-2021-42342"
 
-[[containers]]
+[[container]]
 name_en = "Gogs Arbitrary User Login"
 name_zh = "Gogs 任意用户登录漏洞"
 app = "Gogs"
-cve = "CVE-2018-18925"
+  [[container.cve]]
+  name = "CVE-2018-18925"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18925"
 path = "gogs/CVE-2018-18925"
 
-[[containers]]
+[[container]]
 name_en = "Grafana 8.x Plug-in Module Directory Traversal"
 name_zh = "Grafana 8.x 插件模块目录穿越漏洞"
 app = "Grafana"
-cve = "CVE-2021-43798"
+  [[container.cve]]
+  name = "CVE-2021-43798"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-43798"
 path = "grafana/CVE-2021-43798"
 
-[[containers]]
+[[container]]
 name_en = "Grafana Management Background SSRF"
 name_zh = "Grafana管理后台SSRF"
 app = "Grafana"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "grafana/admin-ssrf"
 
-[[containers]]
+[[container]]
 name_en = "H2 Database Console Unauthorized Access"
 name_zh = "H2 Database Console 未授权访问"
 app = "Springboot H2 Database"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "h2database/h2-console-unacc"
 
-[[containers]]
+[[container]]
 name_en = "Hadoop YARN ResourceManager Unauthorized Access"
 name_zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
 app = "Hadoop YARN"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "hadoop/unauthorized-yarn"
 
-[[containers]]
+[[container]]
 name_en = "Apache HTTPD Newline Parsing"
 name_zh = "Apache HTTPD 换行解析漏洞"
 app = "Apache HTTP Server"
-cve = "CVE-2017-15715"
+  [[container.cve]]
+  name = "CVE-2017-15715"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-15715"
 path = "httpd/CVE-2017-15715"
 
-[[containers]]
+[[container]]
 name_en = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
 name_zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
 app = "Apache HTTP Server"
-cve = "CVE-2021-40438"
+  [[container.cve]]
+  name = "CVE-2021-40438"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-40438"
 path = "httpd/CVE-2021-40438"
 
-[[containers]]
+[[container]]
 name_en = "Apache HTTP Server 2.4.49 Path Traversal"
 name_zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
 app = "Apache HTTP Server"
-cve = "CVE-2021-41773"
+  [[container.cve]]
+  name = "CVE-2021-41773"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41773"
 path = "httpd/CVE-2021-41773"
 
-[[containers]]
+[[container]]
 name_en = "Apache HTTP Server 2.4.50 Path Traversal"
 name_zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
 app = "Apache HTTP Server"
-cve = "CVE-2021-42013"
+  [[container.cve]]
+  name = "CVE-2021-42013"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42013"
 path = "httpd/CVE-2021-42013"
 
-[[containers]]
+[[container]]
 name_en = "Apache HTTPD Unknown Suffix Parsing"
 name_zh = "Apache HTTPD 未知后缀解析漏洞"
 app = "Apache HTTP Server"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "httpd/apache_parsing_vulnerability"
 
-[[containers]]
+[[container]]
 name_en = "Apache SSI Remote Command Execution"
 name_zh = "Apache SSI 远程命令执行漏洞"
 app = "Apache HTTP Server"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "httpd/ssi-rce"
 
-[[containers]]
+[[container]]
 name_en = "Imagetragick Command Execution"
 name_zh = "Imagetragick 命令执行漏洞"
 app = "ImageMagick"
-cve = "CVE-2016-3714"
+  [[container.cve]]
+  name = "CVE-2016-3714"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3714"
 path = "imagemagick/imagetragick"
 
-[[containers]]
+[[container]]
 name_en = "ImageMagick PDF Password Location Command Injection"
 name_zh = "ImageMagick PDF密码位置命令注入漏洞"
 app = "imagemagick"
-cve = "CVE-2020-29599"
+  [[container.cve]]
+  name = "CVE-2020-29599"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-29599"
 path = "imagemagick/CVE-2020-29599"
 
-[[containers]]
+[[container]]
 name_en = "ImageMagick Arbitrary File Read"
 name_zh = "ImageMagick任意文件读取漏洞"
 app = "imagemagick"
-cve = "CVE-2022-44268"
+  [[container.cve]]
+  name = "CVE-2022-44268"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-44268"
 path = "imagemagick/CVE-2022-44268"
 
-[[containers]]
+[[container]]
 name_en = "InfluxDB Empty JWT Secret Key Authentication Bypass"
 name_zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
 app = "InfluxDB"
-cve = "CVE-2019-20933"
+  [[container.cve]]
+  name = "CVE-2019-20933"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-20933"
 path = "influxdb/CVE-2019-20933"
 
-[[containers]]
+[[container]]
 name_en = "Jackson-databind Deserialization"
 name_zh = "Jackson-databind 反序列化漏洞"
 app = "Jackson-databind"
-cve = "CVE-2017-7525"
+  [[container.cve]]
+  name = "CVE-2017-7525"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
 path = "jackson/CVE-2017-7525"
 
-[[containers]]
+[[container]]
 name_en = "Java RMI codebase Remote Code Execution"
 name_zh = "Java RMI codebase 远程代码执行漏洞"
 app = "java rmi"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "java/rmi-codebase"
 
-[[containers]]
+[[container]]
 name_en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
 name_zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
 app = "java rmi"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "java/rmi-registry-bind-deserialization"
 
-[[containers]]
+[[container]]
 name_en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
 name_zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
 app = "java rmi"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "java/rmi-registry-bind-deserialization-bypass"
 
-[[containers]]
+[[container]]
 name_en = "JBoss 5.x/6.x Deserialization"
 name_zh = "JBoss 5.x/6.x 反序列化漏洞"
 app = "jboss"
-cve = "CVE-2017-12149"
+  [[container.cve]]
+  name = "CVE-2017-12149"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12149"
 path = "jboss/CVE-2017-12149"
 
-[[containers]]
+[[container]]
 name_en = "JBoss 4.x JBossMQ JMS Deserialization"
 name_zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
 app = "jboss"
-cve = "CVE-2017-7504"
+  [[container.cve]]
+  name = "CVE-2017-7504"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7504"
 path = "jboss/CVE-2017-7504"
 
-[[containers]]
+[[container]]
 name_en = "JBoss JMXInvokerServlet Deserialization"
 name_zh = "JBoss JMXInvokerServlet 反序列化漏洞"
 app = "jboss"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "jboss/JMXInvokerServlet-deserialization"
 
-[[containers]]
+[[container]]
 name_en = "Jenkins-CI Remote Code Execution"
 name_zh = "Jenkins-CI 远程代码执行漏洞"
 app = "Jenkins"
-cve = "CVE-2017-1000353"
+  [[container.cve]]
+  name = "CVE-2017-1000353"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-1000353"
 path = "jenkins/CVE-2017-1000353"
 
-[[containers]]
+[[container]]
 name_en = "Jenkins Remote Command Execution"
 name_zh = "Jenkins远程命令执行漏洞"
 app = "Jenkins"
-cve = "CVE-2018-1000861"
+  [[container.cve]]
+  name = "CVE-2018-1000861"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000861"
 path = "jenkins/CVE-2018-1000861"
 
-[[containers]]
+[[container]]
 name_en = "Jetty WEB-INF Sensitive Information Disclosure"
 name_zh = "Jetty WEB-INF 敏感信息泄露漏洞"
 app = "jetty"
-cve = "CVE-2021-28164"
+  [[container.cve]]
+  name = "CVE-2021-28164"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28164"
 path = "jetty/CVE-2021-28164"
 
-[[containers]]
+[[container]]
 name_en = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
 name_zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
 app = "jetty"
-cve = "CVE-2021-28169"
+  [[container.cve]]
+  name = "CVE-2021-28169"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28169"
 path = "jetty/CVE-2021-28169"
 
-[[containers]]
+[[container]]
 name_en = "Jetty WEB-INF Sensitive Information Disclosure"
 name_zh = "Jetty WEB-INF 敏感信息泄露漏洞"
 app = "jetty"
-cve = "CVE-2021-34429"
+  [[container.cve]]
+  name = "CVE-2021-34429"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34429"
 path = "jetty/CVE-2021-34429"
 
-[[containers]]
+[[container]]
 name_en = "Atlassian Jira Template Injection"
 name_zh = "Atlassian Jira 模板注入漏洞"
 app = "jira"
-cve = "CVE-2019-11581"
+  [[container.cve]]
+  name = "CVE-2019-11581"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11581"
 path = "jira/CVE-2019-11581"
 
-[[containers]]
+[[container]]
 name_en = "Jmeter RMI Deserialization Command Execution"
 name_zh = "Jmeter RMI 反序列化命令执行漏洞"
 app = "Apache Jmeter"
-cve = "CVE-2018-1297"
+  [[container.cve]]
+  name = "CVE-2018-1297"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1297"
 path = "jmeter/CVE-2018-1297"
 
-[[containers]]
+[[container]]
 name_en = "Joomla 3.4.5 Deserialization"
 name_zh = "Joomla 3.4.5 反序列化漏洞"
 app = "Joomla"
-cve = "CVE-2015-8562"
+  [[container.cve]]
+  name = "CVE-2015-8562"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-8562"
 path = "joomla/CVE-2015-8562"
 
-[[containers]]
+[[container]]
 name_en = "Joomla 3.7.0 SQL Injection"
 name_zh = "Joomla 3.7.0 SQL注入漏洞"
 app = "Joomla"
-cve = "CVE-2017-8917"
+  [[container.cve]]
+  name = "CVE-2017-8917"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8917"
 path = "joomla/CVE-2017-8917"
 
-[[containers]]
+[[container]]
 name_en = "Joomla 4.2.7 Permission Bypass"
 name_zh = "Joomla 4.2.7 权限绕过漏洞"
 app = "Joomla"
-cve = "CVE-2023-23752"
+  [[container.cve]]
+  name = "CVE-2023-23752"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-23752"
 path = "joomla/CVE-2023-23752"
 
-[[containers]]
+[[container]]
 name_en = "Jupyter Notebook Unauthorized Access"
 name_zh = "Jupyter Notebook 未授权访问漏洞"
 app = "Jupyter"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "jupyter/notebook-rce"
 
-[[containers]]
+[[container]]
 name_en = "Apache Kafka Clients JNDI Injection"
 name_zh = "Apache Kafka Clients JNDI注入漏洞"
 app = "Apache Kafka"
-cve = "CVE-2023-25194"
+  [[container.cve]]
+  name = "CVE-2023-25194"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25194"
 path = "kafka/CVE-2023-25194"
 
-[[containers]]
+[[container]]
 name_en = "Kibana Local File Inclusion"
 name_zh = "Kibana 本地文件包含漏洞"
 app = "kibana"
-cve = "CVE-2018-17246"
+  [[container.cve]]
+  name = "CVE-2018-17246"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-17246"
 path = "kibana/CVE-2018-17246"
 
-[[containers]]
+[[container]]
 name_en = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
 name_zh = "Kibana 原型链污染导致任意代码执行漏洞"
 app = "kibana"
-cve = "CVE-2019-7609"
+  [[container.cve]]
+  name = "CVE-2019-7609"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7609"
 path = "kibana/CVE-2019-7609"
 
-[[containers]]
+[[container]]
 name_en = "Laravel Ignition 2.5.1 Code Execution"
 name_zh = "Laravel Ignition 2.5.1 代码执行漏洞"
 app = "laravel"
-cve = "CVE-2021-3129"
+  [[container.cve]]
+  name = "CVE-2021-3129"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-3129"
 path = "kibana/CVE-2021-3129"
 
-[[containers]]
+[[container]]
 name_en = "libssh Server-side Authentication Bypass"
 name_zh = "libssh 服务端权限认证绕过漏洞"
 app = "libssh"
-cve = "CVE-2018-10933"
+  [[container.cve]]
+  name = "CVE-2018-10933"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-10933"
 path = "libssh/CVE-2018-10933"
 
-[[containers]]
+[[container]]
 name_en = "Liferay Portal CE Deserialization Command Execution"
 name_zh = "Liferay Portal CE 反序列化命令执行漏洞"
 app = "Liferay Portal"
-cve = "CVE-2020-7961"
+  [[container.cve]]
+  name = "CVE-2020-7961"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7961"
 path = "liferay-portal/CVE-2020-7961"
 
-[[containers]]
+[[container]]
 name_en = "Apache Log4j Server Deserialization Command Execution"
 name_zh = "Apache Log4j Server 反序列化命令执行漏洞"
 app = "Apache Log4j"
-cve = "CVE-2017-5645"
+  [[container.cve]]
+  name = "CVE-2017-5645"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5645"
 path = "log4j/CVE-2017-5645"
 
-[[containers]]
+[[container]]
 name_en = "Apache Log4j2 lookup JNDI Injection"
 name_zh = "Apache Log4j2 lookup JNDI 注入漏洞"
 app = "Apache Log4j"
-cve = "CVE-2021-44228"
+  [[container.cve]]
+  name = "CVE-2021-44228"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
 path = "log4j/CVE-2021-44228"
 
-[[containers]]
+[[container]]
 name_en = "Magento 2.2 SQL Injection"
 name_zh = "Magento 2.2 SQL注入漏洞"
 app = "Magento"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "magento/2.2-sqli"
 
-[[containers]]
+[[container]]
 name_en = "Metabase Arbitrary File Read"
 name_zh = "Metabase任意文件读取漏洞"
 app = "metabase"
-cve = "CVE-2021-41277"
+  [[container.cve]]
+  name = "CVE-2021-41277"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41277"
 path = "metabase/CVE-2021-41277"
 
-[[containers]]
+[[container]]
 name_en = "mini_httpd Arbitrary File Read"
 name_zh = "mini_httpd任意文件读取漏洞"
 app = "mini_httpd"
-cve = "CVE-2018-18778"
+  [[container.cve]]
+  name = "CVE-2018-18778"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18778"
 path = "mini_httpd/CVE-2018-18778"
 
-[[containers]]
+[[container]]
 name_en = "MinIO Cluster Mode Information Disclosure"
 name_zh = "MinIO集群模式信息泄露漏洞"
 app = "MinIO"
-cve = "CVE-2023-28432"
+  [[container.cve]]
+  name = "CVE-2023-28432"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-28432"
 path = "minio/CVE-2023-28432"
 
-[[containers]]
+[[container]]
 name_en = "Mojarra JSF ViewState Deserialization"
 name_zh = "Mojarra JSF ViewState 反序列化漏洞"
 app = "Mojarra JSF"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "mojarra/jsf-viewstate-deserialization"
 
-[[containers]]
+[[container]]
 name_en = "Mongo Express Remote Code Execution"
 name_zh = "Mongo Express 远程代码执行漏洞"
 app = "mongo-express"
-cve = "CVE-2019-10758"
+  [[container.cve]]
+  name = "CVE-2019-10758"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-10758"
 path = "mongo-express/CVE-2019-10758"
 
-[[containers]]
+[[container]]
 name_en = "MySQL Authentication Bypass"
 name_zh = "MySQL 身份认证绕过漏洞"
 app = "MySQL"
-cve = "CVE-2012-2122"
+  [[container.cve]]
+  name = "CVE-2012-2122"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-2122"
 path = "mysql/CVE-2012-2122"
 
-[[containers]]
+[[container]]
 name_en = "Nacos Authentication Bypass"
 name_zh = "Nacos 认证绕过漏洞"
 app = "Nacos"
-cve = "CVE-2021-29441"
+  [[container.cve]]
+  name = "CVE-2021-29441"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29441"
 path = "nacos/CVE-2021-29441"
 
-[[containers]]
+[[container]]
 name_en = "Neo4j Shell Server Deserialization"
 name_zh = "Neo4j Shell Server 反序列化漏洞"
 app = "Neo4j"
-cve = "CVE-2021-34371"
+  [[container.cve]]
+  name = "CVE-2021-34371"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34371"
 path = "neo4j/CVE-2021-34371"
 
-[[containers]]
+[[container]]
 name_en = "Nexus Repository Manager 3 Remote Command Execution"
 name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
-cve = "CVE-2019-7238"
+  [[container.cve]]
+  name = "CVE-2019-7238"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7238"
 path = "nexus/CVE-2019-7238"
 
-[[containers]]
+[[container]]
 name_en = "Nexus Repository Manager 3 Remote Command Execution"
 name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
-cve = "CVE-2020-10199"
+  [[container.cve]]
+  name = "CVE-2020-10199"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10199"
 path = "nexus/CVE-2020-10199"
 
-[[containers]]
+[[container]]
 name_en = "Nexus Repository Manager 3 Remote Command Execution"
 name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
-cve = "CVE-2020-10204"
+  [[container.cve]]
+  name = "CVE-2020-10204"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10204"
 path = "nexus/CVE-2020-10204"
 
-[[containers]]
+[[container]]
 name_en = "Nginx Filename Logic"
 name_zh = "Nginx 文件名逻辑漏洞"
 app = "Nginx"
-cve = "CVE-2013-4547"
+  [[container.cve]]
+  name = "CVE-2013-4547"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-4547"
 path = "nginx/CVE-2013-4547"
 
-[[containers]]
+[[container]]
 name_en = "Nginx Out-of-Bounds Read Cache"
 name_zh = "Nginx越界读取缓存漏洞"
 app = "Nginx"
-cve = "CVE-2017-7529"
+  [[container.cve]]
+  name = "CVE-2017-7529"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7529"
 path = "nginx/CVE-2017-7529"
 
-[[containers]]
+[[container]]
 name_en = "Nginx Configuration Errors"
 name_zh = "Nginx 配置错误三例"
 app = "Nginx"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "nginx/insecure-configuration"
 
-[[containers]]
+[[container]]
 name_en = "Nginx Parsing"
 name_zh = "Nginx 解析漏洞"
 app = "Nginx"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "nginx/nginx_parsing_vulnerability"
 
-[[containers]]
+[[container]]
 name_en = "NodeJS Directory Traversal"
 name_zh = "NodeJS 目录穿越漏洞"
 app = "node"
-cve = "CVE-2017-14849"
+  [[container.cve]]
+  name = "CVE-2017-14849"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-14849"
 path = "node/CVE-2017-14849"
 
-[[containers]]
+[[container]]
 name_en = "node-postgres Code Execution"
 name_zh = "node-postgres 代码执行漏洞分析"
 app = "node-postgres"
-cve = "CVE-2017-16082"
+  [[container.cve]]
+  name = "CVE-2017-16082"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-16082"
 path = "node/CVE-2017-16082"
 
-[[containers]]
+[[container]]
 name_en = "ntopng Permission Bypass"
 name_zh = "ntopng权限绕过漏洞"
 app = "ntopng"
-cve = "CVE-2021-28073"
+  [[container.cve]]
+  name = "CVE-2021-28073"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28073"
 path = "ntopng/CVE-2021-28073"
 
-[[containers]]
+[[container]]
 name_en = "Apache OfBiz Deserialization Command Execution"
 name_zh = "Apache OfBiz 反序列化命令执行漏洞"
 app = "Apache OfBiz"
-cve = "CVE-2020-9496"
+  [[container.cve]]
+  name = "CVE-2020-9496"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9496"
 path = "ofbiz/CVE-2020-9496"
 
-[[containers]]
+[[container]]
 name_en = "Openfire Management Background Authentication Bypass"
 name_zh = "Openfire管理后台认证绕过漏洞"
 app = "Openfire"
-cve = "CVE-2023-32315"
+  [[container.cve]]
+  name = "CVE-2023-32315"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-32315"
 path = "openfire/CVE-2023-32315"
 
-[[containers]]
+[[container]]
 name_en = "OpenSMTPD Remote Command Execution"
 name_zh = "OpenSMTPD 远程命令执行漏洞"
 app = "OpenSMTPD"
-cve = "CVE-2020-7247"
+  [[container.cve]]
+  name = "CVE-2020-7247"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7247"
 path = "opensmtpd/CVE-2020-7247"
 
-[[containers]]
+[[container]]
 name_en = "OpenSSH Username Enumeration"
 name_zh = "OpenSSH 用户名枚举漏洞"
 app = "OpenSSH"
-cve = "CVE-2018-15473"
+  [[container.cve]]
+  name = "CVE-2018-15473"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15473"
 path = "openssh/CVE-2018-15473"
 
-[[containers]]
+[[container]]
 name_en = "OpenSSL Heartbleed"
 name_zh = "OpenSSL 心脏出血漏洞"
 app = "OpenSSL"
-cve = "CVE-2014-0160"
+  [[container.cve]]
+  name = "CVE-2014-0160"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-0160"
 path = "openssl/CVE-2014-0160"
 
-[[containers]]
+[[container]]
 name_en = "OpenSSL Infinite Loop DoS"
 name_zh = "OpenSSL无限循环DoS漏洞"
 app = "OpenSSL"
-cve = "CVE-2022-0778"
+  [[container.cve]]
+  name = "CVE-2022-0778"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0778"
 path = "openssl/CVE-2022-0778"
 
-[[containers]]
+[[container]]
 name_en = "OpenTSDB Command Injection"
 name_zh = "OpenTSDB 命令注入漏洞"
 app = "OpenTSDB"
-cve = "CVE-2020-35476"
+  [[container.cve]]
+  name = "CVE-2020-35476"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-35476"
 path = "opentsdb/CVE-2020-35476"
 
-[[containers]]
+[[container]]
 name_en = "PHP 8.1.0-dev Development Version Backdoor Event"
 name_zh = "PHP 8.1.0-dev 开发版本后门事件"
 app = "PHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "php/8.1-backdoor"
 
-[[containers]]
+[[container]]
 name_en = "PHP-CGI Remote Code Execution"
 name_zh = "PHP-CGI远程代码执行漏洞"
 app = "PHP-CGI"
-cve = "CVE-2012-1823"
+  [[container.cve]]
+  name = "CVE-2012-1823"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-1823"
 path = "php/CVE-2012-1823"
 
-[[containers]]
+[[container]]
 name_en = "PHP-IMAP Remote Command Execution"
 name_zh = "PHP-IMAP 远程命令执行漏洞"
 app = "PHP-IMAP"
-cve = "CVE-2018-19518"
+  [[container.cve]]
+  name = "CVE-2018-19518"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19518"
 path = "php/CVE-2018-19518"
 
-[[containers]]
+[[container]]
 name_en = "PHP-FPM Remote Command Execution"
 name_zh = "PHP-FPM 远程代码执行漏洞"
 app = "PHP-FPM"
-cve = "CVE-2019-11043"
+  [[container.cve]]
+  name = "CVE-2019-11043"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11043"
 path = "php/CVE-2019-11043"
 
-[[containers]]
+[[container]]
 name_en = "PHP-FPM FastCGI Unauthorized Access"
 name_zh = "PHP-FPM FastCGI 未授权访问漏洞"
 app = "PHP-FPM"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "php/fpm"
 
-[[containers]]
+[[container]]
 name_en = "PHP Files Vulnerabilities (by phpinfo())"
 name_zh = "PHP文件包含漏洞 (利用phpinfo())"
 app = "PHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "php/inclusion"
 
-[[containers]]
+[[container]]
 name_en = "PHP XML Entity Injection"
 name_zh = "PHP XML实体注入"
 app = "PHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "php/php_xxe"
 
-[[containers]]
+[[container]]
 name_en = "XDebug Remote Debugging Code Execution"
 name_zh = "XDebug 远程调试漏洞 (代码执行)"
 app = "PHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "php/xdebug-rce"
 
-[[containers]]
+[[container]]
 name_en = "PHPMailer Arbitrary File Read"
 name_zh = "PHPMailer 任意文件读取漏洞"
 app = "PHPMailer"
-cve = "CVE-2017-5223"
+  [[container.cve]]
+  name = "CVE-2017-5223"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5223"
 path = "phpmailer/CVE-2017-5223"
 
-[[containers]]
+[[container]]
 name_en = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
 name_zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
 app = "phpmyadmin"
-cve = "CVE-2016-5734"
+  [[container.cve]]
+  name = "CVE-2016-5734"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5734"
 path = "phpmyadmin/CVE-2016-5734"
 
-[[containers]]
+[[container]]
 name_en = "phpmyadmin 4.8.1 Remote File Inclusion"
 name_zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
 app = "phpmyadmin"
-cve = "CVE-2018-12613"
+  [[container.cve]]
+  name = "CVE-2018-12613"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-12613"
 path = "phpmyadmin/CVE-2018-12613"
 
-[[containers]]
+[[container]]
 name_en = "phpmyadmin scripts/setup.php Deserialization"
 name_zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
 app = "phpmyadmin"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "phpmyadmin/WooYun-2016-199433"
 
-[[containers]]
+[[container]]
 name_en = "phpunit Remote Code Execution"
 name_zh = "phpunit 远程代码执行漏洞"
 app = "phpunit"
-cve = "CVE-2017-9841"
+  [[container.cve]]
+  name = "CVE-2017-9841"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9841"
 path = "phpunit/CVE-2017-9841"
 
-[[containers]]
+[[container]]
 name_en = "Polkit pkexec Privilege Escalation"
 name_zh = "Polkit pkexec 权限提升漏洞"
 app = "Polkit Pkexec"
-cve = "CVE-2021-4034"
+  [[container.cve]]
+  name = "CVE-2021-4034"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-4034"
 path = "polkit/CVE-2021-4034"
 
-[[containers]]
+[[container]]
 name_en = "PostgreSQL Privilege Escalation"
 name_zh = "PostgreSQL 提权漏洞"
 app = "PostgreSQL"
-cve = "CVE-2018-1058"
+  [[container.cve]]
+  name = "CVE-2018-1058"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1058"
 path = "postgres/CVE-2018-1058"
 
-[[containers]]
+[[container]]
 name_en = "PostgreSQL High Privilege Command Execution"
 name_zh = "PostgreSQL 高权限命令执行漏洞"
 app = "PostgreSQL"
-cve = "CVE-2019-9193"
+  [[container.cve]]
+  name = "CVE-2019-9193"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-9193"
 path = "postgres/CVE-2019-9193"
 
-[[containers]]
+[[container]]
 name_en = "Python PIL Remote Command Execution (GhostButt)"
 name_zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
 app = "Python"
-cve = "CVE-2017-8291"
+  [[container.cve]]
+  name = "CVE-2017-8291"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8291"
 path = "python/PIL-CVE-2017-8291"
 
-[[containers]]
+[[container]]
 name_en = "Python PIL Remote Command Execution (via Ghostscript)"
 name_zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
 app = "Python"
-cve = "CVE-2018-16509"
+  [[container.cve]]
+  name = "CVE-2018-16509"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
 path = "python/PIL-CVE-2018-16509"
 
-[[containers]]
+[[container]]
 name_en = "Python Unpickle Deserialization"
 name_zh = "Python Unpickle 反序列化漏洞"
 app = "Python"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "python/unpickle"
 
-[[containers]]
+[[container]]
 name_en = "Ruby on Rails Path Traversal"
 name_zh = "Ruby on Rails 路径穿越漏洞"
 app = "Ruby on Rails"
-cve = "CVE-2018-3760"
+  [[container.cve]]
+  name = "CVE-2018-3760"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-3760"
 path = "rails/CVE-2018-3760"
 
-[[containers]]
+[[container]]
 name_en = "Ruby on Rails Path Traversal and Arbitrary File Read"
 name_zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
 app = "Ruby on Rails"
-cve = "CVE-2019-5418"
+  [[container.cve]]
+  name = "CVE-2019-5418"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-5418"
 path = "rails/CVE-2019-5418"
 
-[[containers]]
+[[container]]
 name_en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
 name_zh = "Redis 4.x/5.x 主从复制导致的命令执行"
 app = "redis"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "redis/4-unacc"
 
-[[containers]]
+[[container]]
 name_en = "Redis Lua Sandbox Bypass Command Execution"
 name_zh = "Redis Lua沙盒绕过命令执行"
 app = "redis"
-cve = "CVE-2022-0543"
+  [[container.cve]]
+  name = "CVE-2022-0543"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0543"
 path = "redis/CVE-2022-0543"
 
-[[containers]]
+[[container]]
 name_en = "Rocket Chat MongoDB Injection"
 name_zh = "Rocket Chat MongoDB 注入漏洞"
 app = "rocket chat"
-cve = "CVE-2021-22911"
+  [[container.cve]]
+  name = "CVE-2021-22911"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22911"
 path = "rocketchat/CVE-2021-22911"
 
-[[containers]]
+[[container]]
 name_en = "Apache RocketMQ Remote Command Execution"
 name_zh = "Apache RocketMQ 远程命令执行漏洞"
 app = "Apache RocketMQ"
-cve = "CVE-2023-33246"
+  [[container.cve]]
+  name = "CVE-2023-33246"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-33246"
 path = "rocketmq/CVE-2023-33246"
 
-[[containers]]
+[[container]]
 name_en = "rsync Unauthorized Access"
 name_zh = "rsync 未授权访问漏洞"
 app = "rsync"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "rsync/common"
 
-[[containers]]
+[[container]]
 name_en = "Ruby Net::FTP Module Command Injection"
 name_zh = "Ruby Net::FTP 模块命令注入漏洞"
 app = "ruby"
-cve = "CVE-2017-17405"
+  [[container.cve]]
+  name = "CVE-2017-17405"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17405"
 path = "ruby/CVE-2017-17405"
 
-[[containers]]
+[[container]]
 name_en = "SaltStack Horizontal Privilege Bypass"
 name_zh = "SaltStack 水平权限绕过漏洞"
 app = "SaltStack"
-cve = "CVE-2020-11651"
+  [[container.cve]]
+  name = "CVE-2020-11651"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11651"
 path = "saltstack/CVE-2020-11651"
 
-[[containers]]
+[[container]]
 name_en = "SaltStack Arbitrary File Read and Write"
 name_zh = "SaltStack 任意文件读写漏洞"
 app = "SaltStack"
-cve = "CVE-2020-11652"
+  [[container.cve]]
+  name = "CVE-2020-11652"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11652"
 path = "saltstack/CVE-2020-11652"
 
-[[containers]]
+[[container]]
 name_en = "SaltStack Command Injection"
 name_zh = "SaltStack 命令注入漏洞"
 app = "SaltStack"
-cve = "CVE-2020-16846"
+  [[container.cve]]
+  name = "CVE-2020-16846"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-16846"
 path = "saltstack/CVE-2020-16846"
 
-[[containers]]
+[[container]]
 name_en = "Samba Remote Command Execution"
 name_zh = "Samba 远程命令执行漏洞"
 app = "Samba"
-cve = "CVE-2017-7494"
+  [[container.cve]]
+  name = "CVE-2017-7494"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7494"
 path = "samba/CVE-2017-7494"
 
-[[containers]]
+[[container]]
 name_en = "Scrapyd Unauthorized Access"
 name_zh = "Scrapyd 未授权访问漏洞"
 app = "Scrapyd"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "scrapy/scrapyd-unacc"
 
-[[containers]]
+[[container]]
 name_en = "Apache Shiro Authentication Bypass"
 name_zh = "Apache Shiro 认证绕过漏洞"
 app = "shiro"
-cve = "CVE-2010-3863"
+  [[container.cve]]
+  name = "CVE-2010-3863"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-3863"
 path = "shiro/CVE-2010-3863"
 
-[[containers]]
+[[container]]
 name_en = "Apache Shiro 1.2.4 Deserialization"
 name_zh = "Apache Shiro 1.2.4反序列化漏洞"
 app = "shiro"
-cve = "CVE-2016-4437"
+  [[container.cve]]
+  name = "CVE-2016-4437"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4437"
 path = "shiro/CVE-2016-4437"
 
-[[containers]]
+[[container]]
 name_en = "Apache Shiro Authentication Bypass"
 name_zh = "Apache Shiro 认证绕过漏洞"
 app = "shiro"
-cve = "CVE-2020-1957"
+  [[container.cve]]
+  name = "CVE-2020-1957"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1957"
 path = "shiro/CVE-2020-1957"
 
-[[containers]]
+[[container]]
 name_en = "Apache Skywalking 8.3.0 SQL Injection"
 name_zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
 app = "skywalking"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "skywalking/8.3.0-sqli"
 
-[[containers]]
+[[container]]
 name_en = "Apache Solr Remote Command Execution"
 name_zh = "Apache Solr 远程命令执行漏洞"
 app = "solr"
-cve = "CVE-2017-12629"
+  [[container.cve]]
+  name = "CVE-2017-12629"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
 path = "solr/CVE-2017-12629-RCE"
 
-[[containers]]
+[[container]]
 name_en = "Apache Solr XML Entity Injection"
 name_zh = "Apache Solr XML 实体注入漏洞"
 app = "solr"
-cve = "CVE-2017-12629"
+  [[container.cve]]
+  name = "CVE-2017-12629"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
 path = "solr/CVE-2017-12629-XXE"
 
-[[containers]]
+[[container]]
 name_en = "Apache Solr Remote Command Execution"
 name_zh = "Apache Solr 远程命令执行漏洞"
 app = "solr"
-cve = "CVE-2019-0193"
+  [[container.cve]]
+  name = "CVE-2019-0193"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0193"
 path = "solr/CVE-2019-0193"
 
-[[containers]]
+[[container]]
 name_en = "Apache Solr Velocity Inject Remote Command Execution"
 name_zh = "Apache Solr Velocity 注入远程命令执行漏洞"
 app = "solr"
-cve = "CVE-2019-17558"
+  [[container.cve]]
+  name = "CVE-2019-17558"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17558"
 path = "solr/CVE-2019-17558"
 
-[[containers]]
+[[container]]
 name_en = "Apache Solr RemoteStreaming File Reading and SSRF"
 name_zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
 app = "solr"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "solr/Remote-Streaming-Fileread"
 
-[[containers]]
+[[container]]
 name_en = "Apache Spark Unauthorized Access Leak"
 name_zh = "Apache Spark 未授权访问漏"
 app = "spark"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "spark/unacc"
 
-[[containers]]
+[[container]]
 name_en = "Spring Security Oauth2 Remote Command Execution"
 name_zh = "Spring Security Oauth2 远程命令执行漏洞"
 app = "spring security oauth2"
-cve = "CVE-2016-4977"
+  [[container.cve]]
+  name = "CVE-2016-4977"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4977"
 path = "spring/CVE-2016-4977"
 
-[[containers]]
+[[container]]
 name_en = "Spring WebFlow Remote Code Execution"
 name_zh = "Spring WebFlow 远程代码执行漏洞"
 app = "spring webflow"
-cve = "CVE-2017-4971"
+  [[container.cve]]
+  name = "CVE-2017-4971"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-4971"
 path = "spring/CVE-2017-4971"
 
-[[containers]]
+[[container]]
 name_en = "Spring Data Rest Remote Command Execution"
 name_zh = "Spring Data Rest 远程命令执行漏洞"
 app = "spring data rest"
-cve = "CVE-2017-8046"
+  [[container.cve]]
+  name = "CVE-2017-8046"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8046"
 path = "spring/CVE-2017-8046"
 
-[[containers]]
+[[container]]
 name_en = "Spring Messaging Remote Command Execution"
 name_zh = "Spring Messaging 远程命令执行漏洞"
 app = "spring messaging"
-cve = "CVE-2018-1270"
+  [[container.cve]]
+  name = "CVE-2018-1270"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1270"
 path = "spring/CVE-2018-1270"
 
-[[containers]]
+[[container]]
 name_en = "Spring Data Commons Remote Command Execution"
 name_zh = "Spring Data Commons 远程命令执行漏洞"
 app = "spring data commons"
-cve = "CVE-2018-1273"
+  [[container.cve]]
+  name = "CVE-2018-1273"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1273"
 path = "spring/CVE-2018-1273"
 
-[[containers]]
+[[container]]
 name_en = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
 name_zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
 app = "spring cloud gateway"
-cve = "CVE-2022-22947"
+  [[container.cve]]
+  name = "CVE-2022-22947"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22947"
 path = "spring/CVE-2022-22947"
 
-[[containers]]
+[[container]]
 name_en = "Spring Cloud Function SpEL Expression Command Injection"
 name_zh = "Spring Cloud Function SpEL表达式命令注入"
 app = "spring cloud function"
-cve = "CVE-2022-22963"
+  [[container.cve]]
+  name = "CVE-2022-22963"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22963"
 path = "spring/CVE-2022-22963"
 
-[[containers]]
+[[container]]
 name_en = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
 name_zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
 app = "Spring"
-cve = "CVE-2022-22965"
+  [[container.cve]]
+  name = "CVE-2022-22965"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22965"
 path = "spring/CVE-2022-22965"
 
-[[containers]]
+[[container]]
 name_en = "Spring Security Authorization Bypass in RegexRequestMatcher"
 name_zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
 app = "Spring"
-cve = "CVE-2022-22978"
+  [[container.cve]]
+  name = "CVE-2022-22978"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22978"
 path = "spring/CVE-2022-22978"
 
-[[containers]]
+[[container]]
 name_en = "S2-001 Remote Code Execution"
 name_zh = "S2-001 远程代码执行漏洞"
 app = "Struts2"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "struts2/s2-001"
 
-[[containers]]
+[[container]]
 name_en = "S2-005 Remote Code Execution"
 name_zh = "S2-005 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2010-1870"
+  [[container.cve]]
+  name = "CVE-2010-1870"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-1870"
 path = "struts2/s2-005"
 
-[[containers]]
+[[container]]
 name_en = "S2-007 Remote Code Execution"
 name_zh = "S2-007 远程代码执行漏洞"
 app = "Struts2"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "struts2/s2-007"
 
-[[containers]]
+[[container]]
 name_en = "S2-008 Remote Code Execution"
 name_zh = "S2-008 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2012-0391"
+  [[container.cve]]
+  name = "CVE-2012-0391"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-0391"
 path = "struts2/s2-008"
 
-[[containers]]
+[[container]]
 name_en = "S2-009 Remote Code Execution"
 name_zh = "S2-009 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2011-3923"
+  [[container.cve]]
+  name = "CVE-2011-3923"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2011-3923"
 path = "struts2/s2-009"
 
-[[containers]]
+[[container]]
 name_en = "S2-012 Remote Code Execution"
 name_zh = "S2-012 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2013-1965"
+  [[container.cve]]
+  name = "CVE-2013-1965"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1965"
 path = "struts2/s2-012"
 
-[[containers]]
+[[container]]
 name_en = "S2-013 Remote Code Execution"
 name_zh = "S2-013 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2013-1966"
+  [[container.cve]]
+  name = "CVE-2013-1966"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1966"
 path = "struts2/s2-013"
 
-[[containers]]
+[[container]]
 name_en = "S2-015 Remote Code Execution"
 name_zh = "S2-015 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2013-2134,CVE-2013-2135"
+  [[container.cve]]
+  name = "CVE-2013-2134"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2134"
+
+  [[container.cve]]
+  name = "CVE-2013-2135"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2135"
 path = "struts2/s2-015"
 
-[[containers]]
+[[container]]
 name_en = "S2-016 Remote Code Execution"
 name_zh = "S2-016 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2013-2251"
+  [[container.cve]]
+  name = "CVE-2013-2251"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2251"
 path = "struts2/s2-016"
 
-[[containers]]
+[[container]]
 name_en = "S2-032 Remote Code Execution"
 name_zh = "S2-032 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2016-3081"
+  [[container.cve]]
+  name = "CVE-2016-3081"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3081"
 path = "struts2/s2-032"
 
-[[containers]]
+[[container]]
 name_en = "S2-045 Remote Code Execution"
 name_zh = "S2-045 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2017-5638"
+  [[container.cve]]
+  name = "CVE-2017-5638"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
 path = "struts2/s2-045"
 
-[[containers]]
+[[container]]
 name_en = "S2-046 Remote Code Execution"
 name_zh = "S2-046 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2017-5638"
+  [[container.cve]]
+  name = "CVE-2017-5638"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
 path = "struts2/s2-046"
 
-[[containers]]
+[[container]]
 name_en = "S2-048 Remote Code Execution"
 name_zh = "S2-048 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2017-9791"
+  [[container.cve]]
+  name = "CVE-2017-9791"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9791"
 path = "struts2/s2-048"
 
-[[containers]]
+[[container]]
 name_en = "S2-052 Remote Code Execution"
 name_zh = "S2-052 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2017-9805"
+  [[container.cve]]
+  name = "CVE-2017-9805"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9805"
 path = "struts2/s2-052"
 
-[[containers]]
+[[container]]
 name_en = "S2-053 Remote Code Execution"
 name_zh = "S2-053 远程代码执行漏洞"
 app = "Struts2"
-cve = "CVE-2017-12611"
+  [[container.cve]]
+  name = "CVE-2017-12611"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12611"
 path = "struts2/s2-053"
 
-[[containers]]
+[[container]]
 name_en = "Struts2 S2-057 Remote Command Execution"
 name_zh = "Struts2 S2-057 远程命令执行漏洞"
 app = "Struts2"
-cve = "CVE-2018-11776"
+  [[container.cve]]
+  name = "CVE-2018-11776"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-11776"
 path = "struts2/s2-057"
 
-[[containers]]
+[[container]]
 name_en = "Struts2 S2-059 Remote Command Execution"
 name_zh = "Struts2 S2-059 远程命令执行漏洞"
 app = "Struts2"
-cve = "CVE-2019-0230"
+  [[container.cve]]
+  name = "CVE-2019-0230"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0230"
 path = "struts2/s2-059"
 
-[[containers]]
+[[container]]
 name_en = "Struts2 S2-061 Remote Command Execution"
 name_zh = "Struts2 S2-061 远程命令执行漏洞"
 app = "Struts2"
-cve = "CVE-2020-17530"
+  [[container.cve]]
+  name = "CVE-2020-17530"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17530"
 path = "struts2/s2-061"
 
-[[containers]]
+[[container]]
 name_en = "Supervisord Remote Command Execution"
 name_zh = "Supervisord 远程命令执行漏洞"
 app = "Supervisor"
-cve = "CVE-2017-11610"
+  [[container.cve]]
+  name = "CVE-2017-11610"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-11610"
 path = "supervisor/CVE-2017-11610"
 
-[[containers]]
+[[container]]
 name_en = "ThinkPHP 2.x Arbitrary Code Execution"
 name_zh = "ThinkPHP 2.x 任意代码执行漏洞"
 app = "ThinkPHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "thinkphp/2-rce"
 
-[[containers]]
+[[container]]
 name_en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
 name_zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
 app = "ThinkPHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "thinkphp/5-rce"
 
-[[containers]]
+[[container]]
 name_en = "ThinkPHP5 5.0.23 Remote Code Execution"
 name_zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
 app = "ThinkPHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "thinkphp/5.0.23-rce"
 
-[[containers]]
+[[container]]
 name_en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
 name_zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
 app = "ThinkPHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "thinkphp/in-sqlinjection"
 
-[[containers]]
+[[container]]
 name_en = "ThinkPHP Multilingual Local File Inclusion"
 name_zh = "ThinkPHP 多语言本地文件包含漏洞"
 app = "ThinkPHP"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "thinkphp/lang-rce"
 
-[[containers]]
+[[container]]
 name_en = "Tiki Wiki CMS Groupware Authentication Bypass"
 name_zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
 app = "Tiki Wiki"
-cve = "CVE-2020-15906"
+  [[container.cve]]
+  name = "CVE-2020-15906"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-15906"
 path = "tikiwiki/CVE-2020-15906"
 
-[[containers]]
+[[container]]
 name_en = "Tomcat Arbitrary Writing of Files in the PUT Method"
 name_zh = "Tomcat PUT方法任意写文件漏洞"
 app = "Tomcat"
-cve = "CVE-2017-12615"
+  [[container.cve]]
+  name = "CVE-2017-12615"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12615"
 path = "tomcat/CVE-2017-12615"
 
-[[containers]]
+[[container]]
 name_en = "Apache Tomcat AJP Bug"
 name_zh = "Apache Tomcat AJP 文件包含漏洞"
 app = "Tomcat"
-cve = "CVE-2020-1938"
+  [[container.cve]]
+  name = "CVE-2020-1938"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1938"
 path = "tomcat/CVE-2020-1938"
 
-[[containers]]
+[[container]]
 name_en = "Tomcat Weak Password"
 name_zh = "Tomcat弱口令"
 app = "Tomcat"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "tomcat/tomcat8"
 
-[[containers]]
+[[container]]
 name_en = "Apache Unomi Remote Expression Code Execution"
 name_zh = "Apache Unomi 远程表达式代码执行漏洞"
 app = "unomi"
-cve = "CVE-2020-13942"
+  [[container.cve]]
+  name = "CVE-2020-13942"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13942"
 path = "unomi/CVE-2020-13942"
 
-[[containers]]
+[[container]]
 name_en = "uWSGI PHP Directory Traversal"
 name_zh = "uWSGI PHP目录穿越漏洞"
 app = "uWSGI"
-cve = "CVE-2018-7490"
+  [[container.cve]]
+  name = "CVE-2018-7490"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7490"
 path = "uwsgi/CVE-2018-7490"
 
-[[containers]]
+[[container]]
 name_en = "uWSGI Unauthorized Access"
 name_zh = "uWSGI 未授权访问漏洞"
 app = "uWSGI"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "uwsgi/unacc"
 
-[[containers]]
+[[container]]
 name_en = "V2board 1.6.1 Privilege Escalation"
 name_zh = "V2board 1.6.1 提权漏洞"
 app = "V2board"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "v2board/1.6-privilege-escalation"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
 name_zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
 app = "WebLogic"
-cve = "CVE-2017-10271"
+  [[container.cve]]
+  name = "CVE-2017-10271"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-10271"
 path = "weblogic/CVE-2017-10271"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic WLS Core Components Deserialization Command Execution"
 name_zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
 app = "WebLogic"
-cve = "CVE-2018-2628"
+  [[container.cve]]
+  name = "CVE-2018-2628"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2628"
 path = "weblogic/CVE-2018-2628"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic Arbitrary File Upload"
 name_zh = "WebLogic 任意文件上传漏洞"
 app = "WebLogic"
-cve = "CVE-2018-2894"
+  [[container.cve]]
+  name = "CVE-2018-2894"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2894"
 path = "weblogic/CVE-2018-2894"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic Management Console Unauthorized Remote Command Execution"
 name_zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
 app = "WebLogic"
-cve = "CVE-2020-14882"
+  [[container.cve]]
+  name = "CVE-2020-14882"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-14882"
 path = "weblogic/CVE-2020-14882"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic Unauthorized Remote Code Execution"
 name_zh = "WebLogic未授权远程代码执行漏洞"
 app = "WebLogic"
-cve = "CVE-2023-21839"
+  [[container.cve]]
+  name = "CVE-2023-21839"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-21839"
 path = "weblogic/CVE-2023-21839"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic SSRF"
 name_zh = "WebLogic SSRF漏洞"
 app = "WebLogic"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "weblogic/ssrf"
 
-[[containers]]
+[[container]]
 name_en = "WebLogic File Read"
 name_zh = "WebLogic 文件读取漏洞"
 app = "WebLogic"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "weblogic/weak_password"
 
-[[containers]]
+[[container]]
 name_en = "Webmin Remote Command Execution"
 name_zh = "Webmin 远程命令执行漏洞"
 app = "Webmin"
-cve = "CVE-2019-15107"
+  [[container.cve]]
+  name = "CVE-2019-15107"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-15107"
 path = "webmin/CVE-2019-15107"
 
-[[containers]]
+[[container]]
 name_en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
 name_zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
 app = "Wordpress"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "wordpress/pwnscriptum"
 
-[[containers]]
+[[container]]
 name_en = "XStream Deserialization Command Execution"
 name_zh = "XStream 反序列化命令执行漏洞"
 app = "XStream"
-cve = "CVE-2021-21351"
+  [[container.cve]]
+  name = "CVE-2021-21351"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-21351"
 path = "xstream/CVE-2021-21351"
 
-[[containers]]
+[[container]]
 name_en = "XStream Deserialization Command Execution"
 name_zh = "XStream 反序列化命令执行漏洞"
 app = "XStream"
-cve = "CVE-2021-29505"
+  [[container.cve]]
+  name = "CVE-2021-29505"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29505"
 path = "xstream/CVE-2021-29505"
 
-[[containers]]
+[[container]]
 name_en = "XXL-JOB Executor Unauthorized Access"
 name_zh = "XXL-JOB Executor 未授权访问漏洞"
 app = "xxl-job"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "xxl-job/unacc"
 
-[[containers]]
+[[container]]
 name_en = "YApi NoSQL Injection to Remote Command Execution"
 name_zh = "YApi NoSQL注入导致远程命令执行漏洞"
 app = "YApi"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "yapi/mongodb-inj"
 
-[[containers]]
+[[container]]
 name_en = "YApi Open Registration due to RCE"
 name_zh = "YApi开放注册导致RCE"
 app = "YApi"
-cve = ""
+  [[container.cve]]
+  name = ""
+  nvd = ""
 path = "yapi/unacc"
 
-[[containers]]
+[[container]]
 name_en = "Zabbix latest.php SQL Injection"
 name_zh = "Zabbix latest.php SQL注入漏洞"
 app = "Zabbix"
-cve = "CVE-2016-10134"
+  [[container.cve]]
+  name = "CVE-2016-10134"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-10134"
 path = "zabbix/CVE-2016-10134"
 
-[[containers]]
+[[container]]
 name_en = "Zabbix Server Trapper Command Injection"
 name_zh = "Zabbix Server Trapper命令注入漏洞"
 app = "Zabbix"
-cve = "CVE-2020-11800"
+  [[container.cve]]
+  name = "CVE-2020-11800"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11800"
 path = "zabbix/CVE-2020-11800"

--- a/environments.toml
+++ b/environments.toml
@@ -787,8 +787,8 @@ path = "gitlist/CVE-2018-1000533"
   zh = "gitlist 0.6.0 远程命令执行漏洞"
 
   [[container.cve]]
-  id = ""
-  nvd = ""
+  id = "CVE-2018-1000533"
+  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000533"
 
 [[container]]
 app = "GlassFish"

--- a/environments.toml
+++ b/environments.toml
@@ -1,2353 +1,2821 @@
 [[container]]
+app = "ActiveMQ"
+path = "activemq/CVE-2015-5254"
+
   [[container.name]]
   en = "Apache ActiveMQ Deserialization"
   zh = "Apache ActiveMQ 反序列化漏洞"
-app = "ActiveMQ"
+
   [[container.cve]]
   id = "CVE-2015-5254"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5254"
-path = "activemq/CVE-2015-5254"
 
 [[container]]
+app = "ActiveMQ"
+path = "activemq/CVE-2016-3088"
+
   [[container.name]]
   en = "Apache ActiveMQ Arbitrary File Write"
   zh = "Apache ActiveMQ 任意文件写入漏洞"
-app = "ActiveMQ"
+
   [[container.cve]]
   id = "CVE-2016-3088"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3088"
-path = "activemq/CVE-2016-3088"
 
 [[container]]
+app = "Airflow"
+path = "airflow/CVE-2020-11978"
+
   [[container.name]]
   en = "Apache Airflow Command Injection"
   zh = "Apache Airflow 示例dag中的命令注入"
-app = "Airflow"
+
   [[container.cve]]
   id = "CVE-2020-11978"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11978"
-path = "airflow/CVE-2020-11978"
 
 [[container]]
+app = "Airflow"
+path = "airflow/CVE-2020-11981"
+
   [[container.name]]
   en = "Apache Airflow Celery Message Middleware Command Execution"
   zh = "Apache Airflow Celery 消息中间件命令执行"
-app = "Airflow"
+
   [[container.cve]]
   id = "CVE-2020-11981"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11981"
-path = "airflow/CVE-2020-11981"
 
 [[container]]
+app = "Airflow"
+path = "airflow/CVE-2020-17526"
+
   [[container.name]]
   en = "Apache Airflow Permission Bypass"
   zh = "Apache Airflow 默认密钥导致的权限绕过"
-app = "Airflow"
+
   [[container.cve]]
   id = "CVE-2020-17526"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17526"
-path = "airflow/CVE-2020-17526"
 
 [[container]]
+app = "Apache Druid"
+path = "apache-druid/CVE-2021-25646"
+
   [[container.name]]
   en = "Apache Druid Code Execution"
   zh = "Apache Druid 代码执行漏洞"
-app = "Apache Druid"
+
   [[container.cve]]
   id = "CVE-2021-25646"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-25646"
-path = "apache-druid/CVE-2021-25646"
 
 [[container]]
+app = "Apereo CAS"
+path = "apereo-cas/4.1-rce"
+
   [[container.name]]
   en = "Apereo CAS 4.1 Deserialization Command Execution"
   zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
-app = "Apereo CAS"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "apereo-cas/4.1-rce"
 
 [[container]]
+app = "Apache APISIX"
+path = "apisix/CVE-2020-13945"
+
   [[container.name]]
   en = "Apache APISIX Default Key"
   zh = "Apache APISIX 默认密钥漏洞"
-app = "Apache APISIX"
+
   [[container.cve]]
   id = "CVE-2020-13945"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13945"
-path = "apisix/CVE-2020-13945"
 
 [[container]]
+app = "Apache APISIX"
+path = "apisix/CVE-2021-45232"
+
   [[container.name]]
   en = "Apache APISIX Dashboard API Permission Bypass to RCE"
   zh = "Apache APISIX Dashboard API权限绕过导致RCE"
-app = "Apache APISIX"
+
   [[container.cve]]
   id = "CVE-2021-45232"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-45232"
-path = "apisix/CVE-2021-45232"
 
 [[container]]
+app = "AppWeb"
+path = "appweb/CVE-2018-8715"
+
   [[container.name]]
   en = "AppWeb Authentication Bypass"
   zh = "AppWeb 认证绕过漏洞"
-app = "AppWeb"
+
   [[container.cve]]
   id = "CVE-2018-8715"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-8715"
-path = "appweb/CVE-2018-8715"
 
 [[container]]
+app = "Aria2"
+path = "aria2/rce"
+
   [[container.name]]
   en = "Aria2 Arbitrary File Write"
   zh = "Aria2 任意文件写入漏洞"
-app = "Aria2"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "aria2/rce"
 
 [[container]]
+app = "bash"
+path = "bash/CVE-2014-6271"
+
   [[container.name]]
   en = "Bash Shellshock Shell Exploit"
   zh = "Bash Shellshock 破壳漏洞"
-app = "bash"
+
   [[container.cve]]
   id = "CVE-2014-6271"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-6271"
-path = "bash/CVE-2014-6271"
 
 [[container]]
+app = "cacti"
+path = "cacti/CVE-2022-46169"
+
   [[container.name]]
   en = "Cacti Foreground Command Injection"
   zh = "Cacti 前台命令注入漏洞"
-app = "cacti"
+
   [[container.cve]]
   id = "CVE-2022-46169"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-46169"
-path = "cacti/CVE-2022-46169"
 
 [[container]]
+app = "celery"
+path = "celery/celery3_redis_unauth"
+
   [[container.name]]
   en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
   zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
-app = "celery"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "celery/celery3_redis_unauth"
 
 [[container]]
+app = "cgi"
+path = "cgi/CVE-2016-5385"
+
   [[container.name]]
   en = "CGI HTTPoxy Flaw"
   zh = "CGI HTTPoxy 漏洞"
-app = "cgi"
+
   [[container.cve]]
   id = "CVE-2016-5385"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5385"
-path = "cgi/CVE-2016-5385"
 
 [[container]]
+app = "Adobe ColdFusion"
+path = "coldfusion/CVE-2010-2861"
+
   [[container.name]]
   en = "Adobe ColdFusion File Read"
   zh = "Adobe ColdFusion 文件读取漏洞"
-app = "Adobe ColdFusion"
+
   [[container.cve]]
   id = "CVE-2010-2861"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-2861"
-path = "coldfusion/CVE-2010-2861"
 
 [[container]]
+app = "Adobe ColdFusion"
+path = "coldfusion/CVE-2017-3066"
+
   [[container.name]]
   en = "Adobe ColdFusion Deserialization"
   zh = "Adobe ColdFusion 反序列化漏洞"
-app = "Adobe ColdFusion"
+
   [[container.cve]]
   id = "CVE-2017-3066"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-3066"
-path = "coldfusion/CVE-2017-3066"
 
 [[container]]
+app = "Atlassian Confluence"
+path = "confluence/CVE-2019-3396"
+
   [[container.name]]
   en = "Atlassian Confluence Path Traversal and Command Execution"
   zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
-app = "Atlassian Confluence"
+
   [[container.cve]]
   id = "CVE-2019-3396"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-3396"
-path = "confluence/CVE-2019-3396"
 
 [[container]]
+app = "Atlassian Confluence"
+path = "confluence/CVE-2021-26084"
+
   [[container.name]]
   en = "Atlassian Confluence OGNL Expression Injection Code Execution"
   zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
-app = "Atlassian Confluence"
+
   [[container.cve]]
   id = "CVE-2021-26084"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-26084"
-path = "confluence/CVE-2021-26084"
 
 [[container]]
+app = "Atlassian Confluence"
+path = "confluence/CVE-2022-26134"
+
   [[container.name]]
   en = "Atlassian Confluence OGNL Expression Injection Command Execution"
   zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
-app = "Atlassian Confluence"
+
   [[container.cve]]
   id = "CVE-2022-26134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-26134"
-path = "confluence/CVE-2022-26134"
 
 [[container]]
+app = "CouchDB"
+path = "couchdb/CVE-2017-12635"
+
   [[container.name]]
   en = "CouchDB Vertical Permission Bypass"
   zh = "CouchDB 垂直权限绕过漏洞"
-app = "CouchDB"
+
   [[container.cve]]
   id = "CVE-2017-12635"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12635"
-path = "couchdb/CVE-2017-12635"
 
 [[container]]
+app = "CouchDB"
+path = "couchdb/CVE-2017-12636"
+
   [[container.name]]
   en = "CouchDB Arbitrary Command Execution"
   zh = "CouchDB 任意命令执行漏洞"
-app = "CouchDB"
+
   [[container.cve]]
   id = "CVE-2017-12636"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12636"
-path = "couchdb/CVE-2017-12636"
 
 [[container]]
+app = "CouchDB"
+path = "couchdb/CVE-2022-24706"
+
   [[container.name]]
   en = "CouchDB Erlang Distributed Protocol Code Execution"
   zh = "CouchDB Erlang 分布式协议代码执行"
-app = "CouchDB"
+
   [[container.cve]]
   id = "CVE-2022-24706"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-24706"
-path = "couchdb/CVE-2022-24706"
 
 [[container]]
+app = "Discuz"
+path = "discuz/wooyun-2010-080723"
+
   [[container.name]]
   en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
   zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
-app = "Discuz"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "discuz/wooyun-2010-080723"
 
 [[container]]
+app = "Discuz"
+path = "discuz/x3.4-arbitrary-file-deletion"
+
   [[container.name]]
   en = "Discuz!X ≤3.4 Arbitrary File Deletion"
   zh = "Discuz!X ≤3.4 任意文件删除漏洞"
-app = "Discuz"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "discuz/x3.4-arbitrary-file-deletion"
 
 [[container]]
+app = "Django"
+path = "django/CVE-2017-12794"
+
   [[container.name]]
   en = "Django debug page XSS Flaw"
   zh = "Django debug page XSS 漏洞"
-app = "Django"
+
   [[container.cve]]
   id = "CVE-2017-12794"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12794"
-path = "django/CVE-2017-12794"
 
 [[container]]
+app = "Django"
+path = "django/CVE-2018-14574"
+
   [[container.name]]
   en = "Django < 2.0.8 Arbitrary URL Redirection"
   zh = "Django < 2.0.8 任意URL跳转漏洞"
-app = "Django"
+
   [[container.cve]]
   id = "CVE-2018-14574"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-14574"
-path = "django/CVE-2018-14574"
 
 [[container]]
+app = "Django"
+path = "django/CVE-2019-14234"
+
   [[container.name]]
   en = "Django JSONField/HStoreField SQL Injection"
   zh = "Django JSONField/HStoreField SQL注入漏洞"
-app = "Django"
+
   [[container.cve]]
   id = "CVE-2019-14234"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-14234"
-path = "django/CVE-2019-14234"
 
 [[container]]
+app = "Django"
+path = "django/CVE-2020-9402"
+
   [[container.name]]
   en = "Django GIS SQL Injection"
   zh = "Django GIS SQL注入漏洞"
-app = "Django"
+
   [[container.cve]]
   id = "CVE-2020-9402"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9402"
-path = "django/CVE-2020-9402"
 
 [[container]]
+app = "Django"
+path = "django/CVE-2021-35042"
+
   [[container.name]]
   en = "Django QuerySet.order_by() SQL Injection"
   zh = "Django QuerySet.order_by() SQL注入漏洞"
-app = "Django"
+
   [[container.cve]]
   id = "CVE-2021-35042"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-35042"
-path = "django/CVE-2021-35042"
 
 [[container]]
+app = "Django"
+path = "django/CVE-2022-34265"
+
   [[container.name]]
   en = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
   zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
-app = "Django"
+
   [[container.cve]]
   id = "CVE-2022-34265"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-34265"
-path = "django/CVE-2022-34265"
 
 [[container]]
+app = "dns"
+path = "dns/dns-zone-transfer"
+
   [[container.name]]
   en = "DNS Domain Transfer"
   zh = "DNS域传送漏洞"
-app = "dns"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "dns/dns-zone-transfer"
 
 [[container]]
+app = "docker"
+path = "docker/unauthorized-rce"
+
   [[container.name]]
   en = "Docker Daemon API Unauthorized Access"
   zh = "Docker Daemon API 未授权访问漏洞"
-app = "docker"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "docker/unauthorized-rce"
 
 [[container]]
+app = "drupal"
+path = "drupal/CVE-2014-3704"
+
   [[container.name]]
   en = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
   zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
-app = "drupal"
+
   [[container.cve]]
   id = "CVE-2014-3704"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3704"
-path = "drupal/CVE-2014-3704"
 
 [[container]]
+app = "drupal"
+path = "drupal/CVE-2017-6920"
+
   [[container.name]]
   en = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
   zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
-app = "drupal"
+
   [[container.cve]]
   id = "CVE-2017-6920"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-6920"
-path = "drupal/CVE-2017-6920"
 
 [[container]]
+app = "drupal"
+path = "drupal/CVE-2018-7600"
+
   [[container.name]]
   en = "Drupal Drupalgeddon 2 Remote Code Execution"
   zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
-app = "drupal"
+
   [[container.cve]]
   id = "CVE-2018-7600"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7600"
-path = "drupal/CVE-2018-7600"
 
 [[container]]
+app = "drupal"
+path = "drupal/CVE-2018-7602"
+
   [[container.name]]
   en = "Drupal Remote Code Execution"
   zh = "Drupal 远程代码执行漏洞"
-app = "drupal"
+
   [[container.cve]]
   id = "CVE-2018-7602"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7602"
-path = "drupal/CVE-2018-7602"
 
 [[container]]
+app = "drupal"
+path = "drupal/CVE-2019-6339"
+
   [[container.name]]
   en = "Drupal Remote Code Execution"
   zh = "Drupal 远程代码执行漏洞"
-app = "drupal"
+
   [[container.cve]]
   id = "CVE-2019-6339"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6339"
-path = "drupal/CVE-2019-6339"
 
 [[container]]
+app = "drupal"
+path = "drupal/CVE-2019-6341"
+
   [[container.name]]
   en = "Drupal XSS"
   zh = "Drupal XSS漏洞"
-app = "drupal"
+
   [[container.cve]]
   id = "CVE-2019-6341"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6341"
-path = "drupal/CVE-2019-6341"
 
 [[container]]
+app = "dubbo"
+path = "dubbo/CVE-2019-17564"
+
   [[container.name]]
   en = "Apache Dubbo Java Deserialization"
   zh = "Apache Dubbo Java反序列化漏洞"
-app = "dubbo"
+
   [[container.cve]]
   id = "CVE-2019-17564"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17564"
-path = "dubbo/CVE-2019-17564"
 
 [[container]]
+app = "ecshop"
+path = "ecshop/collection_list-sqli"
+
   [[container.name]]
   en = "ECShop 4.x collection_list SQL Injection"
   zh = "ECShop 4.x collection_list SQL注入"
-app = "ecshop"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "ecshop/collection_list-sqli"
 
 [[container]]
+app = "ecshop"
+path = "ecshop/xianzhi-2017-02-82239600"
+
   [[container.name]]
   en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
   zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
-app = "ecshop"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "ecshop/xianzhi-2017-02-82239600"
 
 [[container]]
+app = "ElasticSearch"
+path = "elasticsearch/CVE-2014-3120"
+
   [[container.name]]
   en = "ElasticSearch Command Execution"
   zh = "ElasticSearch 命令执行漏洞"
-app = "ElasticSearch"
+
   [[container.cve]]
   id = "CVE-2014-3120"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3120"
-path = "elasticsearch/CVE-2014-3120"
 
 [[container]]
+app = "ElasticSearch"
+path = "elasticsearch/CVE-2015-1427"
+
   [[container.name]]
   en = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
   zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
-app = "ElasticSearch"
+
   [[container.cve]]
   id = "CVE-2015-1427"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-1427"
-path = "elasticsearch/CVE-2015-1427"
 
 [[container]]
+app = "ElasticSearch"
+path = "elasticsearch/CVE-2015-3337"
+
   [[container.name]]
   en = "ElasticSearch Plug-in Directory Traversal"
   zh = "ElasticSearch 插件目录穿越漏洞"
-app = "ElasticSearch"
+
   [[container.cve]]
   id = "CVE-2015-3337"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-3337"
-path = "elasticsearch/CVE-2015-3337"
 
 [[container]]
+app = "ElasticSearch"
+path = "elasticsearch/CVE-2015-5531"
+
   [[container.name]]
   en = "ElasticSearch Directory Traversal"
   zh = "ElasticSearch 目录穿越漏洞"
-app = "ElasticSearch"
+
   [[container.cve]]
   id = "CVE-2015-5531"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5531"
-path = "elasticsearch/CVE-2015-5531"
 
 [[container]]
+app = "ElasticSearch"
+path = "elasticsearch/WooYun-2015-110216"
+
   [[container.name]]
   en = "Elasticsearch Webshell"
   zh = "Elasticsearch 写入webshell漏洞"
-app = "ElasticSearch"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "elasticsearch/WooYun-2015-110216"
 
 [[container]]
+app = "electron"
+path = "electron/CVE-2018-1000006"
+
   [[container.name]]
   en = "Electron Remote Command Execution"
   zh = "Electron 远程命令执行漏洞"
-app = "electron"
+
   [[container.cve]]
   id = "CVE-2018-1000006"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000006"
-path = "electron/CVE-2018-1000006"
 
 [[container]]
+app = "electron"
+path = "electron/CVE-2018-15685"
+
   [[container.name]]
   en = "Electron WebPreferences Remote Command Execution"
   zh = "Electron WebPreferences 远程命令执行漏洞"
-app = "electron"
+
   [[container.cve]]
   id = "CVE-2018-15685"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15685"
-path = "electron/CVE-2018-15685"
 
 [[container]]
+app = "elFinder"
+path = "elfinder/CVE-2021-32682"
+
   [[container.name]]
   en = "elFinder ZIP Parameter and Arbitrary Command Injection"
   zh = "elFinder ZIP 参数与任意命令注入"
-app = "elFinder"
+
   [[container.cve]]
   id = "CVE-2021-32682"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-32682"
-path = "elfinder/CVE-2021-32682"
 
 [[container]]
+app = "Fastjson"
+path = "fastjson/1.2.24-rce"
+
   [[container.name]]
   en = "Fastjson Deserialization to Arbitrary Command Execution"
   zh = "Fastjson 反序列化导致任意命令执行漏洞"
-app = "Fastjson"
+
   [[container.cve]]
   id = "CVE-2017-18349"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-18349"
-path = "fastjson/1.2.24-rce"
 
 [[container]]
+app = "Fastjson"
+path = "fastjson/1.2.47-rce"
+
   [[container.name]]
   en = "Fastjson 1.2.47 Remote Command Execution"
   zh = "Fastjson 1.2.47 远程命令执行漏洞"
-app = "Fastjson"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "fastjson/1.2.47-rce"
 
 [[container]]
+app = "ffmpeg"
+path = "ffmpeg/CVE-2016-1897"
+
   [[container.name]]
   en = "FFmpeg Arbitrary File Read/SSRF"
   zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
-app = "ffmpeg"
+
   [[container.cve]]
   id = "CVE-2016-1897,CVE-2016-1898"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-1897,CVE-2016-1898"
-path = "ffmpeg/CVE-2016-1897"
 
 [[container]]
+app = "ffmpeg"
+path = "ffmpeg/phdays"
+
   [[container.name]]
   en = "FFmpeg Arbitrary File Read"
   zh = "FFmpeg 任意文件读取漏洞"
-app = "ffmpeg"
+
   [[container.cve]]
   id = "CVE-2017-9993"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9993"
-path = "ffmpeg/phdays"
 
 [[container]]
+app = "Jinja2"
+path = "flask/ssti"
+
   [[container.name]]
   en = "Jinja2 SSTI Template Injection"
   zh = "Jinja2 SSTI模板注入"
-app = "Jinja2"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "flask/ssti"
 
 [[container]]
+app = "flink"
+path = "flink/CVE-2020-17518"
+
   [[container.name]]
   en = "Apache Flink File Upload"
   zh = "Apache Flink 文件上传漏洞"
-app = "flink"
+
   [[container.cve]]
   id = "CVE-2020-17518"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17518"
-path = "flink/CVE-2020-17518"
 
 [[container]]
+app = "flink"
+path = "flink/CVE-2020-17519"
+
   [[container.name]]
   en = "Apache Flink Jobmanager/Logs Directory Traversal"
   zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
-app = "flink"
+
   [[container.cve]]
   id = "CVE-2020-17519"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17519"
-path = "flink/CVE-2020-17519"
 
 [[container]]
+app = "GeoServer"
+path = "geoserver/CVE-2023-25157"
+
   [[container.name]]
   en = "GeoServer OGC Filter SQL Injection"
   zh = "GeoServer OGC Filter SQL注入漏洞"
-app = "GeoServer"
+
   [[container.cve]]
   id = "CVE-2023-25157"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25157"
-path = "geoserver/CVE-2023-25157"
 
 [[container]]
+app = "ghostscript"
+path = "ghostscript/CVE-2018-16509"
+
   [[container.name]]
   en = "GhostScript Sandbox Bypass (Command Execution)"
   zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
-app = "ghostscript"
+
   [[container.cve]]
   id = "CVE-2018-16509"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
-path = "ghostscript/CVE-2018-16509"
 
 [[container]]
+app = "ghostscript"
+path = "ghostscript/CVE-2018-19475"
+
   [[container.name]]
   en = "GhostScript Sandbox Bypass (Command Execution)"
   zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
-app = "ghostscript"
+
   [[container.cve]]
   id = "CVE-2018-19475"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19475"
-path = "ghostscript/CVE-2018-19475"
 
 [[container]]
+app = "ghostscript"
+path = "ghostscript/CVE-2019-6116"
+
   [[container.name]]
   en = "GhostScript Sandbox Bypass (Command Execution)"
   zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
-app = "ghostscript"
+
   [[container.cve]]
   id = "CVE-2019-6116"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6116"
-path = "ghostscript/CVE-2019-6116"
 
 [[container]]
+app = "git"
+path = "git/CVE-2017-8386"
+
   [[container.name]]
   en = "GIT-SHELL Sandbox Bypass"
   zh = "GIT-SHELL 沙盒绕过"
-app = "git"
+
   [[container.cve]]
   id = "CVE-2017-8386"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8386"
-path = "git/CVE-2017-8386"
 
 [[container]]
+app = "gitea"
+path = "gitea/1.4-rce"
+
   [[container.name]]
   en = "Gitea 1.4.0 Directory Traversal to Command Execution"
   zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
-app = "gitea"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "gitea/1.4-rce"
 
 [[container]]
+app = "gitlab"
+path = "gitlab/CVE-2016-9086"
+
   [[container.name]]
   en = "GitLab Arbitrary File Read"
   zh = "GitLab 任意文件读取漏洞"
-app = "gitlab"
+
   [[container.cve]]
   id = "CVE-2016-9086"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-9086"
-path = "gitlab/CVE-2016-9086"
 
 [[container]]
+app = "gitlab"
+path = "gitlab/CVE-2021-22205"
+
   [[container.name]]
   en = "GitLab Remote Command Execution"
   zh = "GitLab 远程命令执行漏洞"
-app = "gitlab"
+
   [[container.cve]]
   id = "CVE-2021-22205"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22205"
-path = "gitlab/CVE-2021-22205"
 
 [[container]]
+app = "gitlist"
+path = "gitlist/0.6.0-rce"
+
   [[container.name]]
   en = "gitlist 0.6.0 Remote Command Execution"
   zh = "gitlist 0.6.0 远程命令执行漏洞"
-app = "gitlist"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "gitlist/0.6.0-rce"
 
 [[container]]
+app = "GlassFish"
+path = "glassfish/4.1.0"
+
   [[container.name]]
   en = "GlassFish Arbitrary File Read"
   zh = "GlassFish 任意文件读取漏洞"
-app = "GlassFish"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "glassfish/4.1.0"
 
 [[container]]
+app = "GoAhead"
+path = "goahead/CVE-2017-17562"
+
   [[container.name]]
   en = "GoAhead Remote Command Execution"
   zh = "GoAhead 远程命令执行漏洞"
-app = "GoAhead"
+
   [[container.cve]]
   id = "CVE-2017-17562"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17562"
-path = "goahead/CVE-2017-17562"
 
 [[container]]
+app = "GoAhead"
+path = "goahead/CVE-2021-42342"
+
   [[container.name]]
   en = "GoAhead Server Environment Variable Injection"
   zh = "GoAhead Server 环境变量注入"
-app = "GoAhead"
+
   [[container.cve]]
   id = "CVE-2021-42342"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42342"
-path = "goahead/CVE-2021-42342"
 
 [[container]]
+app = "Gogs"
+path = "gogs/CVE-2018-18925"
+
   [[container.name]]
   en = "Gogs Arbitrary User Login"
   zh = "Gogs 任意用户登录漏洞"
-app = "Gogs"
+
   [[container.cve]]
   id = "CVE-2018-18925"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18925"
-path = "gogs/CVE-2018-18925"
 
 [[container]]
+app = "Grafana"
+path = "grafana/CVE-2021-43798"
+
   [[container.name]]
   en = "Grafana 8.x Plug-in Module Directory Traversal"
   zh = "Grafana 8.x 插件模块目录穿越漏洞"
-app = "Grafana"
+
   [[container.cve]]
   id = "CVE-2021-43798"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-43798"
-path = "grafana/CVE-2021-43798"
 
 [[container]]
+app = "Grafana"
+path = "grafana/admin-ssrf"
+
   [[container.name]]
   en = "Grafana Management Background SSRF"
   zh = "Grafana管理后台SSRF"
-app = "Grafana"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "grafana/admin-ssrf"
 
 [[container]]
+app = "Springboot H2 Database"
+path = "h2database/h2-console-unacc"
+
   [[container.name]]
   en = "H2 Database Console Unauthorized Access"
   zh = "H2 Database Console 未授权访问"
-app = "Springboot H2 Database"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "h2database/h2-console-unacc"
 
 [[container]]
+app = "Hadoop YARN"
+path = "hadoop/unauthorized-yarn"
+
   [[container.name]]
   en = "Hadoop YARN ResourceManager Unauthorized Access"
   zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
-app = "Hadoop YARN"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "hadoop/unauthorized-yarn"
 
 [[container]]
+app = "Apache HTTP Server"
+path = "httpd/CVE-2017-15715"
+
   [[container.name]]
   en = "Apache HTTPD Newline Parsing"
   zh = "Apache HTTPD 换行解析漏洞"
-app = "Apache HTTP Server"
+
   [[container.cve]]
   id = "CVE-2017-15715"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-15715"
-path = "httpd/CVE-2017-15715"
 
 [[container]]
+app = "Apache HTTP Server"
+path = "httpd/CVE-2021-40438"
+
   [[container.name]]
   en = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
   zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
-app = "Apache HTTP Server"
+
   [[container.cve]]
   id = "CVE-2021-40438"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-40438"
-path = "httpd/CVE-2021-40438"
 
 [[container]]
+app = "Apache HTTP Server"
+path = "httpd/CVE-2021-41773"
+
   [[container.name]]
   en = "Apache HTTP Server 2.4.49 Path Traversal"
   zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
-app = "Apache HTTP Server"
+
   [[container.cve]]
   id = "CVE-2021-41773"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41773"
-path = "httpd/CVE-2021-41773"
 
 [[container]]
+app = "Apache HTTP Server"
+path = "httpd/CVE-2021-42013"
+
   [[container.name]]
   en = "Apache HTTP Server 2.4.50 Path Traversal"
   zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
-app = "Apache HTTP Server"
+
   [[container.cve]]
   id = "CVE-2021-42013"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42013"
-path = "httpd/CVE-2021-42013"
 
 [[container]]
+app = "Apache HTTP Server"
+path = "httpd/apache_parsing_vulnerability"
+
   [[container.name]]
   en = "Apache HTTPD Unknown Suffix Parsing"
   zh = "Apache HTTPD 未知后缀解析漏洞"
-app = "Apache HTTP Server"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "httpd/apache_parsing_vulnerability"
 
 [[container]]
+app = "Apache HTTP Server"
+path = "httpd/ssi-rce"
+
   [[container.name]]
   en = "Apache SSI Remote Command Execution"
   zh = "Apache SSI 远程命令执行漏洞"
-app = "Apache HTTP Server"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "httpd/ssi-rce"
 
 [[container]]
+app = "ImageMagick"
+path = "imagemagick/imagetragick"
+
   [[container.name]]
   en = "Imagetragick Command Execution"
   zh = "Imagetragick 命令执行漏洞"
-app = "ImageMagick"
+
   [[container.cve]]
   id = "CVE-2016-3714"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3714"
-path = "imagemagick/imagetragick"
 
 [[container]]
+app = "imagemagick"
+path = "imagemagick/CVE-2020-29599"
+
   [[container.name]]
   en = "ImageMagick PDF Password Location Command Injection"
   zh = "ImageMagick PDF密码位置命令注入漏洞"
-app = "imagemagick"
+
   [[container.cve]]
   id = "CVE-2020-29599"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-29599"
-path = "imagemagick/CVE-2020-29599"
 
 [[container]]
+app = "imagemagick"
+path = "imagemagick/CVE-2022-44268"
+
   [[container.name]]
   en = "ImageMagick Arbitrary File Read"
   zh = "ImageMagick任意文件读取漏洞"
-app = "imagemagick"
+
   [[container.cve]]
   id = "CVE-2022-44268"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-44268"
-path = "imagemagick/CVE-2022-44268"
 
 [[container]]
+app = "InfluxDB"
+path = "influxdb/CVE-2019-20933"
+
   [[container.name]]
   en = "InfluxDB Empty JWT Secret Key Authentication Bypass"
   zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
-app = "InfluxDB"
+
   [[container.cve]]
   id = "CVE-2019-20933"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-20933"
-path = "influxdb/CVE-2019-20933"
 
 [[container]]
+app = "Jackson-databind"
+path = "jackson/CVE-2017-7525"
+
   [[container.name]]
   en = "Jackson-databind Deserialization"
   zh = "Jackson-databind 反序列化漏洞"
-app = "Jackson-databind"
+
   [[container.cve]]
   id = "CVE-2017-7525"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
-path = "jackson/CVE-2017-7525"
 
 [[container]]
+app = "java rmi"
+path = "java/rmi-codebase"
+
   [[container.name]]
   en = "Java RMI codebase Remote Code Execution"
   zh = "Java RMI codebase 远程代码执行漏洞"
-app = "java rmi"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "java/rmi-codebase"
 
 [[container]]
+app = "java rmi"
+path = "java/rmi-registry-bind-deserialization"
+
   [[container.name]]
   en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
   zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
-app = "java rmi"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "java/rmi-registry-bind-deserialization"
 
 [[container]]
+app = "java rmi"
+path = "java/rmi-registry-bind-deserialization-bypass"
+
   [[container.name]]
   en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
   zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
-app = "java rmi"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "java/rmi-registry-bind-deserialization-bypass"
 
 [[container]]
+app = "jboss"
+path = "jboss/CVE-2017-12149"
+
   [[container.name]]
   en = "JBoss 5.x/6.x Deserialization"
   zh = "JBoss 5.x/6.x 反序列化漏洞"
-app = "jboss"
+
   [[container.cve]]
   id = "CVE-2017-12149"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12149"
-path = "jboss/CVE-2017-12149"
 
 [[container]]
+app = "jboss"
+path = "jboss/CVE-2017-7504"
+
   [[container.name]]
   en = "JBoss 4.x JBossMQ JMS Deserialization"
   zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
-app = "jboss"
+
   [[container.cve]]
   id = "CVE-2017-7504"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7504"
-path = "jboss/CVE-2017-7504"
 
 [[container]]
+app = "jboss"
+path = "jboss/JMXInvokerServlet-deserialization"
+
   [[container.name]]
   en = "JBoss JMXInvokerServlet Deserialization"
   zh = "JBoss JMXInvokerServlet 反序列化漏洞"
-app = "jboss"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "jboss/JMXInvokerServlet-deserialization"
 
 [[container]]
+app = "Jenkins"
+path = "jenkins/CVE-2017-1000353"
+
   [[container.name]]
   en = "Jenkins-CI Remote Code Execution"
   zh = "Jenkins-CI 远程代码执行漏洞"
-app = "Jenkins"
+
   [[container.cve]]
   id = "CVE-2017-1000353"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-1000353"
-path = "jenkins/CVE-2017-1000353"
 
 [[container]]
+app = "Jenkins"
+path = "jenkins/CVE-2018-1000861"
+
   [[container.name]]
   en = "Jenkins Remote Command Execution"
   zh = "Jenkins远程命令执行漏洞"
-app = "Jenkins"
+
   [[container.cve]]
   id = "CVE-2018-1000861"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000861"
-path = "jenkins/CVE-2018-1000861"
 
 [[container]]
+app = "jetty"
+path = "jetty/CVE-2021-28164"
+
   [[container.name]]
   en = "Jetty WEB-INF Sensitive Information Disclosure"
   zh = "Jetty WEB-INF 敏感信息泄露漏洞"
-app = "jetty"
+
   [[container.cve]]
   id = "CVE-2021-28164"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28164"
-path = "jetty/CVE-2021-28164"
 
 [[container]]
+app = "jetty"
+path = "jetty/CVE-2021-28169"
+
   [[container.name]]
   en = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
   zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
-app = "jetty"
+
   [[container.cve]]
   id = "CVE-2021-28169"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28169"
-path = "jetty/CVE-2021-28169"
 
 [[container]]
+app = "jetty"
+path = "jetty/CVE-2021-34429"
+
   [[container.name]]
   en = "Jetty WEB-INF Sensitive Information Disclosure"
   zh = "Jetty WEB-INF 敏感信息泄露漏洞"
-app = "jetty"
+
   [[container.cve]]
   id = "CVE-2021-34429"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34429"
-path = "jetty/CVE-2021-34429"
 
 [[container]]
+app = "jira"
+path = "jira/CVE-2019-11581"
+
   [[container.name]]
   en = "Atlassian Jira Template Injection"
   zh = "Atlassian Jira 模板注入漏洞"
-app = "jira"
+
   [[container.cve]]
   id = "CVE-2019-11581"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11581"
-path = "jira/CVE-2019-11581"
 
 [[container]]
+app = "Apache Jmeter"
+path = "jmeter/CVE-2018-1297"
+
   [[container.name]]
   en = "Jmeter RMI Deserialization Command Execution"
   zh = "Jmeter RMI 反序列化命令执行漏洞"
-app = "Apache Jmeter"
+
   [[container.cve]]
   id = "CVE-2018-1297"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1297"
-path = "jmeter/CVE-2018-1297"
 
 [[container]]
+app = "Joomla"
+path = "joomla/CVE-2015-8562"
+
   [[container.name]]
   en = "Joomla 3.4.5 Deserialization"
   zh = "Joomla 3.4.5 反序列化漏洞"
-app = "Joomla"
+
   [[container.cve]]
   id = "CVE-2015-8562"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-8562"
-path = "joomla/CVE-2015-8562"
 
 [[container]]
+app = "Joomla"
+path = "joomla/CVE-2017-8917"
+
   [[container.name]]
   en = "Joomla 3.7.0 SQL Injection"
   zh = "Joomla 3.7.0 SQL注入漏洞"
-app = "Joomla"
+
   [[container.cve]]
   id = "CVE-2017-8917"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8917"
-path = "joomla/CVE-2017-8917"
 
 [[container]]
+app = "Joomla"
+path = "joomla/CVE-2023-23752"
+
   [[container.name]]
   en = "Joomla 4.2.7 Permission Bypass"
   zh = "Joomla 4.2.7 权限绕过漏洞"
-app = "Joomla"
+
   [[container.cve]]
   id = "CVE-2023-23752"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-23752"
-path = "joomla/CVE-2023-23752"
 
 [[container]]
+app = "Jupyter"
+path = "jupyter/notebook-rce"
+
   [[container.name]]
   en = "Jupyter Notebook Unauthorized Access"
   zh = "Jupyter Notebook 未授权访问漏洞"
-app = "Jupyter"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "jupyter/notebook-rce"
 
 [[container]]
+app = "Apache Kafka"
+path = "kafka/CVE-2023-25194"
+
   [[container.name]]
   en = "Apache Kafka Clients JNDI Injection"
   zh = "Apache Kafka Clients JNDI注入漏洞"
-app = "Apache Kafka"
+
   [[container.cve]]
   id = "CVE-2023-25194"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25194"
-path = "kafka/CVE-2023-25194"
 
 [[container]]
+app = "kibana"
+path = "kibana/CVE-2018-17246"
+
   [[container.name]]
   en = "Kibana Local File Inclusion"
   zh = "Kibana 本地文件包含漏洞"
-app = "kibana"
+
   [[container.cve]]
   id = "CVE-2018-17246"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-17246"
-path = "kibana/CVE-2018-17246"
 
 [[container]]
+app = "kibana"
+path = "kibana/CVE-2019-7609"
+
   [[container.name]]
   en = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
   zh = "Kibana 原型链污染导致任意代码执行漏洞"
-app = "kibana"
+
   [[container.cve]]
   id = "CVE-2019-7609"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7609"
-path = "kibana/CVE-2019-7609"
 
 [[container]]
+app = "laravel"
+path = "kibana/CVE-2021-3129"
+
   [[container.name]]
   en = "Laravel Ignition 2.5.1 Code Execution"
   zh = "Laravel Ignition 2.5.1 代码执行漏洞"
-app = "laravel"
+
   [[container.cve]]
   id = "CVE-2021-3129"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-3129"
-path = "kibana/CVE-2021-3129"
 
 [[container]]
+app = "libssh"
+path = "libssh/CVE-2018-10933"
+
   [[container.name]]
   en = "libssh Server-side Authentication Bypass"
   zh = "libssh 服务端权限认证绕过漏洞"
-app = "libssh"
+
   [[container.cve]]
   id = "CVE-2018-10933"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-10933"
-path = "libssh/CVE-2018-10933"
 
 [[container]]
+app = "Liferay Portal"
+path = "liferay-portal/CVE-2020-7961"
+
   [[container.name]]
   en = "Liferay Portal CE Deserialization Command Execution"
   zh = "Liferay Portal CE 反序列化命令执行漏洞"
-app = "Liferay Portal"
+
   [[container.cve]]
   id = "CVE-2020-7961"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7961"
-path = "liferay-portal/CVE-2020-7961"
 
 [[container]]
+app = "Apache Log4j"
+path = "log4j/CVE-2017-5645"
+
   [[container.name]]
   en = "Apache Log4j Server Deserialization Command Execution"
   zh = "Apache Log4j Server 反序列化命令执行漏洞"
-app = "Apache Log4j"
+
   [[container.cve]]
   id = "CVE-2017-5645"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5645"
-path = "log4j/CVE-2017-5645"
 
 [[container]]
+app = "Apache Log4j"
+path = "log4j/CVE-2021-44228"
+
   [[container.name]]
   en = "Apache Log4j2 lookup JNDI Injection"
   zh = "Apache Log4j2 lookup JNDI 注入漏洞"
-app = "Apache Log4j"
+
   [[container.cve]]
   id = "CVE-2021-44228"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
-path = "log4j/CVE-2021-44228"
 
 [[container]]
+app = "Magento"
+path = "magento/2.2-sqli"
+
   [[container.name]]
   en = "Magento 2.2 SQL Injection"
   zh = "Magento 2.2 SQL注入漏洞"
-app = "Magento"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "magento/2.2-sqli"
 
 [[container]]
+app = "metabase"
+path = "metabase/CVE-2021-41277"
+
   [[container.name]]
   en = "Metabase Arbitrary File Read"
   zh = "Metabase任意文件读取漏洞"
-app = "metabase"
+
   [[container.cve]]
   id = "CVE-2021-41277"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41277"
-path = "metabase/CVE-2021-41277"
 
 [[container]]
+app = "mini_httpd"
+path = "mini_httpd/CVE-2018-18778"
+
   [[container.name]]
   en = "mini_httpd Arbitrary File Read"
   zh = "mini_httpd任意文件读取漏洞"
-app = "mini_httpd"
+
   [[container.cve]]
   id = "CVE-2018-18778"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18778"
-path = "mini_httpd/CVE-2018-18778"
 
 [[container]]
+app = "MinIO"
+path = "minio/CVE-2023-28432"
+
   [[container.name]]
   en = "MinIO Cluster Mode Information Disclosure"
   zh = "MinIO集群模式信息泄露漏洞"
-app = "MinIO"
+
   [[container.cve]]
   id = "CVE-2023-28432"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-28432"
-path = "minio/CVE-2023-28432"
 
 [[container]]
+app = "Mojarra JSF"
+path = "mojarra/jsf-viewstate-deserialization"
+
   [[container.name]]
   en = "Mojarra JSF ViewState Deserialization"
   zh = "Mojarra JSF ViewState 反序列化漏洞"
-app = "Mojarra JSF"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "mojarra/jsf-viewstate-deserialization"
 
 [[container]]
+app = "mongo-express"
+path = "mongo-express/CVE-2019-10758"
+
   [[container.name]]
   en = "Mongo Express Remote Code Execution"
   zh = "Mongo Express 远程代码执行漏洞"
-app = "mongo-express"
+
   [[container.cve]]
   id = "CVE-2019-10758"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-10758"
-path = "mongo-express/CVE-2019-10758"
 
 [[container]]
+app = "MySQL"
+path = "mysql/CVE-2012-2122"
+
   [[container.name]]
   en = "MySQL Authentication Bypass"
   zh = "MySQL 身份认证绕过漏洞"
-app = "MySQL"
+
   [[container.cve]]
   id = "CVE-2012-2122"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-2122"
-path = "mysql/CVE-2012-2122"
 
 [[container]]
+app = "Nacos"
+path = "nacos/CVE-2021-29441"
+
   [[container.name]]
   en = "Nacos Authentication Bypass"
   zh = "Nacos 认证绕过漏洞"
-app = "Nacos"
+
   [[container.cve]]
   id = "CVE-2021-29441"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29441"
-path = "nacos/CVE-2021-29441"
 
 [[container]]
+app = "Neo4j"
+path = "neo4j/CVE-2021-34371"
+
   [[container.name]]
   en = "Neo4j Shell Server Deserialization"
   zh = "Neo4j Shell Server 反序列化漏洞"
-app = "Neo4j"
+
   [[container.cve]]
   id = "CVE-2021-34371"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34371"
-path = "neo4j/CVE-2021-34371"
 
 [[container]]
+app = "Nexus Repository Manager"
+path = "nexus/CVE-2019-7238"
+
   [[container.name]]
   en = "Nexus Repository Manager 3 Remote Command Execution"
   zh = "Nexus Repository Manager 3 远程命令执行漏洞"
-app = "Nexus Repository Manager"
+
   [[container.cve]]
   id = "CVE-2019-7238"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7238"
-path = "nexus/CVE-2019-7238"
 
 [[container]]
+app = "Nexus Repository Manager"
+path = "nexus/CVE-2020-10199"
+
   [[container.name]]
   en = "Nexus Repository Manager 3 Remote Command Execution"
   zh = "Nexus Repository Manager 3 远程命令执行漏洞"
-app = "Nexus Repository Manager"
+
   [[container.cve]]
   id = "CVE-2020-10199"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10199"
-path = "nexus/CVE-2020-10199"
 
 [[container]]
+app = "Nexus Repository Manager"
+path = "nexus/CVE-2020-10204"
+
   [[container.name]]
   en = "Nexus Repository Manager 3 Remote Command Execution"
   zh = "Nexus Repository Manager 3 远程命令执行漏洞"
-app = "Nexus Repository Manager"
+
   [[container.cve]]
   id = "CVE-2020-10204"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10204"
-path = "nexus/CVE-2020-10204"
 
 [[container]]
+app = "Nginx"
+path = "nginx/CVE-2013-4547"
+
   [[container.name]]
   en = "Nginx Filename Logic"
   zh = "Nginx 文件名逻辑漏洞"
-app = "Nginx"
+
   [[container.cve]]
   id = "CVE-2013-4547"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-4547"
-path = "nginx/CVE-2013-4547"
 
 [[container]]
+app = "Nginx"
+path = "nginx/CVE-2017-7529"
+
   [[container.name]]
   en = "Nginx Out-of-Bounds Read Cache"
   zh = "Nginx越界读取缓存漏洞"
-app = "Nginx"
+
   [[container.cve]]
   id = "CVE-2017-7529"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7529"
-path = "nginx/CVE-2017-7529"
 
 [[container]]
+app = "Nginx"
+path = "nginx/insecure-configuration"
+
   [[container.name]]
   en = "Nginx Configuration Errors"
   zh = "Nginx 配置错误三例"
-app = "Nginx"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "nginx/insecure-configuration"
 
 [[container]]
+app = "Nginx"
+path = "nginx/nginx_parsing_vulnerability"
+
   [[container.name]]
   en = "Nginx Parsing"
   zh = "Nginx 解析漏洞"
-app = "Nginx"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "nginx/nginx_parsing_vulnerability"
 
 [[container]]
+app = "node"
+path = "node/CVE-2017-14849"
+
   [[container.name]]
   en = "NodeJS Directory Traversal"
   zh = "NodeJS 目录穿越漏洞"
-app = "node"
+
   [[container.cve]]
   id = "CVE-2017-14849"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-14849"
-path = "node/CVE-2017-14849"
 
 [[container]]
+app = "node-postgres"
+path = "node/CVE-2017-16082"
+
   [[container.name]]
   en = "node-postgres Code Execution"
   zh = "node-postgres 代码执行漏洞分析"
-app = "node-postgres"
+
   [[container.cve]]
   id = "CVE-2017-16082"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-16082"
-path = "node/CVE-2017-16082"
 
 [[container]]
+app = "ntopng"
+path = "ntopng/CVE-2021-28073"
+
   [[container.name]]
   en = "ntopng Permission Bypass"
   zh = "ntopng权限绕过漏洞"
-app = "ntopng"
+
   [[container.cve]]
   id = "CVE-2021-28073"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28073"
-path = "ntopng/CVE-2021-28073"
 
 [[container]]
+app = "Apache OfBiz"
+path = "ofbiz/CVE-2020-9496"
+
   [[container.name]]
   en = "Apache OfBiz Deserialization Command Execution"
   zh = "Apache OfBiz 反序列化命令执行漏洞"
-app = "Apache OfBiz"
+
   [[container.cve]]
   id = "CVE-2020-9496"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9496"
-path = "ofbiz/CVE-2020-9496"
 
 [[container]]
+app = "Openfire"
+path = "openfire/CVE-2023-32315"
+
   [[container.name]]
   en = "Openfire Management Background Authentication Bypass"
   zh = "Openfire管理后台认证绕过漏洞"
-app = "Openfire"
+
   [[container.cve]]
   id = "CVE-2023-32315"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-32315"
-path = "openfire/CVE-2023-32315"
 
 [[container]]
+app = "OpenSMTPD"
+path = "opensmtpd/CVE-2020-7247"
+
   [[container.name]]
   en = "OpenSMTPD Remote Command Execution"
   zh = "OpenSMTPD 远程命令执行漏洞"
-app = "OpenSMTPD"
+
   [[container.cve]]
   id = "CVE-2020-7247"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7247"
-path = "opensmtpd/CVE-2020-7247"
 
 [[container]]
+app = "OpenSSH"
+path = "openssh/CVE-2018-15473"
+
   [[container.name]]
   en = "OpenSSH Username Enumeration"
   zh = "OpenSSH 用户名枚举漏洞"
-app = "OpenSSH"
+
   [[container.cve]]
   id = "CVE-2018-15473"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15473"
-path = "openssh/CVE-2018-15473"
 
 [[container]]
+app = "OpenSSL"
+path = "openssl/CVE-2014-0160"
+
   [[container.name]]
   en = "OpenSSL Heartbleed"
   zh = "OpenSSL 心脏出血漏洞"
-app = "OpenSSL"
+
   [[container.cve]]
   id = "CVE-2014-0160"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-0160"
-path = "openssl/CVE-2014-0160"
 
 [[container]]
+app = "OpenSSL"
+path = "openssl/CVE-2022-0778"
+
   [[container.name]]
   en = "OpenSSL Infinite Loop DoS"
   zh = "OpenSSL无限循环DoS漏洞"
-app = "OpenSSL"
+
   [[container.cve]]
   id = "CVE-2022-0778"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0778"
-path = "openssl/CVE-2022-0778"
 
 [[container]]
+app = "OpenTSDB"
+path = "opentsdb/CVE-2020-35476"
+
   [[container.name]]
   en = "OpenTSDB Command Injection"
   zh = "OpenTSDB 命令注入漏洞"
-app = "OpenTSDB"
+
   [[container.cve]]
   id = "CVE-2020-35476"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-35476"
-path = "opentsdb/CVE-2020-35476"
 
 [[container]]
+app = "PHP"
+path = "php/8.1-backdoor"
+
   [[container.name]]
   en = "PHP 8.1.0-dev Development Version Backdoor Event"
   zh = "PHP 8.1.0-dev 开发版本后门事件"
-app = "PHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "php/8.1-backdoor"
 
 [[container]]
+app = "PHP-CGI"
+path = "php/CVE-2012-1823"
+
   [[container.name]]
   en = "PHP-CGI Remote Code Execution"
   zh = "PHP-CGI远程代码执行漏洞"
-app = "PHP-CGI"
+
   [[container.cve]]
   id = "CVE-2012-1823"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-1823"
-path = "php/CVE-2012-1823"
 
 [[container]]
+app = "PHP-IMAP"
+path = "php/CVE-2018-19518"
+
   [[container.name]]
   en = "PHP-IMAP Remote Command Execution"
   zh = "PHP-IMAP 远程命令执行漏洞"
-app = "PHP-IMAP"
+
   [[container.cve]]
   id = "CVE-2018-19518"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19518"
-path = "php/CVE-2018-19518"
 
 [[container]]
+app = "PHP-FPM"
+path = "php/CVE-2019-11043"
+
   [[container.name]]
   en = "PHP-FPM Remote Command Execution"
   zh = "PHP-FPM 远程代码执行漏洞"
-app = "PHP-FPM"
+
   [[container.cve]]
   id = "CVE-2019-11043"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11043"
-path = "php/CVE-2019-11043"
 
 [[container]]
+app = "PHP-FPM"
+path = "php/fpm"
+
   [[container.name]]
   en = "PHP-FPM FastCGI Unauthorized Access"
   zh = "PHP-FPM FastCGI 未授权访问漏洞"
-app = "PHP-FPM"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "php/fpm"
 
 [[container]]
+app = "PHP"
+path = "php/inclusion"
+
   [[container.name]]
   en = "PHP Files Vulnerabilities (by phpinfo())"
   zh = "PHP文件包含漏洞 (利用phpinfo())"
-app = "PHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "php/inclusion"
 
 [[container]]
+app = "PHP"
+path = "php/php_xxe"
+
   [[container.name]]
   en = "PHP XML Entity Injection"
   zh = "PHP XML实体注入"
-app = "PHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "php/php_xxe"
 
 [[container]]
+app = "PHP"
+path = "php/xdebug-rce"
+
   [[container.name]]
   en = "XDebug Remote Debugging Code Execution"
   zh = "XDebug 远程调试漏洞 (代码执行)"
-app = "PHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "php/xdebug-rce"
 
 [[container]]
+app = "PHPMailer"
+path = "phpmailer/CVE-2017-5223"
+
   [[container.name]]
   en = "PHPMailer Arbitrary File Read"
   zh = "PHPMailer 任意文件读取漏洞"
-app = "PHPMailer"
+
   [[container.cve]]
   id = "CVE-2017-5223"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5223"
-path = "phpmailer/CVE-2017-5223"
 
 [[container]]
+app = "phpmyadmin"
+path = "phpmyadmin/CVE-2016-5734"
+
   [[container.name]]
   en = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
   zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
-app = "phpmyadmin"
+
   [[container.cve]]
   id = "CVE-2016-5734"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5734"
-path = "phpmyadmin/CVE-2016-5734"
 
 [[container]]
+app = "phpmyadmin"
+path = "phpmyadmin/CVE-2018-12613"
+
   [[container.name]]
   en = "phpmyadmin 4.8.1 Remote File Inclusion"
   zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
-app = "phpmyadmin"
+
   [[container.cve]]
   id = "CVE-2018-12613"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-12613"
-path = "phpmyadmin/CVE-2018-12613"
 
 [[container]]
+app = "phpmyadmin"
+path = "phpmyadmin/WooYun-2016-199433"
+
   [[container.name]]
   en = "phpmyadmin scripts/setup.php Deserialization"
   zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
-app = "phpmyadmin"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "phpmyadmin/WooYun-2016-199433"
 
 [[container]]
+app = "phpunit"
+path = "phpunit/CVE-2017-9841"
+
   [[container.name]]
   en = "phpunit Remote Code Execution"
   zh = "phpunit 远程代码执行漏洞"
-app = "phpunit"
+
   [[container.cve]]
   id = "CVE-2017-9841"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9841"
-path = "phpunit/CVE-2017-9841"
 
 [[container]]
+app = "Polkit Pkexec"
+path = "polkit/CVE-2021-4034"
+
   [[container.name]]
   en = "Polkit pkexec Privilege Escalation"
   zh = "Polkit pkexec 权限提升漏洞"
-app = "Polkit Pkexec"
+
   [[container.cve]]
   id = "CVE-2021-4034"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-4034"
-path = "polkit/CVE-2021-4034"
 
 [[container]]
+app = "PostgreSQL"
+path = "postgres/CVE-2018-1058"
+
   [[container.name]]
   en = "PostgreSQL Privilege Escalation"
   zh = "PostgreSQL 提权漏洞"
-app = "PostgreSQL"
+
   [[container.cve]]
   id = "CVE-2018-1058"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1058"
-path = "postgres/CVE-2018-1058"
 
 [[container]]
+app = "PostgreSQL"
+path = "postgres/CVE-2019-9193"
+
   [[container.name]]
   en = "PostgreSQL High Privilege Command Execution"
   zh = "PostgreSQL 高权限命令执行漏洞"
-app = "PostgreSQL"
+
   [[container.cve]]
   id = "CVE-2019-9193"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-9193"
-path = "postgres/CVE-2019-9193"
 
 [[container]]
+app = "Python"
+path = "python/PIL-CVE-2017-8291"
+
   [[container.name]]
   en = "Python PIL Remote Command Execution (GhostButt)"
   zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
-app = "Python"
+
   [[container.cve]]
   id = "CVE-2017-8291"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8291"
-path = "python/PIL-CVE-2017-8291"
 
 [[container]]
+app = "Python"
+path = "python/PIL-CVE-2018-16509"
+
   [[container.name]]
   en = "Python PIL Remote Command Execution (via Ghostscript)"
   zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
-app = "Python"
+
   [[container.cve]]
   id = "CVE-2018-16509"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
-path = "python/PIL-CVE-2018-16509"
 
 [[container]]
+app = "Python"
+path = "python/unpickle"
+
   [[container.name]]
   en = "Python Unpickle Deserialization"
   zh = "Python Unpickle 反序列化漏洞"
-app = "Python"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "python/unpickle"
 
 [[container]]
+app = "Ruby on Rails"
+path = "rails/CVE-2018-3760"
+
   [[container.name]]
   en = "Ruby on Rails Path Traversal"
   zh = "Ruby on Rails 路径穿越漏洞"
-app = "Ruby on Rails"
+
   [[container.cve]]
   id = "CVE-2018-3760"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-3760"
-path = "rails/CVE-2018-3760"
 
 [[container]]
+app = "Ruby on Rails"
+path = "rails/CVE-2019-5418"
+
   [[container.name]]
   en = "Ruby on Rails Path Traversal and Arbitrary File Read"
   zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
-app = "Ruby on Rails"
+
   [[container.cve]]
   id = "CVE-2019-5418"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-5418"
-path = "rails/CVE-2019-5418"
 
 [[container]]
+app = "redis"
+path = "redis/4-unacc"
+
   [[container.name]]
   en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
   zh = "Redis 4.x/5.x 主从复制导致的命令执行"
-app = "redis"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "redis/4-unacc"
 
 [[container]]
+app = "redis"
+path = "redis/CVE-2022-0543"
+
   [[container.name]]
   en = "Redis Lua Sandbox Bypass Command Execution"
   zh = "Redis Lua沙盒绕过命令执行"
-app = "redis"
+
   [[container.cve]]
   id = "CVE-2022-0543"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0543"
-path = "redis/CVE-2022-0543"
 
 [[container]]
+app = "rocket chat"
+path = "rocketchat/CVE-2021-22911"
+
   [[container.name]]
   en = "Rocket Chat MongoDB Injection"
   zh = "Rocket Chat MongoDB 注入漏洞"
-app = "rocket chat"
+
   [[container.cve]]
   id = "CVE-2021-22911"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22911"
-path = "rocketchat/CVE-2021-22911"
 
 [[container]]
+app = "Apache RocketMQ"
+path = "rocketmq/CVE-2023-33246"
+
   [[container.name]]
   en = "Apache RocketMQ Remote Command Execution"
   zh = "Apache RocketMQ 远程命令执行漏洞"
-app = "Apache RocketMQ"
+
   [[container.cve]]
   id = "CVE-2023-33246"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-33246"
-path = "rocketmq/CVE-2023-33246"
 
 [[container]]
+app = "rsync"
+path = "rsync/common"
+
   [[container.name]]
   en = "rsync Unauthorized Access"
   zh = "rsync 未授权访问漏洞"
-app = "rsync"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "rsync/common"
 
 [[container]]
+app = "ruby"
+path = "ruby/CVE-2017-17405"
+
   [[container.name]]
   en = "Ruby Net::FTP Module Command Injection"
   zh = "Ruby Net::FTP 模块命令注入漏洞"
-app = "ruby"
+
   [[container.cve]]
   id = "CVE-2017-17405"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17405"
-path = "ruby/CVE-2017-17405"
 
 [[container]]
+app = "SaltStack"
+path = "saltstack/CVE-2020-11651"
+
   [[container.name]]
   en = "SaltStack Horizontal Privilege Bypass"
   zh = "SaltStack 水平权限绕过漏洞"
-app = "SaltStack"
+
   [[container.cve]]
   id = "CVE-2020-11651"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11651"
-path = "saltstack/CVE-2020-11651"
 
 [[container]]
+app = "SaltStack"
+path = "saltstack/CVE-2020-11652"
+
   [[container.name]]
   en = "SaltStack Arbitrary File Read and Write"
   zh = "SaltStack 任意文件读写漏洞"
-app = "SaltStack"
+
   [[container.cve]]
   id = "CVE-2020-11652"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11652"
-path = "saltstack/CVE-2020-11652"
 
 [[container]]
+app = "SaltStack"
+path = "saltstack/CVE-2020-16846"
+
   [[container.name]]
   en = "SaltStack Command Injection"
   zh = "SaltStack 命令注入漏洞"
-app = "SaltStack"
+
   [[container.cve]]
   id = "CVE-2020-16846"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-16846"
-path = "saltstack/CVE-2020-16846"
 
 [[container]]
+app = "Samba"
+path = "samba/CVE-2017-7494"
+
   [[container.name]]
   en = "Samba Remote Command Execution"
   zh = "Samba 远程命令执行漏洞"
-app = "Samba"
+
   [[container.cve]]
   id = "CVE-2017-7494"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7494"
-path = "samba/CVE-2017-7494"
 
 [[container]]
+app = "Scrapyd"
+path = "scrapy/scrapyd-unacc"
+
   [[container.name]]
   en = "Scrapyd Unauthorized Access"
   zh = "Scrapyd 未授权访问漏洞"
-app = "Scrapyd"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "scrapy/scrapyd-unacc"
 
 [[container]]
+app = "shiro"
+path = "shiro/CVE-2010-3863"
+
   [[container.name]]
   en = "Apache Shiro Authentication Bypass"
   zh = "Apache Shiro 认证绕过漏洞"
-app = "shiro"
+
   [[container.cve]]
   id = "CVE-2010-3863"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-3863"
-path = "shiro/CVE-2010-3863"
 
 [[container]]
+app = "shiro"
+path = "shiro/CVE-2016-4437"
+
   [[container.name]]
   en = "Apache Shiro 1.2.4 Deserialization"
   zh = "Apache Shiro 1.2.4反序列化漏洞"
-app = "shiro"
+
   [[container.cve]]
   id = "CVE-2016-4437"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4437"
-path = "shiro/CVE-2016-4437"
 
 [[container]]
+app = "shiro"
+path = "shiro/CVE-2020-1957"
+
   [[container.name]]
   en = "Apache Shiro Authentication Bypass"
   zh = "Apache Shiro 认证绕过漏洞"
-app = "shiro"
+
   [[container.cve]]
   id = "CVE-2020-1957"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1957"
-path = "shiro/CVE-2020-1957"
 
 [[container]]
+app = "skywalking"
+path = "skywalking/8.3.0-sqli"
+
   [[container.name]]
   en = "Apache Skywalking 8.3.0 SQL Injection"
   zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
-app = "skywalking"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "skywalking/8.3.0-sqli"
 
 [[container]]
+app = "solr"
+path = "solr/CVE-2017-12629-RCE"
+
   [[container.name]]
   en = "Apache Solr Remote Command Execution"
   zh = "Apache Solr 远程命令执行漏洞"
-app = "solr"
+
   [[container.cve]]
   id = "CVE-2017-12629"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
-path = "solr/CVE-2017-12629-RCE"
 
 [[container]]
+app = "solr"
+path = "solr/CVE-2017-12629-XXE"
+
   [[container.name]]
   en = "Apache Solr XML Entity Injection"
   zh = "Apache Solr XML 实体注入漏洞"
-app = "solr"
+
   [[container.cve]]
   id = "CVE-2017-12629"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
-path = "solr/CVE-2017-12629-XXE"
 
 [[container]]
+app = "solr"
+path = "solr/CVE-2019-0193"
+
   [[container.name]]
   en = "Apache Solr Remote Command Execution"
   zh = "Apache Solr 远程命令执行漏洞"
-app = "solr"
+
   [[container.cve]]
   id = "CVE-2019-0193"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0193"
-path = "solr/CVE-2019-0193"
 
 [[container]]
+app = "solr"
+path = "solr/CVE-2019-17558"
+
   [[container.name]]
   en = "Apache Solr Velocity Inject Remote Command Execution"
   zh = "Apache Solr Velocity 注入远程命令执行漏洞"
-app = "solr"
+
   [[container.cve]]
   id = "CVE-2019-17558"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17558"
-path = "solr/CVE-2019-17558"
 
 [[container]]
+app = "solr"
+path = "solr/Remote-Streaming-Fileread"
+
   [[container.name]]
   en = "Apache Solr RemoteStreaming File Reading and SSRF"
   zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
-app = "solr"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "solr/Remote-Streaming-Fileread"
 
 [[container]]
+app = "spark"
+path = "spark/unacc"
+
   [[container.name]]
   en = "Apache Spark Unauthorized Access Leak"
   zh = "Apache Spark 未授权访问漏"
-app = "spark"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "spark/unacc"
 
 [[container]]
+app = "spring security oauth2"
+path = "spring/CVE-2016-4977"
+
   [[container.name]]
   en = "Spring Security Oauth2 Remote Command Execution"
   zh = "Spring Security Oauth2 远程命令执行漏洞"
-app = "spring security oauth2"
+
   [[container.cve]]
   id = "CVE-2016-4977"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4977"
-path = "spring/CVE-2016-4977"
 
 [[container]]
+app = "spring webflow"
+path = "spring/CVE-2017-4971"
+
   [[container.name]]
   en = "Spring WebFlow Remote Code Execution"
   zh = "Spring WebFlow 远程代码执行漏洞"
-app = "spring webflow"
+
   [[container.cve]]
   id = "CVE-2017-4971"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-4971"
-path = "spring/CVE-2017-4971"
 
 [[container]]
+app = "spring data rest"
+path = "spring/CVE-2017-8046"
+
   [[container.name]]
   en = "Spring Data Rest Remote Command Execution"
   zh = "Spring Data Rest 远程命令执行漏洞"
-app = "spring data rest"
+
   [[container.cve]]
   id = "CVE-2017-8046"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8046"
-path = "spring/CVE-2017-8046"
 
 [[container]]
+app = "spring messaging"
+path = "spring/CVE-2018-1270"
+
   [[container.name]]
   en = "Spring Messaging Remote Command Execution"
   zh = "Spring Messaging 远程命令执行漏洞"
-app = "spring messaging"
+
   [[container.cve]]
   id = "CVE-2018-1270"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1270"
-path = "spring/CVE-2018-1270"
 
 [[container]]
+app = "spring data commons"
+path = "spring/CVE-2018-1273"
+
   [[container.name]]
   en = "Spring Data Commons Remote Command Execution"
   zh = "Spring Data Commons 远程命令执行漏洞"
-app = "spring data commons"
+
   [[container.cve]]
   id = "CVE-2018-1273"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1273"
-path = "spring/CVE-2018-1273"
 
 [[container]]
+app = "spring cloud gateway"
+path = "spring/CVE-2022-22947"
+
   [[container.name]]
   en = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
   zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
-app = "spring cloud gateway"
+
   [[container.cve]]
   id = "CVE-2022-22947"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22947"
-path = "spring/CVE-2022-22947"
 
 [[container]]
+app = "spring cloud function"
+path = "spring/CVE-2022-22963"
+
   [[container.name]]
   en = "Spring Cloud Function SpEL Expression Command Injection"
   zh = "Spring Cloud Function SpEL表达式命令注入"
-app = "spring cloud function"
+
   [[container.cve]]
   id = "CVE-2022-22963"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22963"
-path = "spring/CVE-2022-22963"
 
 [[container]]
+app = "Spring"
+path = "spring/CVE-2022-22965"
+
   [[container.name]]
   en = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
   zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
-app = "Spring"
+
   [[container.cve]]
   id = "CVE-2022-22965"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22965"
-path = "spring/CVE-2022-22965"
 
 [[container]]
+app = "Spring"
+path = "spring/CVE-2022-22978"
+
   [[container.name]]
   en = "Spring Security Authorization Bypass in RegexRequestMatcher"
   zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
-app = "Spring"
+
   [[container.cve]]
   id = "CVE-2022-22978"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22978"
-path = "spring/CVE-2022-22978"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-001"
+
   [[container.name]]
   en = "S2-001 Remote Code Execution"
   zh = "S2-001 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "struts2/s2-001"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-005"
+
   [[container.name]]
   en = "S2-005 Remote Code Execution"
   zh = "S2-005 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2010-1870"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-1870"
-path = "struts2/s2-005"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-007"
+
   [[container.name]]
   en = "S2-007 Remote Code Execution"
   zh = "S2-007 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "struts2/s2-007"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-008"
+
   [[container.name]]
   en = "S2-008 Remote Code Execution"
   zh = "S2-008 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2012-0391"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-0391"
-path = "struts2/s2-008"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-009"
+
   [[container.name]]
   en = "S2-009 Remote Code Execution"
   zh = "S2-009 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2011-3923"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2011-3923"
-path = "struts2/s2-009"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-012"
+
   [[container.name]]
   en = "S2-012 Remote Code Execution"
   zh = "S2-012 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2013-1965"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1965"
-path = "struts2/s2-012"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-013"
+
   [[container.name]]
   en = "S2-013 Remote Code Execution"
   zh = "S2-013 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2013-1966"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1966"
-path = "struts2/s2-013"
 
 [[container]]
+app = "Struts2"
+
   [[container.name]]
   en = "S2-015 Remote Code Execution"
   zh = "S2-015 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2013-2134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2134"
-
   [[container.cve]]
   id = "CVE-2013-2135"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2135"
-path = "struts2/s2-015"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-016"
+
   [[container.name]]
   en = "S2-016 Remote Code Execution"
   zh = "S2-016 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2013-2251"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2251"
-path = "struts2/s2-016"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-032"
+
   [[container.name]]
   en = "S2-032 Remote Code Execution"
   zh = "S2-032 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2016-3081"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3081"
-path = "struts2/s2-032"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-045"
+
   [[container.name]]
   en = "S2-045 Remote Code Execution"
   zh = "S2-045 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2017-5638"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
-path = "struts2/s2-045"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-046"
+
   [[container.name]]
   en = "S2-046 Remote Code Execution"
   zh = "S2-046 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2017-5638"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
-path = "struts2/s2-046"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-048"
+
   [[container.name]]
   en = "S2-048 Remote Code Execution"
   zh = "S2-048 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2017-9791"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9791"
-path = "struts2/s2-048"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-052"
+
   [[container.name]]
   en = "S2-052 Remote Code Execution"
   zh = "S2-052 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2017-9805"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9805"
-path = "struts2/s2-052"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-053"
+
   [[container.name]]
   en = "S2-053 Remote Code Execution"
   zh = "S2-053 远程代码执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2017-12611"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12611"
-path = "struts2/s2-053"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-057"
+
   [[container.name]]
   en = "Struts2 S2-057 Remote Command Execution"
   zh = "Struts2 S2-057 远程命令执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2018-11776"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-11776"
-path = "struts2/s2-057"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-059"
+
   [[container.name]]
   en = "Struts2 S2-059 Remote Command Execution"
   zh = "Struts2 S2-059 远程命令执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2019-0230"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0230"
-path = "struts2/s2-059"
 
 [[container]]
+app = "Struts2"
+path = "struts2/s2-061"
+
   [[container.name]]
   en = "Struts2 S2-061 Remote Command Execution"
   zh = "Struts2 S2-061 远程命令执行漏洞"
-app = "Struts2"
+
   [[container.cve]]
   id = "CVE-2020-17530"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17530"
-path = "struts2/s2-061"
 
 [[container]]
+app = "Supervisor"
+path = "supervisor/CVE-2017-11610"
+
   [[container.name]]
   en = "Supervisord Remote Command Execution"
   zh = "Supervisord 远程命令执行漏洞"
-app = "Supervisor"
+
   [[container.cve]]
   id = "CVE-2017-11610"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-11610"
-path = "supervisor/CVE-2017-11610"
 
 [[container]]
+app = "ThinkPHP"
+path = "thinkphp/2-rce"
+
   [[container.name]]
   en = "ThinkPHP 2.x Arbitrary Code Execution"
   zh = "ThinkPHP 2.x 任意代码执行漏洞"
-app = "ThinkPHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "thinkphp/2-rce"
 
 [[container]]
+app = "ThinkPHP"
+path = "thinkphp/5-rce"
+
   [[container.name]]
   en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
   zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
-app = "ThinkPHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "thinkphp/5-rce"
 
 [[container]]
+app = "ThinkPHP"
+path = "thinkphp/5.0.23-rce"
+
   [[container.name]]
   en = "ThinkPHP5 5.0.23 Remote Code Execution"
   zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
-app = "ThinkPHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "thinkphp/5.0.23-rce"
 
 [[container]]
+app = "ThinkPHP"
+path = "thinkphp/in-sqlinjection"
+
   [[container.name]]
   en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
   zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
-app = "ThinkPHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "thinkphp/in-sqlinjection"
 
 [[container]]
+app = "ThinkPHP"
+path = "thinkphp/lang-rce"
+
   [[container.name]]
   en = "ThinkPHP Multilingual Local File Inclusion"
   zh = "ThinkPHP 多语言本地文件包含漏洞"
-app = "ThinkPHP"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "thinkphp/lang-rce"
 
 [[container]]
+app = "Tiki Wiki"
+path = "tikiwiki/CVE-2020-15906"
+
   [[container.name]]
   en = "Tiki Wiki CMS Groupware Authentication Bypass"
   zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
-app = "Tiki Wiki"
+
   [[container.cve]]
   id = "CVE-2020-15906"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-15906"
-path = "tikiwiki/CVE-2020-15906"
 
 [[container]]
+app = "Tomcat"
+path = "tomcat/CVE-2017-12615"
+
   [[container.name]]
   en = "Tomcat Arbitrary Writing of Files in the PUT Method"
   zh = "Tomcat PUT方法任意写文件漏洞"
-app = "Tomcat"
+
   [[container.cve]]
   id = "CVE-2017-12615"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12615"
-path = "tomcat/CVE-2017-12615"
 
 [[container]]
+app = "Tomcat"
+path = "tomcat/CVE-2020-1938"
+
   [[container.name]]
   en = "Apache Tomcat AJP Bug"
   zh = "Apache Tomcat AJP 文件包含漏洞"
-app = "Tomcat"
+
   [[container.cve]]
   id = "CVE-2020-1938"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1938"
-path = "tomcat/CVE-2020-1938"
 
 [[container]]
+app = "Tomcat"
+path = "tomcat/tomcat8"
+
   [[container.name]]
   en = "Tomcat Weak Password"
   zh = "Tomcat弱口令"
-app = "Tomcat"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "tomcat/tomcat8"
 
 [[container]]
+app = "unomi"
+path = "unomi/CVE-2020-13942"
+
   [[container.name]]
   en = "Apache Unomi Remote Expression Code Execution"
   zh = "Apache Unomi 远程表达式代码执行漏洞"
-app = "unomi"
+
   [[container.cve]]
   id = "CVE-2020-13942"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13942"
-path = "unomi/CVE-2020-13942"
 
 [[container]]
+app = "uWSGI"
+path = "uwsgi/CVE-2018-7490"
+
   [[container.name]]
   en = "uWSGI PHP Directory Traversal"
   zh = "uWSGI PHP目录穿越漏洞"
-app = "uWSGI"
+
   [[container.cve]]
   id = "CVE-2018-7490"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7490"
-path = "uwsgi/CVE-2018-7490"
 
 [[container]]
+app = "uWSGI"
+path = "uwsgi/unacc"
+
   [[container.name]]
   en = "uWSGI Unauthorized Access"
   zh = "uWSGI 未授权访问漏洞"
-app = "uWSGI"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "uwsgi/unacc"
 
 [[container]]
+app = "V2board"
+path = "v2board/1.6-privilege-escalation"
+
   [[container.name]]
   en = "V2board 1.6.1 Privilege Escalation"
   zh = "V2board 1.6.1 提权漏洞"
-app = "V2board"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "v2board/1.6-privilege-escalation"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/CVE-2017-10271"
+
   [[container.name]]
   en = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
   zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = "CVE-2017-10271"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-10271"
-path = "weblogic/CVE-2017-10271"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/CVE-2018-2628"
+
   [[container.name]]
   en = "WebLogic WLS Core Components Deserialization Command Execution"
   zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = "CVE-2018-2628"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2628"
-path = "weblogic/CVE-2018-2628"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/CVE-2018-2894"
+
   [[container.name]]
   en = "WebLogic Arbitrary File Upload"
   zh = "WebLogic 任意文件上传漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = "CVE-2018-2894"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2894"
-path = "weblogic/CVE-2018-2894"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/CVE-2020-14882"
+
   [[container.name]]
   en = "WebLogic Management Console Unauthorized Remote Command Execution"
   zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = "CVE-2020-14882"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-14882"
-path = "weblogic/CVE-2020-14882"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/CVE-2023-21839"
+
   [[container.name]]
   en = "WebLogic Unauthorized Remote Code Execution"
   zh = "WebLogic未授权远程代码执行漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = "CVE-2023-21839"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-21839"
-path = "weblogic/CVE-2023-21839"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/ssrf"
+
   [[container.name]]
   en = "WebLogic SSRF"
   zh = "WebLogic SSRF漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "weblogic/ssrf"
 
 [[container]]
+app = "WebLogic"
+path = "weblogic/weak_password"
+
   [[container.name]]
   en = "WebLogic File Read"
   zh = "WebLogic 文件读取漏洞"
-app = "WebLogic"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "weblogic/weak_password"
 
 [[container]]
+app = "Webmin"
+path = "webmin/CVE-2019-15107"
+
   [[container.name]]
   en = "Webmin Remote Command Execution"
   zh = "Webmin 远程命令执行漏洞"
-app = "Webmin"
+
   [[container.cve]]
   id = "CVE-2019-15107"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-15107"
-path = "webmin/CVE-2019-15107"
 
 [[container]]
+app = "Wordpress"
+path = "wordpress/pwnscriptum"
+
   [[container.name]]
   en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
   zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
-app = "Wordpress"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "wordpress/pwnscriptum"
 
 [[container]]
+app = "XStream"
+path = "xstream/CVE-2021-21351"
+
   [[container.name]]
   en = "XStream Deserialization Command Execution"
   zh = "XStream 反序列化命令执行漏洞"
-app = "XStream"
+
   [[container.cve]]
   id = "CVE-2021-21351"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-21351"
-path = "xstream/CVE-2021-21351"
 
 [[container]]
+app = "XStream"
+path = "xstream/CVE-2021-29505"
+
   [[container.name]]
   en = "XStream Deserialization Command Execution"
   zh = "XStream 反序列化命令执行漏洞"
-app = "XStream"
+
   [[container.cve]]
   id = "CVE-2021-29505"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29505"
-path = "xstream/CVE-2021-29505"
 
 [[container]]
+app = "xxl-job"
+path = "xxl-job/unacc"
+
   [[container.name]]
   en = "XXL-JOB Executor Unauthorized Access"
   zh = "XXL-JOB Executor 未授权访问漏洞"
-app = "xxl-job"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "xxl-job/unacc"
 
 [[container]]
+app = "YApi"
+path = "yapi/mongodb-inj"
+
   [[container.name]]
   en = "YApi NoSQL Injection to Remote Command Execution"
   zh = "YApi NoSQL注入导致远程命令执行漏洞"
-app = "YApi"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "yapi/mongodb-inj"
 
 [[container]]
+app = "YApi"
+path = "yapi/unacc"
+
   [[container.name]]
   en = "YApi Open Registration due to RCE"
   zh = "YApi开放注册导致RCE"
-app = "YApi"
+
   [[container.cve]]
   id = ""
   nvd = ""
-path = "yapi/unacc"
 
 [[container]]
+app = "Zabbix"
+path = "zabbix/CVE-2016-10134"
+
   [[container.name]]
   en = "Zabbix latest.php SQL Injection"
   zh = "Zabbix latest.php SQL注入漏洞"
-app = "Zabbix"
+
   [[container.cve]]
   id = "CVE-2016-10134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-10134"
-path = "zabbix/CVE-2016-10134"
 
 [[container]]
+app = "Zabbix"
+path = "zabbix/CVE-2020-11800"
+
   [[container.name]]
   en = "Zabbix Server Trapper Command Injection"
   zh = "Zabbix Server Trapper命令注入漏洞"
-app = "Zabbix"
+
   [[container.cve]]
   id = "CVE-2020-11800"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11800"
-path = "zabbix/CVE-2020-11800"

--- a/environments.toml
+++ b/environments.toml
@@ -1,2823 +1,1409 @@
-[[container]]
+[[environment]]
+name = "Apache ActiveMQ Deserialization"
+cve = ["CVE-2015-5254"]
 app = "ActiveMQ"
 path = "activemq/CVE-2015-5254"
 
-  [[container.name]]
-  en = "Apache ActiveMQ Deserialization"
-  zh = "Apache ActiveMQ 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2015-5254"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5254"
-
-[[container]]
+[[environment]]
+name = "Apache ActiveMQ Arbitrary File Write"
+cve = ["CVE-2016-3088"]
 app = "ActiveMQ"
 path = "activemq/CVE-2016-3088"
 
-  [[container.name]]
-  en = "Apache ActiveMQ Arbitrary File Write"
-  zh = "Apache ActiveMQ 任意文件写入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-3088"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3088"
-
-[[container]]
+[[environment]]
+name = "Apache Airflow Command Injection"
+cve = ["CVE-2020-11978"]
 app = "Airflow"
 path = "airflow/CVE-2020-11978"
 
-  [[container.name]]
-  en = "Apache Airflow Command Injection"
-  zh = "Apache Airflow 示例dag中的命令注入"
-
-  [[container.cve]]
-  id = "CVE-2020-11978"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11978"
-
-[[container]]
+[[environment]]
+name = "Apache Airflow Celery Message Middleware Command Execution"
+cve = ["CVE-2020-11981"]
 app = "Airflow"
 path = "airflow/CVE-2020-11981"
 
-  [[container.name]]
-  en = "Apache Airflow Celery Message Middleware Command Execution"
-  zh = "Apache Airflow Celery 消息中间件命令执行"
-
-  [[container.cve]]
-  id = "CVE-2020-11981"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11981"
-
-[[container]]
+[[environment]]
+name = "Apache Airflow Permission Bypass"
+cve = ["CVE-2020-17526"]
 app = "Airflow"
 path = "airflow/CVE-2020-17526"
 
-  [[container.name]]
-  en = "Apache Airflow Permission Bypass"
-  zh = "Apache Airflow 默认密钥导致的权限绕过"
-
-  [[container.cve]]
-  id = "CVE-2020-17526"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17526"
-
-[[container]]
+[[environment]]
+name = "Apache Druid Code Execution"
+cve = ["CVE-2021-25646"]
 app = "Apache Druid"
 path = "apache-druid/CVE-2021-25646"
 
-  [[container.name]]
-  en = "Apache Druid Code Execution"
-  zh = "Apache Druid 代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-25646"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-25646"
-
-[[container]]
+[[environment]]
+name = "Apereo CAS 4.1 Deserialization Command Execution"
+cve = [""]
 app = "Apereo CAS"
 path = "apereo-cas/4.1-rce"
 
-  [[container.name]]
-  en = "Apereo CAS 4.1 Deserialization Command Execution"
-  zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache APISIX Default Key"
+cve = ["CVE-2020-13945"]
 app = "Apache APISIX"
 path = "apisix/CVE-2020-13945"
 
-  [[container.name]]
-  en = "Apache APISIX Default Key"
-  zh = "Apache APISIX 默认密钥漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-13945"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13945"
-
-[[container]]
+[[environment]]
+name = "Apache APISIX Dashboard API Permission Bypass to RCE"
+cve = ["CVE-2021-45232"]
 app = "Apache APISIX"
 path = "apisix/CVE-2021-45232"
 
-  [[container.name]]
-  en = "Apache APISIX Dashboard API Permission Bypass to RCE"
-  zh = "Apache APISIX Dashboard API权限绕过导致RCE"
-
-  [[container.cve]]
-  id = "CVE-2021-45232"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-45232"
-
-[[container]]
+[[environment]]
+name = "AppWeb Authentication Bypass"
+cve = ["CVE-2018-8715"]
 app = "AppWeb"
 path = "appweb/CVE-2018-8715"
 
-  [[container.name]]
-  en = "AppWeb Authentication Bypass"
-  zh = "AppWeb 认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-8715"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-8715"
-
-[[container]]
+[[environment]]
+name = "Aria2 Arbitrary File Write"
+cve = [""]
 app = "Aria2"
 path = "aria2/rce"
 
-  [[container.name]]
-  en = "Aria2 Arbitrary File Write"
-  zh = "Aria2 任意文件写入漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Bash Shellshock Shell Exploit"
+cve = ["CVE-2014-6271"]
 app = "bash"
 path = "bash/CVE-2014-6271"
 
-  [[container.name]]
-  en = "Bash Shellshock Shell Exploit"
-  zh = "Bash Shellshock 破壳漏洞"
-
-  [[container.cve]]
-  id = "CVE-2014-6271"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-6271"
-
-[[container]]
+[[environment]]
+name = "Cacti Foreground Command Injection"
+cve = ["CVE-2022-46169"]
 app = "cacti"
 path = "cacti/CVE-2022-46169"
 
-  [[container.name]]
-  en = "Cacti Foreground Command Injection"
-  zh = "Cacti 前台命令注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2022-46169"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-46169"
-
-[[container]]
+[[environment]]
+name = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
+cve = [""]
 app = "celery"
 path = "celery/celery3_redis_unauth"
 
-  [[container.name]]
-  en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
-  zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "CGI HTTPoxy Flaw"
+cve = ["CVE-2016-5385"]
 app = "cgi"
 path = "cgi/CVE-2016-5385"
 
-  [[container.name]]
-  en = "CGI HTTPoxy Flaw"
-  zh = "CGI HTTPoxy 漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-5385"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5385"
-
-[[container]]
+[[environment]]
+name = "Adobe ColdFusion File Read"
+cve = ["CVE-2010-2861"]
 app = "Adobe ColdFusion"
 path = "coldfusion/CVE-2010-2861"
 
-  [[container.name]]
-  en = "Adobe ColdFusion File Read"
-  zh = "Adobe ColdFusion 文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2010-2861"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-2861"
-
-[[container]]
+[[environment]]
+name = "Adobe ColdFusion Deserialization"
+cve = ["CVE-2017-3066"]
 app = "Adobe ColdFusion"
 path = "coldfusion/CVE-2017-3066"
 
-  [[container.name]]
-  en = "Adobe ColdFusion Deserialization"
-  zh = "Adobe ColdFusion 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-3066"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-3066"
-
-[[container]]
+[[environment]]
+name = "Atlassian Confluence Path Traversal and Command Execution"
+cve = ["CVE-2019-3396"]
 app = "Atlassian Confluence"
 path = "confluence/CVE-2019-3396"
 
-  [[container.name]]
-  en = "Atlassian Confluence Path Traversal and Command Execution"
-  zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-3396"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-3396"
-
-[[container]]
+[[environment]]
+name = "Atlassian Confluence OGNL Expression Injection Code Execution"
+cve = ["CVE-2021-26084"]
 app = "Atlassian Confluence"
 path = "confluence/CVE-2021-26084"
 
-  [[container.name]]
-  en = "Atlassian Confluence OGNL Expression Injection Code Execution"
-  zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-26084"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-26084"
-
-[[container]]
+[[environment]]
+name = "Atlassian Confluence OGNL Expression Injection Command Execution"
+cve = ["CVE-2022-26134"]
 app = "Atlassian Confluence"
 path = "confluence/CVE-2022-26134"
 
-  [[container.name]]
-  en = "Atlassian Confluence OGNL Expression Injection Command Execution"
-  zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2022-26134"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-26134"
-
-[[container]]
+[[environment]]
+name = "CouchDB Vertical Permission Bypass"
+cve = ["CVE-2017-12635"]
 app = "CouchDB"
 path = "couchdb/CVE-2017-12635"
 
-  [[container.name]]
-  en = "CouchDB Vertical Permission Bypass"
-  zh = "CouchDB 垂直权限绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12635"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12635"
-
-[[container]]
+[[environment]]
+name = "CouchDB Arbitrary Command Execution"
+cve = ["CVE-2017-12636"]
 app = "CouchDB"
 path = "couchdb/CVE-2017-12636"
 
-  [[container.name]]
-  en = "CouchDB Arbitrary Command Execution"
-  zh = "CouchDB 任意命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12636"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12636"
-
-[[container]]
+[[environment]]
+name = "CouchDB Erlang Distributed Protocol Code Execution"
+cve = ["CVE-2022-24706"]
 app = "CouchDB"
 path = "couchdb/CVE-2022-24706"
 
-  [[container.name]]
-  en = "CouchDB Erlang Distributed Protocol Code Execution"
-  zh = "CouchDB Erlang 分布式协议代码执行"
-
-  [[container.cve]]
-  id = "CVE-2022-24706"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-24706"
-
-[[container]]
+[[environment]]
+name = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
+cve = [""]
 app = "Discuz"
 path = "discuz/wooyun-2010-080723"
 
-  [[container.name]]
-  en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
-  zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Discuz!X ≤3.4 Arbitrary File Deletion"
+cve = [""]
 app = "Discuz"
 path = "discuz/x3.4-arbitrary-file-deletion"
 
-  [[container.name]]
-  en = "Discuz!X ≤3.4 Arbitrary File Deletion"
-  zh = "Discuz!X ≤3.4 任意文件删除漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Django debug page XSS Flaw"
+cve = ["CVE-2017-12794"]
 app = "Django"
 path = "django/CVE-2017-12794"
 
-  [[container.name]]
-  en = "Django debug page XSS Flaw"
-  zh = "Django debug page XSS 漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12794"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12794"
-
-[[container]]
+[[environment]]
+name = "Django < 2.0.8 Arbitrary URL Redirection"
+cve = ["CVE-2018-14574"]
 app = "Django"
 path = "django/CVE-2018-14574"
 
-  [[container.name]]
-  en = "Django < 2.0.8 Arbitrary URL Redirection"
-  zh = "Django < 2.0.8 任意URL跳转漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-14574"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-14574"
-
-[[container]]
+[[environment]]
+name = "Django JSONField/HStoreField SQL Injection"
+cve = ["CVE-2019-14234"]
 app = "Django"
 path = "django/CVE-2019-14234"
 
-  [[container.name]]
-  en = "Django JSONField/HStoreField SQL Injection"
-  zh = "Django JSONField/HStoreField SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-14234"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-14234"
-
-[[container]]
+[[environment]]
+name = "Django GIS SQL Injection"
+cve = ["CVE-2020-9402"]
 app = "Django"
 path = "django/CVE-2020-9402"
 
-  [[container.name]]
-  en = "Django GIS SQL Injection"
-  zh = "Django GIS SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-9402"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9402"
-
-[[container]]
+[[environment]]
+name = "Django QuerySet.order_by() SQL Injection"
+cve = ["CVE-2021-35042"]
 app = "Django"
 path = "django/CVE-2021-35042"
 
-  [[container.name]]
-  en = "Django QuerySet.order_by() SQL Injection"
-  zh = "Django QuerySet.order_by() SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-35042"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-35042"
-
-[[container]]
+[[environment]]
+name = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
+cve = ["CVE-2022-34265"]
 app = "Django"
 path = "django/CVE-2022-34265"
 
-  [[container.name]]
-  en = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
-  zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2022-34265"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-34265"
-
-[[container]]
+[[environment]]
+name = "DNS Domain Transfer"
+cve = [""]
 app = "dns"
 path = "dns/dns-zone-transfer"
 
-  [[container.name]]
-  en = "DNS Domain Transfer"
-  zh = "DNS域传送漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Docker Daemon API Unauthorized Access"
+cve = [""]
 app = "docker"
 path = "docker/unauthorized-rce"
 
-  [[container.name]]
-  en = "Docker Daemon API Unauthorized Access"
-  zh = "Docker Daemon API 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
+cve = ["CVE-2014-3704"]
 app = "drupal"
 path = "drupal/CVE-2014-3704"
 
-  [[container.name]]
-  en = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
-  zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2014-3704"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3704"
-
-[[container]]
+[[environment]]
+name = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
+cve = ["CVE-2017-6920"]
 app = "drupal"
 path = "drupal/CVE-2017-6920"
 
-  [[container.name]]
-  en = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
-  zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-6920"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-6920"
-
-[[container]]
+[[environment]]
+name = "Drupal Drupalgeddon 2 Remote Code Execution"
+cve = ["CVE-2018-7600"]
 app = "drupal"
 path = "drupal/CVE-2018-7600"
 
-  [[container.name]]
-  en = "Drupal Drupalgeddon 2 Remote Code Execution"
-  zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-7600"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7600"
-
-[[container]]
+[[environment]]
+name = "Drupal Remote Code Execution"
+cve = ["CVE-2018-7602"]
 app = "drupal"
 path = "drupal/CVE-2018-7602"
 
-  [[container.name]]
-  en = "Drupal Remote Code Execution"
-  zh = "Drupal 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-7602"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7602"
-
-[[container]]
+[[environment]]
+name = "Drupal Remote Code Execution"
+cve = ["CVE-2019-6339"]
 app = "drupal"
 path = "drupal/CVE-2019-6339"
 
-  [[container.name]]
-  en = "Drupal Remote Code Execution"
-  zh = "Drupal 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-6339"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6339"
-
-[[container]]
+[[environment]]
+name = "Drupal XSS"
+cve = ["CVE-2019-6341"]
 app = "drupal"
 path = "drupal/CVE-2019-6341"
 
-  [[container.name]]
-  en = "Drupal XSS"
-  zh = "Drupal XSS漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-6341"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6341"
-
-[[container]]
+[[environment]]
+name = "Apache Dubbo Java Deserialization"
+cve = ["CVE-2019-17564"]
 app = "dubbo"
 path = "dubbo/CVE-2019-17564"
 
-  [[container.name]]
-  en = "Apache Dubbo Java Deserialization"
-  zh = "Apache Dubbo Java反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-17564"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17564"
-
-[[container]]
+[[environment]]
+name = "ECShop 4.x collection_list SQL Injection"
+cve = [""]
 app = "ecshop"
 path = "ecshop/collection_list-sqli"
 
-  [[container.name]]
-  en = "ECShop 4.x collection_list SQL Injection"
-  zh = "ECShop 4.x collection_list SQL注入"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
+cve = [""]
 app = "ecshop"
 path = "ecshop/xianzhi-2017-02-82239600"
 
-  [[container.name]]
-  en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
-  zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "ElasticSearch Command Execution"
+cve = ["CVE-2014-3120"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2014-3120"
 
-  [[container.name]]
-  en = "ElasticSearch Command Execution"
-  zh = "ElasticSearch 命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2014-3120"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3120"
-
-[[container]]
+[[environment]]
+name = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
+cve = ["CVE-2015-1427"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-1427"
 
-  [[container.name]]
-  en = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
-  zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2015-1427"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-1427"
-
-[[container]]
+[[environment]]
+name = "ElasticSearch Plug-in Directory Traversal"
+cve = ["CVE-2015-3337"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-3337"
 
-  [[container.name]]
-  en = "ElasticSearch Plug-in Directory Traversal"
-  zh = "ElasticSearch 插件目录穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2015-3337"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-3337"
-
-[[container]]
+[[environment]]
+name = "ElasticSearch Directory Traversal"
+cve = ["CVE-2015-5531"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-5531"
 
-  [[container.name]]
-  en = "ElasticSearch Directory Traversal"
-  zh = "ElasticSearch 目录穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2015-5531"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5531"
-
-[[container]]
+[[environment]]
+name = "Elasticsearch Webshell"
+cve = [""]
 app = "ElasticSearch"
 path = "elasticsearch/WooYun-2015-110216"
 
-  [[container.name]]
-  en = "Elasticsearch Webshell"
-  zh = "Elasticsearch 写入webshell漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Electron Remote Command Execution"
+cve = ["CVE-2018-1000006"]
 app = "electron"
 path = "electron/CVE-2018-1000006"
 
-  [[container.name]]
-  en = "Electron Remote Command Execution"
-  zh = "Electron 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1000006"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000006"
-
-[[container]]
+[[environment]]
+name = "Electron WebPreferences Remote Command Execution"
+cve = ["CVE-2018-15685"]
 app = "electron"
 path = "electron/CVE-2018-15685"
 
-  [[container.name]]
-  en = "Electron WebPreferences Remote Command Execution"
-  zh = "Electron WebPreferences 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-15685"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15685"
-
-[[container]]
+[[environment]]
+name = "elFinder ZIP Parameter and Arbitrary Command Injection"
+cve = ["CVE-2021-32682"]
 app = "elFinder"
 path = "elfinder/CVE-2021-32682"
 
-  [[container.name]]
-  en = "elFinder ZIP Parameter and Arbitrary Command Injection"
-  zh = "elFinder ZIP 参数与任意命令注入"
-
-  [[container.cve]]
-  id = "CVE-2021-32682"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-32682"
-
-[[container]]
+[[environment]]
+name = "Fastjson Deserialization to Arbitrary Command Execution"
+cve = ["CVE-2017-18349"]
 app = "Fastjson"
 path = "fastjson/1.2.24-rce"
 
-  [[container.name]]
-  en = "Fastjson Deserialization to Arbitrary Command Execution"
-  zh = "Fastjson 反序列化导致任意命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-18349"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-18349"
-
-[[container]]
+[[environment]]
+name = "Fastjson 1.2.47 Remote Command Execution"
+cve = [""]
 app = "Fastjson"
 path = "fastjson/1.2.47-rce"
 
-  [[container.name]]
-  en = "Fastjson 1.2.47 Remote Command Execution"
-  zh = "Fastjson 1.2.47 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "FFmpeg Arbitrary File Read/SSRF"
+cve = ["CVE-2016-1897", "CVE-2016-1898"]
 app = "ffmpeg"
 path = "ffmpeg/CVE-2016-1897"
 
-  [[container.name]]
-  en = "FFmpeg Arbitrary File Read/SSRF"
-  zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-1897,CVE-2016-1898"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-1897,CVE-2016-1898"
-
-[[container]]
+[[environment]]
+name = "FFmpeg Arbitrary File Read"
+cve = ["CVE-2017-9993"]
 app = "ffmpeg"
 path = "ffmpeg/phdays"
 
-  [[container.name]]
-  en = "FFmpeg Arbitrary File Read"
-  zh = "FFmpeg 任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-9993"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9993"
-
-[[container]]
+[[environment]]
+name = "Jinja2 SSTI Template Injection"
+cve = [""]
 app = "Jinja2"
 path = "flask/ssti"
 
-  [[container.name]]
-  en = "Jinja2 SSTI Template Injection"
-  zh = "Jinja2 SSTI模板注入"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache Flink File Upload"
+cve = ["CVE-2020-17518"]
 app = "flink"
 path = "flink/CVE-2020-17518"
 
-  [[container.name]]
-  en = "Apache Flink File Upload"
-  zh = "Apache Flink 文件上传漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-17518"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17518"
-
-[[container]]
+[[environment]]
+name = "Apache Flink Jobmanager/Logs Directory Traversal"
+cve = ["CVE-2020-17519"]
 app = "flink"
 path = "flink/CVE-2020-17519"
 
-  [[container.name]]
-  en = "Apache Flink Jobmanager/Logs Directory Traversal"
-  zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-17519"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17519"
-
-[[container]]
+[[environment]]
+name = "GeoServer OGC Filter SQL Injection"
+cve = ["CVE-2023-25157"]
 app = "GeoServer"
 path = "geoserver/CVE-2023-25157"
 
-  [[container.name]]
-  en = "GeoServer OGC Filter SQL Injection"
-  zh = "GeoServer OGC Filter SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-25157"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25157"
-
-[[container]]
+[[environment]]
+name = "GhostScript Sandbox Bypass (Command Execution)"
+cve = ["CVE-2018-16509"]
 app = "ghostscript"
 path = "ghostscript/CVE-2018-16509"
 
-  [[container.name]]
-  en = "GhostScript Sandbox Bypass (Command Execution)"
-  zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-16509"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
-
-[[container]]
+[[environment]]
+name = "GhostScript Sandbox Bypass (Command Execution)"
+cve = ["CVE-2018-19475"]
 app = "ghostscript"
 path = "ghostscript/CVE-2018-19475"
 
-  [[container.name]]
-  en = "GhostScript Sandbox Bypass (Command Execution)"
-  zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-19475"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19475"
-
-[[container]]
+[[environment]]
+name = "GhostScript Sandbox Bypass (Command Execution)"
+cve = ["CVE-2019-6116"]
 app = "ghostscript"
 path = "ghostscript/CVE-2019-6116"
 
-  [[container.name]]
-  en = "GhostScript Sandbox Bypass (Command Execution)"
-  zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-6116"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6116"
-
-[[container]]
+[[environment]]
+name = "GIT-SHELL Sandbox Bypass"
+cve = ["CVE-2017-8386"]
 app = "git"
 path = "git/CVE-2017-8386"
 
-  [[container.name]]
-  en = "GIT-SHELL Sandbox Bypass"
-  zh = "GIT-SHELL 沙盒绕过"
-
-  [[container.cve]]
-  id = "CVE-2017-8386"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8386"
-
-[[container]]
+[[environment]]
+name = "Gitea 1.4.0 Directory Traversal to Command Execution"
+cve = [""]
 app = "gitea"
 path = "gitea/1.4-rce"
 
-  [[container.name]]
-  en = "Gitea 1.4.0 Directory Traversal to Command Execution"
-  zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "GitLab Arbitrary File Read"
+cve = ["CVE-2016-9086"]
 app = "gitlab"
 path = "gitlab/CVE-2016-9086"
 
-  [[container.name]]
-  en = "GitLab Arbitrary File Read"
-  zh = "GitLab 任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-9086"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-9086"
-
-[[container]]
+[[environment]]
+name = "GitLab Remote Command Execution"
+cve = ["CVE-2021-22205"]
 app = "gitlab"
 path = "gitlab/CVE-2021-22205"
 
-  [[container.name]]
-  en = "GitLab Remote Command Execution"
-  zh = "GitLab 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-22205"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22205"
-
-[[container]]
+[[environment]]
+name = "gitlist 0.6.0 Remote Command Execution"
+cve = ["CVE-2018-1000533"]
 app = "gitlist"
 path = "gitlist/CVE-2018-1000533"
 
-  [[container.name]]
-  en = "gitlist 0.6.0 Remote Command Execution"
-  zh = "gitlist 0.6.0 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1000533"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000533"
-
-[[container]]
+[[environment]]
+name = "GlassFish Arbitrary File Read"
+cve = [""]
 app = "GlassFish"
 path = "glassfish/4.1.0"
 
-  [[container.name]]
-  en = "GlassFish Arbitrary File Read"
-  zh = "GlassFish 任意文件读取漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "GoAhead Remote Command Execution"
+cve = ["CVE-2017-17562"]
 app = "GoAhead"
 path = "goahead/CVE-2017-17562"
 
-  [[container.name]]
-  en = "GoAhead Remote Command Execution"
-  zh = "GoAhead 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-17562"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17562"
-
-[[container]]
+[[environment]]
+name = "GoAhead Server Environment Variable Injection"
+cve = ["CVE-2021-42342"]
 app = "GoAhead"
 path = "goahead/CVE-2021-42342"
 
-  [[container.name]]
-  en = "GoAhead Server Environment Variable Injection"
-  zh = "GoAhead Server 环境变量注入"
-
-  [[container.cve]]
-  id = "CVE-2021-42342"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42342"
-
-[[container]]
+[[environment]]
+name = "Gogs Arbitrary User Login"
+cve = ["CVE-2018-18925"]
 app = "Gogs"
 path = "gogs/CVE-2018-18925"
 
-  [[container.name]]
-  en = "Gogs Arbitrary User Login"
-  zh = "Gogs 任意用户登录漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-18925"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18925"
-
-[[container]]
+[[environment]]
+name = "Grafana 8.x Plug-in Module Directory Traversal"
+cve = ["CVE-2021-43798"]
 app = "Grafana"
 path = "grafana/CVE-2021-43798"
 
-  [[container.name]]
-  en = "Grafana 8.x Plug-in Module Directory Traversal"
-  zh = "Grafana 8.x 插件模块目录穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-43798"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-43798"
-
-[[container]]
+[[environment]]
+name = "Grafana Management Background SSRF"
+cve = [""]
 app = "Grafana"
 path = "grafana/admin-ssrf"
 
-  [[container.name]]
-  en = "Grafana Management Background SSRF"
-  zh = "Grafana管理后台SSRF"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "H2 Database Console Unauthorized Access"
+cve = [""]
 app = "Springboot H2 Database"
 path = "h2database/h2-console-unacc"
 
-  [[container.name]]
-  en = "H2 Database Console Unauthorized Access"
-  zh = "H2 Database Console 未授权访问"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Hadoop YARN ResourceManager Unauthorized Access"
+cve = [""]
 app = "Hadoop YARN"
 path = "hadoop/unauthorized-yarn"
 
-  [[container.name]]
-  en = "Hadoop YARN ResourceManager Unauthorized Access"
-  zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache HTTPD Newline Parsing"
+cve = ["CVE-2017-15715"]
 app = "Apache HTTP Server"
 path = "httpd/CVE-2017-15715"
 
-  [[container.name]]
-  en = "Apache HTTPD Newline Parsing"
-  zh = "Apache HTTPD 换行解析漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-15715"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-15715"
-
-[[container]]
+[[environment]]
+name = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
+cve = ["CVE-2021-40438"]
 app = "Apache HTTP Server"
 path = "httpd/CVE-2021-40438"
 
-  [[container.name]]
-  en = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
-  zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-40438"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-40438"
-
-[[container]]
+[[environment]]
+name = "Apache HTTP Server 2.4.49 Path Traversal"
+cve = ["CVE-2021-41773"]
 app = "Apache HTTP Server"
 path = "httpd/CVE-2021-41773"
 
-  [[container.name]]
-  en = "Apache HTTP Server 2.4.49 Path Traversal"
-  zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-41773"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41773"
-
-[[container]]
+[[environment]]
+name = "Apache HTTP Server 2.4.50 Path Traversal"
+cve = ["CVE-2021-42013"]
 app = "Apache HTTP Server"
 path = "httpd/CVE-2021-42013"
 
-  [[container.name]]
-  en = "Apache HTTP Server 2.4.50 Path Traversal"
-  zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-42013"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42013"
-
-[[container]]
+[[environment]]
+name = "Apache HTTPD Unknown Suffix Parsing"
+cve = [""]
 app = "Apache HTTP Server"
 path = "httpd/apache_parsing_vulnerability"
 
-  [[container.name]]
-  en = "Apache HTTPD Unknown Suffix Parsing"
-  zh = "Apache HTTPD 未知后缀解析漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache SSI Remote Command Execution"
+cve = [""]
 app = "Apache HTTP Server"
 path = "httpd/ssi-rce"
 
-  [[container.name]]
-  en = "Apache SSI Remote Command Execution"
-  zh = "Apache SSI 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Imagetragick Command Execution"
+cve = ["CVE-2016-3714"]
 app = "ImageMagick"
 path = "imagemagick/imagetragick"
 
-  [[container.name]]
-  en = "Imagetragick Command Execution"
-  zh = "Imagetragick 命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-3714"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3714"
-
-[[container]]
+[[environment]]
+name = "ImageMagick PDF Password Location Command Injection"
+cve = ["CVE-2020-29599"]
 app = "imagemagick"
 path = "imagemagick/CVE-2020-29599"
 
-  [[container.name]]
-  en = "ImageMagick PDF Password Location Command Injection"
-  zh = "ImageMagick PDF密码位置命令注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-29599"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-29599"
-
-[[container]]
+[[environment]]
+name = "ImageMagick Arbitrary File Read"
+cve = ["CVE-2022-44268"]
 app = "imagemagick"
 path = "imagemagick/CVE-2022-44268"
 
-  [[container.name]]
-  en = "ImageMagick Arbitrary File Read"
-  zh = "ImageMagick任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2022-44268"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-44268"
-
-[[container]]
+[[environment]]
+name = "InfluxDB Empty JWT Secret Key Authentication Bypass"
+cve = ["CVE-2019-20933"]
 app = "InfluxDB"
 path = "influxdb/CVE-2019-20933"
 
-  [[container.name]]
-  en = "InfluxDB Empty JWT Secret Key Authentication Bypass"
-  zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
-
-  [[container.cve]]
-  id = "CVE-2019-20933"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-20933"
-
-[[container]]
+[[environment]]
+name = "Jackson-databind Deserialization"
+cve = ["CVE-2017-7525"]
 app = "Jackson-databind"
 path = "jackson/CVE-2017-7525"
 
-  [[container.name]]
-  en = "Jackson-databind Deserialization"
-  zh = "Jackson-databind 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-7525"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
-
-[[container]]
+[[environment]]
+name = "Java RMI codebase Remote Code Execution"
+cve = [""]
 app = "java rmi"
 path = "java/rmi-codebase"
 
-  [[container.name]]
-  en = "Java RMI codebase Remote Code Execution"
-  zh = "Java RMI codebase 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
+cve = [""]
 app = "java rmi"
 path = "java/rmi-registry-bind-deserialization"
 
-  [[container.name]]
-  en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
-  zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
+cve = [""]
 app = "java rmi"
 path = "java/rmi-registry-bind-deserialization-bypass"
 
-  [[container.name]]
-  en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
-  zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "JBoss 5.x/6.x Deserialization"
+cve = ["CVE-2017-12149"]
 app = "jboss"
 path = "jboss/CVE-2017-12149"
 
-  [[container.name]]
-  en = "JBoss 5.x/6.x Deserialization"
-  zh = "JBoss 5.x/6.x 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12149"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12149"
-
-[[container]]
+[[environment]]
+name = "JBoss 4.x JBossMQ JMS Deserialization"
+cve = ["CVE-2017-7504"]
 app = "jboss"
 path = "jboss/CVE-2017-7504"
 
-  [[container.name]]
-  en = "JBoss 4.x JBossMQ JMS Deserialization"
-  zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-7504"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7504"
-
-[[container]]
+[[environment]]
+name = "JBoss JMXInvokerServlet Deserialization"
+cve = [""]
 app = "jboss"
 path = "jboss/JMXInvokerServlet-deserialization"
 
-  [[container.name]]
-  en = "JBoss JMXInvokerServlet Deserialization"
-  zh = "JBoss JMXInvokerServlet 反序列化漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Jenkins-CI Remote Code Execution"
+cve = ["CVE-2017-1000353"]
 app = "Jenkins"
 path = "jenkins/CVE-2017-1000353"
 
-  [[container.name]]
-  en = "Jenkins-CI Remote Code Execution"
-  zh = "Jenkins-CI 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-1000353"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-1000353"
-
-[[container]]
+[[environment]]
+name = "Jenkins Remote Command Execution"
+cve = ["CVE-2018-1000861"]
 app = "Jenkins"
 path = "jenkins/CVE-2018-1000861"
 
-  [[container.name]]
-  en = "Jenkins Remote Command Execution"
-  zh = "Jenkins远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1000861"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000861"
-
-[[container]]
+[[environment]]
+name = "Jetty WEB-INF Sensitive Information Disclosure"
+cve = ["CVE-2021-28164"]
 app = "jetty"
 path = "jetty/CVE-2021-28164"
 
-  [[container.name]]
-  en = "Jetty WEB-INF Sensitive Information Disclosure"
-  zh = "Jetty WEB-INF 敏感信息泄露漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-28164"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28164"
-
-[[container]]
+[[environment]]
+name = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
+cve = ["CVE-2021-28169"]
 app = "jetty"
 path = "jetty/CVE-2021-28169"
 
-  [[container.name]]
-  en = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
-  zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-28169"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28169"
-
-[[container]]
+[[environment]]
+name = "Jetty WEB-INF Sensitive Information Disclosure"
+cve = ["CVE-2021-34429"]
 app = "jetty"
 path = "jetty/CVE-2021-34429"
 
-  [[container.name]]
-  en = "Jetty WEB-INF Sensitive Information Disclosure"
-  zh = "Jetty WEB-INF 敏感信息泄露漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-34429"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34429"
-
-[[container]]
+[[environment]]
+name = "Atlassian Jira Template Injection"
+cve = ["CVE-2019-11581"]
 app = "jira"
 path = "jira/CVE-2019-11581"
 
-  [[container.name]]
-  en = "Atlassian Jira Template Injection"
-  zh = "Atlassian Jira 模板注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-11581"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11581"
-
-[[container]]
+[[environment]]
+name = "Jmeter RMI Deserialization Command Execution"
+cve = ["CVE-2018-1297"]
 app = "Apache Jmeter"
 path = "jmeter/CVE-2018-1297"
 
-  [[container.name]]
-  en = "Jmeter RMI Deserialization Command Execution"
-  zh = "Jmeter RMI 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1297"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1297"
-
-[[container]]
+[[environment]]
+name = "Joomla 3.4.5 Deserialization"
+cve = ["CVE-2015-8562"]
 app = "Joomla"
 path = "joomla/CVE-2015-8562"
 
-  [[container.name]]
-  en = "Joomla 3.4.5 Deserialization"
-  zh = "Joomla 3.4.5 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2015-8562"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-8562"
-
-[[container]]
+[[environment]]
+name = "Joomla 3.7.0 SQL Injection"
+cve = ["CVE-2017-8917"]
 app = "Joomla"
 path = "joomla/CVE-2017-8917"
 
-  [[container.name]]
-  en = "Joomla 3.7.0 SQL Injection"
-  zh = "Joomla 3.7.0 SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-8917"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8917"
-
-[[container]]
+[[environment]]
+name = "Joomla 4.2.7 Permission Bypass"
+cve = ["CVE-2023-23752"]
 app = "Joomla"
 path = "joomla/CVE-2023-23752"
 
-  [[container.name]]
-  en = "Joomla 4.2.7 Permission Bypass"
-  zh = "Joomla 4.2.7 权限绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-23752"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-23752"
-
-[[container]]
+[[environment]]
+name = "Jupyter Notebook Unauthorized Access"
+cve = [""]
 app = "Jupyter"
 path = "jupyter/notebook-rce"
 
-  [[container.name]]
-  en = "Jupyter Notebook Unauthorized Access"
-  zh = "Jupyter Notebook 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache Kafka Clients JNDI Injection"
+cve = ["CVE-2023-25194"]
 app = "Apache Kafka"
 path = "kafka/CVE-2023-25194"
 
-  [[container.name]]
-  en = "Apache Kafka Clients JNDI Injection"
-  zh = "Apache Kafka Clients JNDI注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-25194"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25194"
-
-[[container]]
+[[environment]]
+name = "Kibana Local File Inclusion"
+cve = ["CVE-2018-17246"]
 app = "kibana"
 path = "kibana/CVE-2018-17246"
 
-  [[container.name]]
-  en = "Kibana Local File Inclusion"
-  zh = "Kibana 本地文件包含漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-17246"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-17246"
-
-[[container]]
+[[environment]]
+name = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
+cve = ["CVE-2019-7609"]
 app = "kibana"
 path = "kibana/CVE-2019-7609"
 
-  [[container.name]]
-  en = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
-  zh = "Kibana 原型链污染导致任意代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-7609"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7609"
-
-[[container]]
+[[environment]]
+name = "Laravel Ignition 2.5.1 Code Execution"
+cve = ["CVE-2021-3129"]
 app = "laravel"
 path = "kibana/CVE-2021-3129"
 
-  [[container.name]]
-  en = "Laravel Ignition 2.5.1 Code Execution"
-  zh = "Laravel Ignition 2.5.1 代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-3129"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-3129"
-
-[[container]]
+[[environment]]
+name = "libssh Server-side Authentication Bypass"
+cve = ["CVE-2018-10933"]
 app = "libssh"
 path = "libssh/CVE-2018-10933"
 
-  [[container.name]]
-  en = "libssh Server-side Authentication Bypass"
-  zh = "libssh 服务端权限认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-10933"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-10933"
-
-[[container]]
+[[environment]]
+name = "Liferay Portal CE Deserialization Command Execution"
+cve = ["CVE-2020-7961"]
 app = "Liferay Portal"
 path = "liferay-portal/CVE-2020-7961"
 
-  [[container.name]]
-  en = "Liferay Portal CE Deserialization Command Execution"
-  zh = "Liferay Portal CE 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-7961"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7961"
-
-[[container]]
+[[environment]]
+name = "Apache Log4j Server Deserialization Command Execution"
+cve = ["CVE-2017-5645"]
 app = "Apache Log4j"
 path = "log4j/CVE-2017-5645"
 
-  [[container.name]]
-  en = "Apache Log4j Server Deserialization Command Execution"
-  zh = "Apache Log4j Server 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-5645"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5645"
-
-[[container]]
+[[environment]]
+name = "Apache Log4j2 lookup JNDI Injection"
+cve = ["CVE-2021-44228"]
 app = "Apache Log4j"
 path = "log4j/CVE-2021-44228"
 
-  [[container.name]]
-  en = "Apache Log4j2 lookup JNDI Injection"
-  zh = "Apache Log4j2 lookup JNDI 注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-44228"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
-
-[[container]]
+[[environment]]
+name = "Magento 2.2 SQL Injection"
+cve = [""]
 app = "Magento"
 path = "magento/2.2-sqli"
 
-  [[container.name]]
-  en = "Magento 2.2 SQL Injection"
-  zh = "Magento 2.2 SQL注入漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Metabase Arbitrary File Read"
+cve = ["CVE-2021-41277"]
 app = "metabase"
 path = "metabase/CVE-2021-41277"
 
-  [[container.name]]
-  en = "Metabase Arbitrary File Read"
-  zh = "Metabase任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-41277"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41277"
-
-[[container]]
+[[environment]]
+name = "mini_httpd Arbitrary File Read"
+cve = ["CVE-2018-18778"]
 app = "mini_httpd"
 path = "mini_httpd/CVE-2018-18778"
 
-  [[container.name]]
-  en = "mini_httpd Arbitrary File Read"
-  zh = "mini_httpd任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-18778"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18778"
-
-[[container]]
+[[environment]]
+name = "MinIO Cluster Mode Information Disclosure"
+cve = ["CVE-2023-28432"]
 app = "MinIO"
 path = "minio/CVE-2023-28432"
 
-  [[container.name]]
-  en = "MinIO Cluster Mode Information Disclosure"
-  zh = "MinIO集群模式信息泄露漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-28432"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-28432"
-
-[[container]]
+[[environment]]
+name = "Mojarra JSF ViewState Deserialization"
+cve = [""]
 app = "Mojarra JSF"
 path = "mojarra/jsf-viewstate-deserialization"
 
-  [[container.name]]
-  en = "Mojarra JSF ViewState Deserialization"
-  zh = "Mojarra JSF ViewState 反序列化漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Mongo Express Remote Code Execution"
+cve = ["CVE-2019-10758"]
 app = "mongo-express"
 path = "mongo-express/CVE-2019-10758"
 
-  [[container.name]]
-  en = "Mongo Express Remote Code Execution"
-  zh = "Mongo Express 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-10758"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-10758"
-
-[[container]]
+[[environment]]
+name = "MySQL Authentication Bypass"
+cve = ["CVE-2012-2122"]
 app = "MySQL"
 path = "mysql/CVE-2012-2122"
 
-  [[container.name]]
-  en = "MySQL Authentication Bypass"
-  zh = "MySQL 身份认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2012-2122"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-2122"
-
-[[container]]
+[[environment]]
+name = "Nacos Authentication Bypass"
+cve = ["CVE-2021-29441"]
 app = "Nacos"
 path = "nacos/CVE-2021-29441"
 
-  [[container.name]]
-  en = "Nacos Authentication Bypass"
-  zh = "Nacos 认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-29441"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29441"
-
-[[container]]
+[[environment]]
+name = "Neo4j Shell Server Deserialization"
+cve = ["CVE-2021-34371"]
 app = "Neo4j"
 path = "neo4j/CVE-2021-34371"
 
-  [[container.name]]
-  en = "Neo4j Shell Server Deserialization"
-  zh = "Neo4j Shell Server 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-34371"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34371"
-
-[[container]]
+[[environment]]
+name = "Nexus Repository Manager 3 Remote Command Execution"
+cve = ["CVE-2019-7238"]
 app = "Nexus Repository Manager"
 path = "nexus/CVE-2019-7238"
 
-  [[container.name]]
-  en = "Nexus Repository Manager 3 Remote Command Execution"
-  zh = "Nexus Repository Manager 3 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-7238"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7238"
-
-[[container]]
+[[environment]]
+name = "Nexus Repository Manager 3 Remote Command Execution"
+cve = ["CVE-2020-10199"]
 app = "Nexus Repository Manager"
 path = "nexus/CVE-2020-10199"
 
-  [[container.name]]
-  en = "Nexus Repository Manager 3 Remote Command Execution"
-  zh = "Nexus Repository Manager 3 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-10199"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10199"
-
-[[container]]
+[[environment]]
+name = "Nexus Repository Manager 3 Remote Command Execution"
+cve = ["CVE-2020-10204"]
 app = "Nexus Repository Manager"
 path = "nexus/CVE-2020-10204"
 
-  [[container.name]]
-  en = "Nexus Repository Manager 3 Remote Command Execution"
-  zh = "Nexus Repository Manager 3 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-10204"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10204"
-
-[[container]]
+[[environment]]
+name = "Nginx Filename Logic"
+cve = ["CVE-2013-4547"]
 app = "Nginx"
 path = "nginx/CVE-2013-4547"
 
-  [[container.name]]
-  en = "Nginx Filename Logic"
-  zh = "Nginx 文件名逻辑漏洞"
-
-  [[container.cve]]
-  id = "CVE-2013-4547"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-4547"
-
-[[container]]
+[[environment]]
+name = "Nginx Out-of-Bounds Read Cache"
+cve = ["CVE-2017-7529"]
 app = "Nginx"
 path = "nginx/CVE-2017-7529"
 
-  [[container.name]]
-  en = "Nginx Out-of-Bounds Read Cache"
-  zh = "Nginx越界读取缓存漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-7529"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7529"
-
-[[container]]
+[[environment]]
+name = "Nginx Configuration Errors"
+cve = [""]
 app = "Nginx"
 path = "nginx/insecure-configuration"
 
-  [[container.name]]
-  en = "Nginx Configuration Errors"
-  zh = "Nginx 配置错误三例"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Nginx Parsing"
+cve = [""]
 app = "Nginx"
 path = "nginx/nginx_parsing_vulnerability"
 
-  [[container.name]]
-  en = "Nginx Parsing"
-  zh = "Nginx 解析漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "NodeJS Directory Traversal"
+cve = ["CVE-2017-14849"]
 app = "node"
 path = "node/CVE-2017-14849"
 
-  [[container.name]]
-  en = "NodeJS Directory Traversal"
-  zh = "NodeJS 目录穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-14849"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-14849"
-
-[[container]]
+[[environment]]
+name = "node-postgres Code Execution"
+cve = ["CVE-2017-16082"]
 app = "node-postgres"
 path = "node/CVE-2017-16082"
 
-  [[container.name]]
-  en = "node-postgres Code Execution"
-  zh = "node-postgres 代码执行漏洞分析"
-
-  [[container.cve]]
-  id = "CVE-2017-16082"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-16082"
-
-[[container]]
+[[environment]]
+name = "ntopng Permission Bypass"
+cve = ["CVE-2021-28073"]
 app = "ntopng"
 path = "ntopng/CVE-2021-28073"
 
-  [[container.name]]
-  en = "ntopng Permission Bypass"
-  zh = "ntopng权限绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-28073"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28073"
-
-[[container]]
+[[environment]]
+name = "Apache OfBiz Deserialization Command Execution"
+cve = ["CVE-2020-9496"]
 app = "Apache OfBiz"
 path = "ofbiz/CVE-2020-9496"
 
-  [[container.name]]
-  en = "Apache OfBiz Deserialization Command Execution"
-  zh = "Apache OfBiz 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-9496"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9496"
-
-[[container]]
+[[environment]]
+name = "Openfire Management Background Authentication Bypass"
+cve = ["CVE-2023-32315"]
 app = "Openfire"
 path = "openfire/CVE-2023-32315"
 
-  [[container.name]]
-  en = "Openfire Management Background Authentication Bypass"
-  zh = "Openfire管理后台认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-32315"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-32315"
-
-[[container]]
+[[environment]]
+name = "OpenSMTPD Remote Command Execution"
+cve = ["CVE-2020-7247"]
 app = "OpenSMTPD"
 path = "opensmtpd/CVE-2020-7247"
 
-  [[container.name]]
-  en = "OpenSMTPD Remote Command Execution"
-  zh = "OpenSMTPD 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-7247"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7247"
-
-[[container]]
+[[environment]]
+name = "OpenSSH Username Enumeration"
+cve = ["CVE-2018-15473"]
 app = "OpenSSH"
 path = "openssh/CVE-2018-15473"
 
-  [[container.name]]
-  en = "OpenSSH Username Enumeration"
-  zh = "OpenSSH 用户名枚举漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-15473"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15473"
-
-[[container]]
+[[environment]]
+name = "OpenSSL Heartbleed"
+cve = ["CVE-2014-0160"]
 app = "OpenSSL"
 path = "openssl/CVE-2014-0160"
 
-  [[container.name]]
-  en = "OpenSSL Heartbleed"
-  zh = "OpenSSL 心脏出血漏洞"
-
-  [[container.cve]]
-  id = "CVE-2014-0160"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-0160"
-
-[[container]]
+[[environment]]
+name = "OpenSSL Infinite Loop DoS"
+cve = ["CVE-2022-0778"]
 app = "OpenSSL"
 path = "openssl/CVE-2022-0778"
 
-  [[container.name]]
-  en = "OpenSSL Infinite Loop DoS"
-  zh = "OpenSSL无限循环DoS漏洞"
-
-  [[container.cve]]
-  id = "CVE-2022-0778"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0778"
-
-[[container]]
+[[environment]]
+name = "OpenTSDB Command Injection"
+cve = ["CVE-2020-35476"]
 app = "OpenTSDB"
 path = "opentsdb/CVE-2020-35476"
 
-  [[container.name]]
-  en = "OpenTSDB Command Injection"
-  zh = "OpenTSDB 命令注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-35476"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-35476"
-
-[[container]]
+[[environment]]
+name = "PHP 8.1.0-dev Development Version Backdoor Event"
+cve = [""]
 app = "PHP"
 path = "php/8.1-backdoor"
 
-  [[container.name]]
-  en = "PHP 8.1.0-dev Development Version Backdoor Event"
-  zh = "PHP 8.1.0-dev 开发版本后门事件"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "PHP-CGI Remote Code Execution"
+cve = ["CVE-2012-1823"]
 app = "PHP-CGI"
 path = "php/CVE-2012-1823"
 
-  [[container.name]]
-  en = "PHP-CGI Remote Code Execution"
-  zh = "PHP-CGI远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2012-1823"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-1823"
-
-[[container]]
+[[environment]]
+name = "PHP-IMAP Remote Command Execution"
+cve = ["CVE-2018-19518"]
 app = "PHP-IMAP"
 path = "php/CVE-2018-19518"
 
-  [[container.name]]
-  en = "PHP-IMAP Remote Command Execution"
-  zh = "PHP-IMAP 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-19518"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19518"
-
-[[container]]
+[[environment]]
+name = "PHP-FPM Remote Command Execution"
+cve = ["CVE-2019-11043"]
 app = "PHP-FPM"
 path = "php/CVE-2019-11043"
 
-  [[container.name]]
-  en = "PHP-FPM Remote Command Execution"
-  zh = "PHP-FPM 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-11043"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11043"
-
-[[container]]
+[[environment]]
+name = "PHP-FPM FastCGI Unauthorized Access"
+cve = [""]
 app = "PHP-FPM"
 path = "php/fpm"
 
-  [[container.name]]
-  en = "PHP-FPM FastCGI Unauthorized Access"
-  zh = "PHP-FPM FastCGI 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "PHP Files Vulnerabilities (by phpinfo())"
+cve = [""]
 app = "PHP"
 path = "php/inclusion"
 
-  [[container.name]]
-  en = "PHP Files Vulnerabilities (by phpinfo())"
-  zh = "PHP文件包含漏洞 (利用phpinfo())"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "PHP XML Entity Injection"
+cve = [""]
 app = "PHP"
 path = "php/php_xxe"
 
-  [[container.name]]
-  en = "PHP XML Entity Injection"
-  zh = "PHP XML实体注入"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "XDebug Remote Debugging Code Execution"
+cve = [""]
 app = "PHP"
 path = "php/xdebug-rce"
 
-  [[container.name]]
-  en = "XDebug Remote Debugging Code Execution"
-  zh = "XDebug 远程调试漏洞 (代码执行)"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "PHPMailer Arbitrary File Read"
+cve = ["CVE-2017-5223"]
 app = "PHPMailer"
 path = "phpmailer/CVE-2017-5223"
 
-  [[container.name]]
-  en = "PHPMailer Arbitrary File Read"
-  zh = "PHPMailer 任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-5223"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5223"
-
-[[container]]
+[[environment]]
+name = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
+cve = ["CVE-2016-5734"]
 app = "phpmyadmin"
 path = "phpmyadmin/CVE-2016-5734"
 
-  [[container.name]]
-  en = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
-  zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-5734"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5734"
-
-[[container]]
+[[environment]]
+name = "phpmyadmin 4.8.1 Remote File Inclusion"
+cve = ["CVE-2018-12613"]
 app = "phpmyadmin"
 path = "phpmyadmin/CVE-2018-12613"
 
-  [[container.name]]
-  en = "phpmyadmin 4.8.1 Remote File Inclusion"
-  zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-12613"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-12613"
-
-[[container]]
+[[environment]]
+name = "phpmyadmin scripts/setup.php Deserialization"
+cve = [""]
 app = "phpmyadmin"
 path = "phpmyadmin/WooYun-2016-199433"
 
-  [[container.name]]
-  en = "phpmyadmin scripts/setup.php Deserialization"
-  zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "phpunit Remote Code Execution"
+cve = ["CVE-2017-9841"]
 app = "phpunit"
 path = "phpunit/CVE-2017-9841"
 
-  [[container.name]]
-  en = "phpunit Remote Code Execution"
-  zh = "phpunit 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-9841"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9841"
-
-[[container]]
+[[environment]]
+name = "Polkit pkexec Privilege Escalation"
+cve = ["CVE-2021-4034"]
 app = "Polkit Pkexec"
 path = "polkit/CVE-2021-4034"
 
-  [[container.name]]
-  en = "Polkit pkexec Privilege Escalation"
-  zh = "Polkit pkexec 权限提升漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-4034"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-4034"
-
-[[container]]
+[[environment]]
+name = "PostgreSQL Privilege Escalation"
+cve = ["CVE-2018-1058"]
 app = "PostgreSQL"
 path = "postgres/CVE-2018-1058"
 
-  [[container.name]]
-  en = "PostgreSQL Privilege Escalation"
-  zh = "PostgreSQL 提权漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1058"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1058"
-
-[[container]]
+[[environment]]
+name = "PostgreSQL High Privilege Command Execution"
+cve = ["CVE-2019-9193"]
 app = "PostgreSQL"
 path = "postgres/CVE-2019-9193"
 
-  [[container.name]]
-  en = "PostgreSQL High Privilege Command Execution"
-  zh = "PostgreSQL 高权限命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-9193"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-9193"
-
-[[container]]
+[[environment]]
+name = "Python PIL Remote Command Execution (GhostButt)"
+cve = ["CVE-2017-8291"]
 app = "Python"
 path = "python/PIL-CVE-2017-8291"
 
-  [[container.name]]
-  en = "Python PIL Remote Command Execution (GhostButt)"
-  zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
-
-  [[container.cve]]
-  id = "CVE-2017-8291"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8291"
-
-[[container]]
+[[environment]]
+name = "Python PIL Remote Command Execution (via Ghostscript)"
+cve = ["CVE-2018-16509"]
 app = "Python"
 path = "python/PIL-CVE-2018-16509"
 
-  [[container.name]]
-  en = "Python PIL Remote Command Execution (via Ghostscript)"
-  zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
-
-  [[container.cve]]
-  id = "CVE-2018-16509"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
-
-[[container]]
+[[environment]]
+name = "Python Unpickle Deserialization"
+cve = [""]
 app = "Python"
 path = "python/unpickle"
 
-  [[container.name]]
-  en = "Python Unpickle Deserialization"
-  zh = "Python Unpickle 反序列化漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Ruby on Rails Path Traversal"
+cve = ["CVE-2018-3760"]
 app = "Ruby on Rails"
 path = "rails/CVE-2018-3760"
 
-  [[container.name]]
-  en = "Ruby on Rails Path Traversal"
-  zh = "Ruby on Rails 路径穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-3760"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-3760"
-
-[[container]]
+[[environment]]
+name = "Ruby on Rails Path Traversal and Arbitrary File Read"
+cve = ["CVE-2019-5418"]
 app = "Ruby on Rails"
 path = "rails/CVE-2019-5418"
 
-  [[container.name]]
-  en = "Ruby on Rails Path Traversal and Arbitrary File Read"
-  zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-5418"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-5418"
-
-[[container]]
+[[environment]]
+name = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
+cve = [""]
 app = "redis"
 path = "redis/4-unacc"
 
-  [[container.name]]
-  en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
-  zh = "Redis 4.x/5.x 主从复制导致的命令执行"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Redis Lua Sandbox Bypass Command Execution"
+cve = ["CVE-2022-0543"]
 app = "redis"
 path = "redis/CVE-2022-0543"
 
-  [[container.name]]
-  en = "Redis Lua Sandbox Bypass Command Execution"
-  zh = "Redis Lua沙盒绕过命令执行"
-
-  [[container.cve]]
-  id = "CVE-2022-0543"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0543"
-
-[[container]]
+[[environment]]
+name = "Rocket Chat MongoDB Injection"
+cve = ["CVE-2021-22911"]
 app = "rocket chat"
 path = "rocketchat/CVE-2021-22911"
 
-  [[container.name]]
-  en = "Rocket Chat MongoDB Injection"
-  zh = "Rocket Chat MongoDB 注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-22911"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22911"
-
-[[container]]
+[[environment]]
+name = "Apache RocketMQ Remote Command Execution"
+cve = ["CVE-2023-33246"]
 app = "Apache RocketMQ"
 path = "rocketmq/CVE-2023-33246"
 
-  [[container.name]]
-  en = "Apache RocketMQ Remote Command Execution"
-  zh = "Apache RocketMQ 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-33246"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-33246"
-
-[[container]]
+[[environment]]
+name = "rsync Unauthorized Access"
+cve = [""]
 app = "rsync"
 path = "rsync/common"
 
-  [[container.name]]
-  en = "rsync Unauthorized Access"
-  zh = "rsync 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Ruby Net::FTP Module Command Injection"
+cve = ["CVE-2017-17405"]
 app = "ruby"
 path = "ruby/CVE-2017-17405"
 
-  [[container.name]]
-  en = "Ruby Net::FTP Module Command Injection"
-  zh = "Ruby Net::FTP 模块命令注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-17405"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17405"
-
-[[container]]
+[[environment]]
+name = "SaltStack Horizontal Privilege Bypass"
+cve = ["CVE-2020-11651"]
 app = "SaltStack"
 path = "saltstack/CVE-2020-11651"
 
-  [[container.name]]
-  en = "SaltStack Horizontal Privilege Bypass"
-  zh = "SaltStack 水平权限绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-11651"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11651"
-
-[[container]]
+[[environment]]
+name = "SaltStack Arbitrary File Read and Write"
+cve = ["CVE-2020-11652"]
 app = "SaltStack"
 path = "saltstack/CVE-2020-11652"
 
-  [[container.name]]
-  en = "SaltStack Arbitrary File Read and Write"
-  zh = "SaltStack 任意文件读写漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-11652"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11652"
-
-[[container]]
+[[environment]]
+name = "SaltStack Command Injection"
+cve = ["CVE-2020-16846"]
 app = "SaltStack"
 path = "saltstack/CVE-2020-16846"
 
-  [[container.name]]
-  en = "SaltStack Command Injection"
-  zh = "SaltStack 命令注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-16846"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-16846"
-
-[[container]]
+[[environment]]
+name = "Samba Remote Command Execution"
+cve = ["CVE-2017-7494"]
 app = "Samba"
 path = "samba/CVE-2017-7494"
 
-  [[container.name]]
-  en = "Samba Remote Command Execution"
-  zh = "Samba 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-7494"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7494"
-
-[[container]]
+[[environment]]
+name = "Scrapyd Unauthorized Access"
+cve = [""]
 app = "Scrapyd"
 path = "scrapy/scrapyd-unacc"
 
-  [[container.name]]
-  en = "Scrapyd Unauthorized Access"
-  zh = "Scrapyd 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache Shiro Authentication Bypass"
+cve = ["CVE-2010-3863"]
 app = "shiro"
 path = "shiro/CVE-2010-3863"
 
-  [[container.name]]
-  en = "Apache Shiro Authentication Bypass"
-  zh = "Apache Shiro 认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2010-3863"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-3863"
-
-[[container]]
+[[environment]]
+name = "Apache Shiro 1.2.4 Deserialization"
+cve = ["CVE-2016-4437"]
 app = "shiro"
 path = "shiro/CVE-2016-4437"
 
-  [[container.name]]
-  en = "Apache Shiro 1.2.4 Deserialization"
-  zh = "Apache Shiro 1.2.4反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-4437"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4437"
-
-[[container]]
+[[environment]]
+name = "Apache Shiro Authentication Bypass"
+cve = ["CVE-2020-1957"]
 app = "shiro"
 path = "shiro/CVE-2020-1957"
 
-  [[container.name]]
-  en = "Apache Shiro Authentication Bypass"
-  zh = "Apache Shiro 认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-1957"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1957"
-
-[[container]]
+[[environment]]
+name = "Apache Skywalking 8.3.0 SQL Injection"
+cve = [""]
 app = "skywalking"
 path = "skywalking/8.3.0-sqli"
 
-  [[container.name]]
-  en = "Apache Skywalking 8.3.0 SQL Injection"
-  zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache Solr Remote Command Execution"
+cve = ["CVE-2017-12629"]
 app = "solr"
 path = "solr/CVE-2017-12629-RCE"
 
-  [[container.name]]
-  en = "Apache Solr Remote Command Execution"
-  zh = "Apache Solr 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12629"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
-
-[[container]]
+[[environment]]
+name = "Apache Solr XML Entity Injection"
+cve = ["CVE-2017-12629"]
 app = "solr"
 path = "solr/CVE-2017-12629-XXE"
 
-  [[container.name]]
-  en = "Apache Solr XML Entity Injection"
-  zh = "Apache Solr XML 实体注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12629"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
-
-[[container]]
+[[environment]]
+name = "Apache Solr Remote Command Execution"
+cve = ["CVE-2019-0193"]
 app = "solr"
 path = "solr/CVE-2019-0193"
 
-  [[container.name]]
-  en = "Apache Solr Remote Command Execution"
-  zh = "Apache Solr 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-0193"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0193"
-
-[[container]]
+[[environment]]
+name = "Apache Solr Velocity Inject Remote Command Execution"
+cve = ["CVE-2019-17558"]
 app = "solr"
 path = "solr/CVE-2019-17558"
 
-  [[container.name]]
-  en = "Apache Solr Velocity Inject Remote Command Execution"
-  zh = "Apache Solr Velocity 注入远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-17558"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17558"
-
-[[container]]
+[[environment]]
+name = "Apache Solr RemoteStreaming File Reading and SSRF"
+cve = [""]
 app = "solr"
 path = "solr/Remote-Streaming-Fileread"
 
-  [[container.name]]
-  en = "Apache Solr RemoteStreaming File Reading and SSRF"
-  zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache Spark Unauthorized Access Leak"
+cve = [""]
 app = "spark"
 path = "spark/unacc"
 
-  [[container.name]]
-  en = "Apache Spark Unauthorized Access Leak"
-  zh = "Apache Spark 未授权访问漏"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Spring Security Oauth2 Remote Command Execution"
+cve = ["CVE-2016-4977"]
 app = "spring security oauth2"
 path = "spring/CVE-2016-4977"
 
-  [[container.name]]
-  en = "Spring Security Oauth2 Remote Command Execution"
-  zh = "Spring Security Oauth2 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-4977"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4977"
-
-[[container]]
+[[environment]]
+name = "Spring WebFlow Remote Code Execution"
+cve = ["CVE-2017-4971"]
 app = "spring webflow"
 path = "spring/CVE-2017-4971"
 
-  [[container.name]]
-  en = "Spring WebFlow Remote Code Execution"
-  zh = "Spring WebFlow 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-4971"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-4971"
-
-[[container]]
+[[environment]]
+name = "Spring Data Rest Remote Command Execution"
+cve = ["CVE-2017-8046"]
 app = "spring data rest"
 path = "spring/CVE-2017-8046"
 
-  [[container.name]]
-  en = "Spring Data Rest Remote Command Execution"
-  zh = "Spring Data Rest 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-8046"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8046"
-
-[[container]]
+[[environment]]
+name = "Spring Messaging Remote Command Execution"
+cve = ["CVE-2018-1270"]
 app = "spring messaging"
 path = "spring/CVE-2018-1270"
 
-  [[container.name]]
-  en = "Spring Messaging Remote Command Execution"
-  zh = "Spring Messaging 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1270"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1270"
-
-[[container]]
+[[environment]]
+name = "Spring Data Commons Remote Command Execution"
+cve = ["CVE-2018-1273"]
 app = "spring data commons"
 path = "spring/CVE-2018-1273"
 
-  [[container.name]]
-  en = "Spring Data Commons Remote Command Execution"
-  zh = "Spring Data Commons 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-1273"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1273"
-
-[[container]]
+[[environment]]
+name = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
+cve = ["CVE-2022-22947"]
 app = "spring cloud gateway"
 path = "spring/CVE-2022-22947"
 
-  [[container.name]]
-  en = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
-  zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
-
-  [[container.cve]]
-  id = "CVE-2022-22947"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22947"
-
-[[container]]
+[[environment]]
+name = "Spring Cloud Function SpEL Expression Command Injection"
+cve = ["CVE-2022-22963"]
 app = "spring cloud function"
 path = "spring/CVE-2022-22963"
 
-  [[container.name]]
-  en = "Spring Cloud Function SpEL Expression Command Injection"
-  zh = "Spring Cloud Function SpEL表达式命令注入"
-
-  [[container.cve]]
-  id = "CVE-2022-22963"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22963"
-
-[[container]]
+[[environment]]
+name = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
+cve = ["CVE-2022-22965"]
 app = "Spring"
 path = "spring/CVE-2022-22965"
 
-  [[container.name]]
-  en = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
-  zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2022-22965"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22965"
-
-[[container]]
+[[environment]]
+name = "Spring Security Authorization Bypass in RegexRequestMatcher"
+cve = ["CVE-2022-22978"]
 app = "Spring"
 path = "spring/CVE-2022-22978"
 
-  [[container.name]]
-  en = "Spring Security Authorization Bypass in RegexRequestMatcher"
-  zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
-
-  [[container.cve]]
-  id = "CVE-2022-22978"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22978"
-
-[[container]]
+[[environment]]
+name = "S2-001 Remote Code Execution"
+cve = [""]
 app = "Struts2"
 path = "struts2/s2-001"
 
-  [[container.name]]
-  en = "S2-001 Remote Code Execution"
-  zh = "S2-001 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "S2-005 Remote Code Execution"
+cve = ["CVE-2010-1870"]
 app = "Struts2"
 path = "struts2/s2-005"
 
-  [[container.name]]
-  en = "S2-005 Remote Code Execution"
-  zh = "S2-005 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2010-1870"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-1870"
-
-[[container]]
+[[environment]]
+name = "S2-007 Remote Code Execution"
+cve = [""]
 app = "Struts2"
 path = "struts2/s2-007"
 
-  [[container.name]]
-  en = "S2-007 Remote Code Execution"
-  zh = "S2-007 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "S2-008 Remote Code Execution"
+cve = ["CVE-2012-0391"]
 app = "Struts2"
 path = "struts2/s2-008"
 
-  [[container.name]]
-  en = "S2-008 Remote Code Execution"
-  zh = "S2-008 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2012-0391"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-0391"
-
-[[container]]
+[[environment]]
+name = "S2-009 Remote Code Execution"
+cve = ["CVE-2011-3923"]
 app = "Struts2"
 path = "struts2/s2-009"
 
-  [[container.name]]
-  en = "S2-009 Remote Code Execution"
-  zh = "S2-009 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2011-3923"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2011-3923"
-
-[[container]]
+[[environment]]
+name = "S2-012 Remote Code Execution"
+cve = ["CVE-2013-1965"]
 app = "Struts2"
 path = "struts2/s2-012"
 
-  [[container.name]]
-  en = "S2-012 Remote Code Execution"
-  zh = "S2-012 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2013-1965"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1965"
-
-[[container]]
+[[environment]]
+name = "S2-013 Remote Code Execution"
+cve = ["CVE-2013-1966"]
 app = "Struts2"
 path = "struts2/s2-013"
 
-  [[container.name]]
-  en = "S2-013 Remote Code Execution"
-  zh = "S2-013 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2013-1966"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1966"
-
-[[container]]
+[[environment]]
+name = "S2-015 Remote Code Execution"
+cve = ["CVE-2013-2134", "CVE-2013-2135"]
 app = "Struts2"
 path = "struts2/s2-015"
 
-  [[container.name]]
-  en = "S2-015 Remote Code Execution"
-  zh = "S2-015 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2013-2134"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2134"
-  
-  [[container.cve]]
-  id = "CVE-2013-2135"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2135"
-
-[[container]]
+[[environment]]
+name = "S2-016 Remote Code Execution"
+cve = ["CVE-2013-2251"]
 app = "Struts2"
 path = "struts2/s2-016"
 
-  [[container.name]]
-  en = "S2-016 Remote Code Execution"
-  zh = "S2-016 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2013-2251"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2251"
-
-[[container]]
+[[environment]]
+name = "S2-032 Remote Code Execution"
+cve = ["CVE-2016-3081"]
 app = "Struts2"
 path = "struts2/s2-032"
 
-  [[container.name]]
-  en = "S2-032 Remote Code Execution"
-  zh = "S2-032 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-3081"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3081"
-
-[[container]]
+[[environment]]
+name = "S2-045 Remote Code Execution"
+cve = ["CVE-2017-5638"]
 app = "Struts2"
 path = "struts2/s2-045"
 
-  [[container.name]]
-  en = "S2-045 Remote Code Execution"
-  zh = "S2-045 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-5638"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
-
-[[container]]
+[[environment]]
+name = "S2-046 Remote Code Execution"
+cve = ["CVE-2017-5638"]
 app = "Struts2"
 path = "struts2/s2-046"
 
-  [[container.name]]
-  en = "S2-046 Remote Code Execution"
-  zh = "S2-046 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-5638"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
-
-[[container]]
+[[environment]]
+name = "S2-048 Remote Code Execution"
+cve = ["CVE-2017-9791"]
 app = "Struts2"
 path = "struts2/s2-048"
 
-  [[container.name]]
-  en = "S2-048 Remote Code Execution"
-  zh = "S2-048 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-9791"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9791"
-
-[[container]]
+[[environment]]
+name = "S2-052 Remote Code Execution"
+cve = ["CVE-2017-9805"]
 app = "Struts2"
 path = "struts2/s2-052"
 
-  [[container.name]]
-  en = "S2-052 Remote Code Execution"
-  zh = "S2-052 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-9805"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9805"
-
-[[container]]
+[[environment]]
+name = "S2-053 Remote Code Execution"
+cve = ["CVE-2017-12611"]
 app = "Struts2"
 path = "struts2/s2-053"
 
-  [[container.name]]
-  en = "S2-053 Remote Code Execution"
-  zh = "S2-053 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12611"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12611"
-
-[[container]]
+[[environment]]
+name = "Struts2 S2-057 Remote Command Execution"
+cve = ["CVE-2018-11776"]
 app = "Struts2"
 path = "struts2/s2-057"
 
-  [[container.name]]
-  en = "Struts2 S2-057 Remote Command Execution"
-  zh = "Struts2 S2-057 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-11776"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-11776"
-
-[[container]]
+[[environment]]
+name = "Struts2 S2-059 Remote Command Execution"
+cve = ["CVE-2019-0230"]
 app = "Struts2"
 path = "struts2/s2-059"
 
-  [[container.name]]
-  en = "Struts2 S2-059 Remote Command Execution"
-  zh = "Struts2 S2-059 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-0230"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0230"
-
-[[container]]
+[[environment]]
+name = "Struts2 S2-061 Remote Command Execution"
+cve = ["CVE-2020-17530"]
 app = "Struts2"
 path = "struts2/s2-061"
 
-  [[container.name]]
-  en = "Struts2 S2-061 Remote Command Execution"
-  zh = "Struts2 S2-061 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-17530"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17530"
-
-[[container]]
+[[environment]]
+name = "Supervisord Remote Command Execution"
+cve = ["CVE-2017-11610"]
 app = "Supervisor"
 path = "supervisor/CVE-2017-11610"
 
-  [[container.name]]
-  en = "Supervisord Remote Command Execution"
-  zh = "Supervisord 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-11610"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-11610"
-
-[[container]]
+[[environment]]
+name = "ThinkPHP 2.x Arbitrary Code Execution"
+cve = [""]
 app = "ThinkPHP"
 path = "thinkphp/2-rce"
 
-  [[container.name]]
-  en = "ThinkPHP 2.x Arbitrary Code Execution"
-  zh = "ThinkPHP 2.x 任意代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
+cve = [""]
 app = "ThinkPHP"
 path = "thinkphp/5-rce"
 
-  [[container.name]]
-  en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
-  zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "ThinkPHP5 5.0.23 Remote Code Execution"
+cve = [""]
 app = "ThinkPHP"
 path = "thinkphp/5.0.23-rce"
 
-  [[container.name]]
-  en = "ThinkPHP5 5.0.23 Remote Code Execution"
-  zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
+cve = [""]
 app = "ThinkPHP"
 path = "thinkphp/in-sqlinjection"
 
-  [[container.name]]
-  en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
-  zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "ThinkPHP Multilingual Local File Inclusion"
+cve = [""]
 app = "ThinkPHP"
 path = "thinkphp/lang-rce"
 
-  [[container.name]]
-  en = "ThinkPHP Multilingual Local File Inclusion"
-  zh = "ThinkPHP 多语言本地文件包含漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Tiki Wiki CMS Groupware Authentication Bypass"
+cve = ["CVE-2020-15906"]
 app = "Tiki Wiki"
 path = "tikiwiki/CVE-2020-15906"
 
-  [[container.name]]
-  en = "Tiki Wiki CMS Groupware Authentication Bypass"
-  zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-15906"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-15906"
-
-[[container]]
+[[environment]]
+name = "Tomcat Arbitrary Writing of Files in the PUT Method"
+cve = ["CVE-2017-12615"]
 app = "Tomcat"
 path = "tomcat/CVE-2017-12615"
 
-  [[container.name]]
-  en = "Tomcat Arbitrary Writing of Files in the PUT Method"
-  zh = "Tomcat PUT方法任意写文件漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-12615"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12615"
-
-[[container]]
+[[environment]]
+name = "Apache Tomcat AJP Bug"
+cve = ["CVE-2020-1938"]
 app = "Tomcat"
 path = "tomcat/CVE-2020-1938"
 
-  [[container.name]]
-  en = "Apache Tomcat AJP Bug"
-  zh = "Apache Tomcat AJP 文件包含漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-1938"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1938"
-
-[[container]]
+[[environment]]
+name = "Tomcat Weak Password"
+cve = [""]
 app = "Tomcat"
 path = "tomcat/tomcat8"
 
-  [[container.name]]
-  en = "Tomcat Weak Password"
-  zh = "Tomcat弱口令"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Apache Unomi Remote Expression Code Execution"
+cve = ["CVE-2020-13942"]
 app = "unomi"
 path = "unomi/CVE-2020-13942"
 
-  [[container.name]]
-  en = "Apache Unomi Remote Expression Code Execution"
-  zh = "Apache Unomi 远程表达式代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-13942"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13942"
-
-[[container]]
+[[environment]]
+name = "uWSGI PHP Directory Traversal"
+cve = ["CVE-2018-7490"]
 app = "uWSGI"
 path = "uwsgi/CVE-2018-7490"
 
-  [[container.name]]
-  en = "uWSGI PHP Directory Traversal"
-  zh = "uWSGI PHP目录穿越漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-7490"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7490"
-
-[[container]]
+[[environment]]
+name = "uWSGI Unauthorized Access"
+cve = [""]
 app = "uWSGI"
 path = "uwsgi/unacc"
 
-  [[container.name]]
-  en = "uWSGI Unauthorized Access"
-  zh = "uWSGI 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "V2board 1.6.1 Privilege Escalation"
+cve = [""]
 app = "V2board"
 path = "v2board/1.6-privilege-escalation"
 
-  [[container.name]]
-  en = "V2board 1.6.1 Privilege Escalation"
-  zh = "V2board 1.6.1 提权漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
+cve = ["CVE-2017-10271"]
 app = "WebLogic"
 path = "weblogic/CVE-2017-10271"
 
-  [[container.name]]
-  en = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
-  zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
-
-  [[container.cve]]
-  id = "CVE-2017-10271"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-10271"
-
-[[container]]
+[[environment]]
+name = "WebLogic WLS Core Components Deserialization Command Execution"
+cve = ["CVE-2018-2628"]
 app = "WebLogic"
 path = "weblogic/CVE-2018-2628"
 
-  [[container.name]]
-  en = "WebLogic WLS Core Components Deserialization Command Execution"
-  zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-2628"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2628"
-
-[[container]]
+[[environment]]
+name = "WebLogic Arbitrary File Upload"
+cve = ["CVE-2018-2894"]
 app = "WebLogic"
 path = "weblogic/CVE-2018-2894"
 
-  [[container.name]]
-  en = "WebLogic Arbitrary File Upload"
-  zh = "WebLogic 任意文件上传漏洞"
-
-  [[container.cve]]
-  id = "CVE-2018-2894"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2894"
-
-[[container]]
+[[environment]]
+name = "WebLogic Management Console Unauthorized Remote Command Execution"
+cve = ["CVE-2020-14882"]
 app = "WebLogic"
 path = "weblogic/CVE-2020-14882"
 
-  [[container.name]]
-  en = "WebLogic Management Console Unauthorized Remote Command Execution"
-  zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-14882"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-14882"
-
-[[container]]
+[[environment]]
+name = "WebLogic Unauthorized Remote Code Execution"
+cve = ["CVE-2023-21839"]
 app = "WebLogic"
 path = "weblogic/CVE-2023-21839"
 
-  [[container.name]]
-  en = "WebLogic Unauthorized Remote Code Execution"
-  zh = "WebLogic未授权远程代码执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2023-21839"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-21839"
-
-[[container]]
+[[environment]]
+name = "WebLogic SSRF"
+cve = [""]
 app = "WebLogic"
 path = "weblogic/ssrf"
 
-  [[container.name]]
-  en = "WebLogic SSRF"
-  zh = "WebLogic SSRF漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "WebLogic File Read"
+cve = [""]
 app = "WebLogic"
 path = "weblogic/weak_password"
 
-  [[container.name]]
-  en = "WebLogic File Read"
-  zh = "WebLogic 文件读取漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Webmin Remote Command Execution"
+cve = ["CVE-2019-15107"]
 app = "Webmin"
 path = "webmin/CVE-2019-15107"
 
-  [[container.name]]
-  en = "Webmin Remote Command Execution"
-  zh = "Webmin 远程命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2019-15107"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-15107"
-
-[[container]]
+[[environment]]
+name = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
+cve = [""]
 app = "Wordpress"
 path = "wordpress/pwnscriptum"
 
-  [[container.name]]
-  en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
-  zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "XStream Deserialization Command Execution"
+cve = ["CVE-2021-21351"]
 app = "XStream"
 path = "xstream/CVE-2021-21351"
 
-  [[container.name]]
-  en = "XStream Deserialization Command Execution"
-  zh = "XStream 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-21351"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-21351"
-
-[[container]]
+[[environment]]
+name = "XStream Deserialization Command Execution"
+cve = ["CVE-2021-29505"]
 app = "XStream"
 path = "xstream/CVE-2021-29505"
 
-  [[container.name]]
-  en = "XStream Deserialization Command Execution"
-  zh = "XStream 反序列化命令执行漏洞"
-
-  [[container.cve]]
-  id = "CVE-2021-29505"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29505"
-
-[[container]]
+[[environment]]
+name = "XXL-JOB Executor Unauthorized Access"
+cve = [""]
 app = "xxl-job"
 path = "xxl-job/unacc"
 
-  [[container.name]]
-  en = "XXL-JOB Executor Unauthorized Access"
-  zh = "XXL-JOB Executor 未授权访问漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "YApi NoSQL Injection to Remote Command Execution"
+cve = [""]
 app = "YApi"
 path = "yapi/mongodb-inj"
 
-  [[container.name]]
-  en = "YApi NoSQL Injection to Remote Command Execution"
-  zh = "YApi NoSQL注入导致远程命令执行漏洞"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "YApi Open Registration due to RCE"
+cve = [""]
 app = "YApi"
 path = "yapi/unacc"
 
-  [[container.name]]
-  en = "YApi Open Registration due to RCE"
-  zh = "YApi开放注册导致RCE"
-
-  [[container.cve]]
-  id = ""
-  nvd = ""
-
-[[container]]
+[[environment]]
+name = "Zabbix latest.php SQL Injection"
+cve = ["CVE-2016-10134"]
 app = "Zabbix"
 path = "zabbix/CVE-2016-10134"
 
-  [[container.name]]
-  en = "Zabbix latest.php SQL Injection"
-  zh = "Zabbix latest.php SQL注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2016-10134"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-10134"
-
-[[container]]
+[[environment]]
 app = "Zabbix"
 path = "zabbix/CVE-2020-11800"
-
-  [[container.name]]
-  en = "Zabbix Server Trapper Command Injection"
-  zh = "Zabbix Server Trapper命令注入漏洞"
-
-  [[container.cve]]
-  id = "CVE-2020-11800"
-  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11800"
+name = "Zabbix Server Trapper Command Injection"
+cve = ["CVE-2020-11800"]

--- a/environments.toml
+++ b/environments.toml
@@ -36,7 +36,7 @@ path = "apache-druid/CVE-2021-25646"
 
 [[environment]]
 name = "Apereo CAS 4.1 Deserialization Command Execution"
-cve = [""]
+cve = []
 app = "Apereo CAS"
 path = "apereo-cas/4.1-rce"
 
@@ -60,7 +60,7 @@ path = "appweb/CVE-2018-8715"
 
 [[environment]]
 name = "Aria2 Arbitrary File Write"
-cve = [""]
+cve = []
 app = "Aria2"
 path = "aria2/rce"
 
@@ -78,7 +78,7 @@ path = "cacti/CVE-2022-46169"
 
 [[environment]]
 name = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
-cve = [""]
+cve = []
 app = "celery"
 path = "celery/celery3_redis_unauth"
 
@@ -138,13 +138,13 @@ path = "couchdb/CVE-2022-24706"
 
 [[environment]]
 name = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
-cve = [""]
+cve = []
 app = "Discuz"
 path = "discuz/wooyun-2010-080723"
 
 [[environment]]
 name = "Discuz!X ≤3.4 Arbitrary File Deletion"
-cve = [""]
+cve = []
 app = "Discuz"
 path = "discuz/x3.4-arbitrary-file-deletion"
 
@@ -186,13 +186,13 @@ path = "django/CVE-2022-34265"
 
 [[environment]]
 name = "DNS Domain Transfer"
-cve = [""]
+cve = []
 app = "dns"
 path = "dns/dns-zone-transfer"
 
 [[environment]]
 name = "Docker Daemon API Unauthorized Access"
-cve = [""]
+cve = []
 app = "docker"
 path = "docker/unauthorized-rce"
 
@@ -240,13 +240,13 @@ path = "dubbo/CVE-2019-17564"
 
 [[environment]]
 name = "ECShop 4.x collection_list SQL Injection"
-cve = [""]
+cve = []
 app = "ecshop"
 path = "ecshop/collection_list-sqli"
 
 [[environment]]
 name = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
-cve = [""]
+cve = []
 app = "ecshop"
 path = "ecshop/xianzhi-2017-02-82239600"
 
@@ -276,7 +276,7 @@ path = "elasticsearch/CVE-2015-5531"
 
 [[environment]]
 name = "Elasticsearch Webshell"
-cve = [""]
+cve = []
 app = "ElasticSearch"
 path = "elasticsearch/WooYun-2015-110216"
 
@@ -306,7 +306,7 @@ path = "fastjson/1.2.24-rce"
 
 [[environment]]
 name = "Fastjson 1.2.47 Remote Command Execution"
-cve = [""]
+cve = []
 app = "Fastjson"
 path = "fastjson/1.2.47-rce"
 
@@ -324,7 +324,7 @@ path = "ffmpeg/phdays"
 
 [[environment]]
 name = "Jinja2 SSTI Template Injection"
-cve = [""]
+cve = []
 app = "Jinja2"
 path = "flask/ssti"
 
@@ -372,7 +372,7 @@ path = "git/CVE-2017-8386"
 
 [[environment]]
 name = "Gitea 1.4.0 Directory Traversal to Command Execution"
-cve = [""]
+cve = []
 app = "gitea"
 path = "gitea/1.4-rce"
 
@@ -396,7 +396,7 @@ path = "gitlist/CVE-2018-1000533"
 
 [[environment]]
 name = "GlassFish Arbitrary File Read"
-cve = [""]
+cve = []
 app = "GlassFish"
 path = "glassfish/4.1.0"
 
@@ -426,19 +426,19 @@ path = "grafana/CVE-2021-43798"
 
 [[environment]]
 name = "Grafana Management Background SSRF"
-cve = [""]
+cve = []
 app = "Grafana"
 path = "grafana/admin-ssrf"
 
 [[environment]]
 name = "H2 Database Console Unauthorized Access"
-cve = [""]
+cve = []
 app = "Springboot H2 Database"
 path = "h2database/h2-console-unacc"
 
 [[environment]]
 name = "Hadoop YARN ResourceManager Unauthorized Access"
-cve = [""]
+cve = []
 app = "Hadoop YARN"
 path = "hadoop/unauthorized-yarn"
 
@@ -468,13 +468,13 @@ path = "httpd/CVE-2021-42013"
 
 [[environment]]
 name = "Apache HTTPD Unknown Suffix Parsing"
-cve = [""]
+cve = []
 app = "Apache HTTP Server"
 path = "httpd/apache_parsing_vulnerability"
 
 [[environment]]
 name = "Apache SSI Remote Command Execution"
-cve = [""]
+cve = []
 app = "Apache HTTP Server"
 path = "httpd/ssi-rce"
 
@@ -510,19 +510,19 @@ path = "jackson/CVE-2017-7525"
 
 [[environment]]
 name = "Java RMI codebase Remote Code Execution"
-cve = [""]
+cve = []
 app = "java rmi"
 path = "java/rmi-codebase"
 
 [[environment]]
 name = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
-cve = [""]
+cve = []
 app = "java rmi"
 path = "java/rmi-registry-bind-deserialization"
 
 [[environment]]
 name = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
-cve = [""]
+cve = []
 app = "java rmi"
 path = "java/rmi-registry-bind-deserialization-bypass"
 
@@ -540,7 +540,7 @@ path = "jboss/CVE-2017-7504"
 
 [[environment]]
 name = "JBoss JMXInvokerServlet Deserialization"
-cve = [""]
+cve = []
 app = "jboss"
 path = "jboss/JMXInvokerServlet-deserialization"
 
@@ -606,7 +606,7 @@ path = "joomla/CVE-2023-23752"
 
 [[environment]]
 name = "Jupyter Notebook Unauthorized Access"
-cve = [""]
+cve = []
 app = "Jupyter"
 path = "jupyter/notebook-rce"
 
@@ -660,7 +660,7 @@ path = "log4j/CVE-2021-44228"
 
 [[environment]]
 name = "Magento 2.2 SQL Injection"
-cve = [""]
+cve = []
 app = "Magento"
 path = "magento/2.2-sqli"
 
@@ -684,7 +684,7 @@ path = "minio/CVE-2023-28432"
 
 [[environment]]
 name = "Mojarra JSF ViewState Deserialization"
-cve = [""]
+cve = []
 app = "Mojarra JSF"
 path = "mojarra/jsf-viewstate-deserialization"
 
@@ -744,13 +744,13 @@ path = "nginx/CVE-2017-7529"
 
 [[environment]]
 name = "Nginx Configuration Errors"
-cve = [""]
+cve = []
 app = "Nginx"
 path = "nginx/insecure-configuration"
 
 [[environment]]
 name = "Nginx Parsing"
-cve = [""]
+cve = []
 app = "Nginx"
 path = "nginx/nginx_parsing_vulnerability"
 
@@ -816,7 +816,7 @@ path = "opentsdb/CVE-2020-35476"
 
 [[environment]]
 name = "PHP 8.1.0-dev Development Version Backdoor Event"
-cve = [""]
+cve = []
 app = "PHP"
 path = "php/8.1-backdoor"
 
@@ -840,25 +840,25 @@ path = "php/CVE-2019-11043"
 
 [[environment]]
 name = "PHP-FPM FastCGI Unauthorized Access"
-cve = [""]
+cve = []
 app = "PHP-FPM"
 path = "php/fpm"
 
 [[environment]]
 name = "PHP Files Vulnerabilities (by phpinfo())"
-cve = [""]
+cve = []
 app = "PHP"
 path = "php/inclusion"
 
 [[environment]]
 name = "PHP XML Entity Injection"
-cve = [""]
+cve = []
 app = "PHP"
 path = "php/php_xxe"
 
 [[environment]]
 name = "XDebug Remote Debugging Code Execution"
-cve = [""]
+cve = []
 app = "PHP"
 path = "php/xdebug-rce"
 
@@ -882,7 +882,7 @@ path = "phpmyadmin/CVE-2018-12613"
 
 [[environment]]
 name = "phpmyadmin scripts/setup.php Deserialization"
-cve = [""]
+cve = []
 app = "phpmyadmin"
 path = "phpmyadmin/WooYun-2016-199433"
 
@@ -924,7 +924,7 @@ path = "python/PIL-CVE-2018-16509"
 
 [[environment]]
 name = "Python Unpickle Deserialization"
-cve = [""]
+cve = []
 app = "Python"
 path = "python/unpickle"
 
@@ -942,7 +942,7 @@ path = "rails/CVE-2019-5418"
 
 [[environment]]
 name = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
-cve = [""]
+cve = []
 app = "redis"
 path = "redis/4-unacc"
 
@@ -966,7 +966,7 @@ path = "rocketmq/CVE-2023-33246"
 
 [[environment]]
 name = "rsync Unauthorized Access"
-cve = [""]
+cve = []
 app = "rsync"
 path = "rsync/common"
 
@@ -1002,7 +1002,7 @@ path = "samba/CVE-2017-7494"
 
 [[environment]]
 name = "Scrapyd Unauthorized Access"
-cve = [""]
+cve = []
 app = "Scrapyd"
 path = "scrapy/scrapyd-unacc"
 
@@ -1026,7 +1026,7 @@ path = "shiro/CVE-2020-1957"
 
 [[environment]]
 name = "Apache Skywalking 8.3.0 SQL Injection"
-cve = [""]
+cve = []
 app = "skywalking"
 path = "skywalking/8.3.0-sqli"
 
@@ -1056,13 +1056,13 @@ path = "solr/CVE-2019-17558"
 
 [[environment]]
 name = "Apache Solr RemoteStreaming File Reading and SSRF"
-cve = [""]
+cve = []
 app = "solr"
 path = "solr/Remote-Streaming-Fileread"
 
 [[environment]]
 name = "Apache Spark Unauthorized Access Leak"
-cve = [""]
+cve = []
 app = "spark"
 path = "spark/unacc"
 
@@ -1122,7 +1122,7 @@ path = "spring/CVE-2022-22978"
 
 [[environment]]
 name = "S2-001 Remote Code Execution"
-cve = [""]
+cve = []
 app = "Struts2"
 path = "struts2/s2-001"
 
@@ -1134,7 +1134,7 @@ path = "struts2/s2-005"
 
 [[environment]]
 name = "S2-007 Remote Code Execution"
-cve = [""]
+cve = []
 app = "Struts2"
 path = "struts2/s2-007"
 
@@ -1236,31 +1236,31 @@ path = "supervisor/CVE-2017-11610"
 
 [[environment]]
 name = "ThinkPHP 2.x Arbitrary Code Execution"
-cve = [""]
+cve = []
 app = "ThinkPHP"
 path = "thinkphp/2-rce"
 
 [[environment]]
 name = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
-cve = [""]
+cve = []
 app = "ThinkPHP"
 path = "thinkphp/5-rce"
 
 [[environment]]
 name = "ThinkPHP5 5.0.23 Remote Code Execution"
-cve = [""]
+cve = []
 app = "ThinkPHP"
 path = "thinkphp/5.0.23-rce"
 
 [[environment]]
 name = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
-cve = [""]
+cve = []
 app = "ThinkPHP"
 path = "thinkphp/in-sqlinjection"
 
 [[environment]]
 name = "ThinkPHP Multilingual Local File Inclusion"
-cve = [""]
+cve = []
 app = "ThinkPHP"
 path = "thinkphp/lang-rce"
 
@@ -1284,7 +1284,7 @@ path = "tomcat/CVE-2020-1938"
 
 [[environment]]
 name = "Tomcat Weak Password"
-cve = [""]
+cve = []
 app = "Tomcat"
 path = "tomcat/tomcat8"
 
@@ -1302,13 +1302,13 @@ path = "uwsgi/CVE-2018-7490"
 
 [[environment]]
 name = "uWSGI Unauthorized Access"
-cve = [""]
+cve = []
 app = "uWSGI"
 path = "uwsgi/unacc"
 
 [[environment]]
 name = "V2board 1.6.1 Privilege Escalation"
-cve = [""]
+cve = []
 app = "V2board"
 path = "v2board/1.6-privilege-escalation"
 
@@ -1344,13 +1344,13 @@ path = "weblogic/CVE-2023-21839"
 
 [[environment]]
 name = "WebLogic SSRF"
-cve = [""]
+cve = []
 app = "WebLogic"
 path = "weblogic/ssrf"
 
 [[environment]]
 name = "WebLogic File Read"
-cve = [""]
+cve = []
 app = "WebLogic"
 path = "weblogic/weak_password"
 
@@ -1362,7 +1362,7 @@ path = "webmin/CVE-2019-15107"
 
 [[environment]]
 name = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
-cve = [""]
+cve = []
 app = "Wordpress"
 path = "wordpress/pwnscriptum"
 
@@ -1380,19 +1380,19 @@ path = "xstream/CVE-2021-29505"
 
 [[environment]]
 name = "XXL-JOB Executor Unauthorized Access"
-cve = [""]
+cve = []
 app = "xxl-job"
 path = "xxl-job/unacc"
 
 [[environment]]
 name = "YApi NoSQL Injection to Remote Command Execution"
-cve = [""]
+cve = []
 app = "YApi"
 path = "yapi/mongodb-inj"
 
 [[environment]]
 name = "YApi Open Registration due to RCE"
-cve = [""]
+cve = []
 app = "YApi"
 path = "yapi/unacc"
 

--- a/environments.toml
+++ b/environments.toml
@@ -1,0 +1,1586 @@
+[[containers]]
+name_en = "Apache ActiveMQ Deserialization"
+name_zh = "Apache ActiveMQ 反序列化漏洞"
+app = "ActiveMQ"
+cve = "CVE-2015-5254"
+path = "activemq/CVE-2015-5254"
+
+[[containers]]
+name_en = "Apache ActiveMQ Arbitrary File Write"
+name_zh = "Apache ActiveMQ 任意文件写入漏洞"
+app = "ActiveMQ"
+cve = "CVE-2016-3088"
+path = "activemq/CVE-2016-3088"
+
+[[containers]]
+name_en = "Apache Airflow Command Injection"
+name_zh = "Apache Airflow 示例dag中的命令注入"
+app = "Airflow"
+cve = "CVE-2020-11978"
+path = "airflow/CVE-2020-11978"
+
+[[containers]]
+name_en = "Apache Airflow Celery Message Middleware Command Execution"
+name_zh = "Apache Airflow Celery 消息中间件命令执行"
+app = "Airflow"
+cve = "CVE-2020-11981"
+path = "airflow/CVE-2020-11981"
+
+[[containers]]
+name_en = "Apache Airflow Permission Bypass"
+name_zh = "Apache Airflow 默认密钥导致的权限绕过"
+app = "Airflow"
+cve = "CVE-2020-17526"
+path = "airflow/CVE-2020-17526"
+
+[[containers]]
+name_en = "Apache Druid Code Execution"
+name_zh = "Apache Druid 代码执行漏洞"
+app = "Apache Druid"
+cve = "CVE-2021-25646"
+path = "apache-druid/CVE-2021-25646"
+
+[[containers]]
+name_en = "Apereo CAS 4.1 Deserialization Command Execution"
+name_zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
+app = "Apereo CAS"
+path = "apereo-cas/4.1-rce"
+
+[[containers]]
+name_en = "Apache APISIX Default Key"
+name_zh = "Apache APISIX 默认密钥漏洞"
+app = "Apache APISIX"
+cve = "CVE-2020-13945"
+path = "apisix/CVE-2020-13945"
+
+[[containers]]
+name_en = "Apache APISIX Dashboard API Permission Bypass to RCE"
+name_zh = "Apache APISIX Dashboard API权限绕过导致RCE"
+app = "Apache APISIX"
+cve = "CVE-2021-45232"
+path = "apisix/CVE-2021-45232"
+
+[[containers]]
+name_en = "AppWeb Authentication Bypass"
+name_zh = "AppWeb 认证绕过漏洞"
+app = "AppWeb"
+cve = "CVE-2018-8715"
+path = "appweb/CVE-2018-8715"
+
+[[containers]]
+name_en = "Aria2 Arbitrary File Write"
+name_zh = "Aria2 任意文件写入漏洞"
+app = "Aria2"
+path = "aria2/rce"
+
+[[containers]]
+name_en = "Bash Shellshock Shell Exploit"
+name_zh = "Bash Shellshock 破壳漏洞"
+app = "bash"
+cve = "CVE-2014-6271"
+path = "bash/CVE-2014-6271"
+
+[[containers]]
+name_en = "Cacti Foreground Command Injection"
+name_zh = "Cacti 前台命令注入漏洞"
+app = "cacti"
+cve = "CVE-2022-46169"
+path = "cacti/CVE-2022-46169"
+
+[[containers]]
+name_en = "Celery <4.0 Redis Unauthorized Access and Pickle Deserialization"
+name_zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
+app = "celery"
+path = "celery/celery3_redis_unauth"
+
+[[containers]]
+name_en = "CGI HTTPoxy Flaw"
+name_zh = "CGI HTTPoxy 漏洞"
+app = "cgi"
+cve = "CVE-2016-5385"
+path = "cgi/CVE-2016-5385"
+
+[[containers]]
+name_en = "Adobe ColdFusion File Read"
+name_zh = "Adobe ColdFusion 文件读取漏洞"
+app = "Adobe ColdFusion"
+cve = "CVE-2010-2861"
+path = "coldfusion/CVE-2010-2861"
+
+[[containers]]
+name_en = "Adobe ColdFusion Deserialization"
+name_zh = "Adobe ColdFusion 反序列化漏洞"
+app = "Adobe ColdFusion"
+cve = "CVE-2017-3066"
+path = "coldfusion/CVE-2017-3066"
+
+[[containers]]
+name_en = "Atlassian Confluence Path Traversal and Command Execution"
+name_zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
+app = "Atlassian Confluence"
+cve = "CVE-2019-3396"
+path = "confluence/CVE-2019-3396"
+
+[[containers]]
+name_en = "Atlassian Confluence OGNL Expression Injection Code Execution"
+name_zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
+app = "Atlassian Confluence"
+cve = "CVE-2021-26084"
+path = "confluence/CVE-2021-26084"
+
+[[containers]]
+name_en = "Atlassian Confluence OGNL Expression Injection Command Execution"
+name_zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
+app = "Atlassian Confluence"
+cve = "CVE-2022-26134"
+path = "confluence/CVE-2022-26134"
+
+[[containers]]
+name_en = "CouchDB Vertical Permission Bypass"
+name_zh = "CouchDB 垂直权限绕过漏洞"
+app = "CouchDB"
+cve = "CVE-2017-12635"
+path = "couchdb/CVE-2017-12635"
+
+[[containers]]
+name_en = "CouchDB Arbitrary Command Execution"
+name_zh = "CouchDB 任意命令执行漏洞"
+app = "CouchDB"
+cve = "CVE-2017-12636"
+path = "couchdb/CVE-2017-12636"
+
+[[containers]]
+name_en = "CouchDB Erlang Distributed Protocol Code Execution"
+name_zh = "CouchDB Erlang 分布式协议代码执行"
+app = "CouchDB"
+cve = "CVE-2022-24706"
+path = "couchdb/CVE-2022-24706"
+
+[[containers]]
+name_en = "Discuz 7.x/6.x Global Variable Defense Bypass to Code Execution"
+name_zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
+app = "Discuz"
+path = "discuz/wooyun-2010-080723"
+
+[[containers]]
+name_en = "Discuz!X ≤3.4 Arbitrary File Deletion"
+name_zh = "Discuz!X ≤3.4 任意文件删除漏洞"
+app = "Discuz"
+path = "discuz/x3.4-arbitrary-file-deletion"
+
+[[containers]]
+name_en = "Django debug page XSS Flaw"
+name_zh = "Django debug page XSS 漏洞"
+app = "Django"
+cve = "CVE-2017-12794"
+path = "django/CVE-2017-12794"
+
+[[containers]]
+name_en = "Django < 2.0.8 Arbitrary URL Redirection"
+name_zh = "Django < 2.0.8 任意URL跳转漏洞"
+app = "Django"
+cve = "CVE-2018-14574"
+path = "django/CVE-2018-14574"
+
+[[containers]]
+name_en = "Django JSONField/HStoreField SQL Injection"
+name_zh = "Django JSONField/HStoreField SQL注入漏洞"
+app = "Django"
+cve = "CVE-2019-14234"
+path = "django/CVE-2019-14234"
+
+[[containers]]
+name_en = "Django GIS SQL Injection"
+name_zh = "Django GIS SQL注入漏洞"
+app = "Django"
+cve = "CVE-2020-9402"
+path = "django/CVE-2020-9402"
+
+[[containers]]
+name_en = "Django QuerySet.order_by() SQL Injection"
+name_zh = "Django QuerySet.order_by() SQL注入漏洞"
+app = "Django"
+cve = "CVE-2021-35042"
+path = "django/CVE-2021-35042"
+
+[[containers]]
+name_en = "Django Trunc(kind) and Extract(lookup_name) SQL Injection"
+name_zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
+app = "Django"
+cve = "CVE-2022-34265"
+path = "django/CVE-2022-34265"
+
+[[containers]]
+name_en = "DNS Domain Transfer"
+name_zh = "DNS域传送漏洞"
+app = "dns"
+path = "dns/dns-zone-transfer"
+
+[[containers]]
+name_en = "Docker Daemon API Unauthorized Access"
+name_zh = "Docker Daemon API 未授权访问漏洞"
+app = "docker"
+path = "docker/unauthorized-rce"
+
+[[containers]]
+name_en = "Drupal < 7.32 'Drupalgeddon' SQL Injection"
+name_zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
+app = "drupal"
+cve = "CVE-2014-3704"
+path = "drupal/CVE-2014-3704"
+
+[[containers]]
+name_en = "Drupal Core 8 PECL YAML Deserialization Arbitrary Code Execution"
+name_zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
+app = "drupal"
+cve = "CVE-2017-6920"
+path = "drupal/CVE-2017-6920"
+
+[[containers]]
+name_en = "Drupal Drupalgeddon 2 Remote Code Execution"
+name_zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
+app = "drupal"
+cve = "CVE-2018-7600"
+path = "drupal/CVE-2018-7600"
+
+[[containers]]
+name_en = "Drupal Remote Code Execution"
+name_zh = "Drupal 远程代码执行漏洞"
+app = "drupal"
+cve = "CVE-2018-7602"
+path = "drupal/CVE-2018-7602"
+
+[[containers]]
+name_en = "Drupal Remote Code Execution"
+name_zh = "Drupal 远程代码执行漏洞"
+app = "drupal"
+cve = "CVE-2019-6339"
+path = "drupal/CVE-2019-6339"
+
+[[containers]]
+name_en = "Drupal XSS"
+name_zh = "Drupal XSS漏洞"
+app = "drupal"
+cve = "CVE-2019-6341"
+path = "drupal/CVE-2019-6341"
+
+[[containers]]
+name_en = "Apache Dubbo Java Deserialization"
+name_zh = "Apache Dubbo Java反序列化漏洞"
+app = "dubbo"
+cve = "CVE-2019-17564"
+path = "dubbo/CVE-2019-17564"
+
+[[containers]]
+name_en = "ECShop 4.x collection_list SQL Injection"
+name_zh = "ECShop 4.x collection_list SQL注入"
+app = "ecshop"
+path = "ecshop/collection_list-sqli"
+
+[[containers]]
+name_en = "ECShop 2.x/3.x SQL Injection/Arbitrary Code Execution"
+name_zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
+app = "ecshop"
+path = "ecshop/xianzhi-2017-02-82239600"
+
+[[containers]]
+name_en = "ElasticSearch Command Execution"
+name_zh = "ElasticSearch 命令执行漏洞"
+app = "ElasticSearch"
+cve = "CVE-2014-3120"
+path = "elasticsearch/CVE-2014-3120"
+
+[[containers]]
+name_en = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
+name_zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
+app = "ElasticSearch"
+cve = "CVE-2015-1427"
+path = "elasticsearch/CVE-2015-1427"
+
+[[containers]]
+name_en = "ElasticSearch Plug-in Directory Traversal"
+name_zh = "ElasticSearch 插件目录穿越漏洞"
+app = "ElasticSearch"
+cve = "CVE-2015-3337"
+path = "elasticsearch/CVE-2015-3337"
+
+[[containers]]
+name_en = "ElasticSearch Directory Traversal"
+name_zh = "ElasticSearch 目录穿越漏洞"
+app = "ElasticSearch"
+cve = "CVE-2015-5531"
+path = "elasticsearch/CVE-2015-5531"
+
+[[containers]]
+name_en = "Elasticsearch Webshell"
+name_zh = "Elasticsearch 写入webshell漏洞"
+app = "ElasticSearch"
+path = "elasticsearch/WooYun-2015-110216"
+
+[[containers]]
+name_en = "Electron Remote Command Execution"
+name_zh = "Electron 远程命令执行漏洞"
+app = "electron"
+cve = "CVE-2018-1000006"
+path = "electron/CVE-2018-1000006"
+
+[[containers]]
+name_en = "Electron WebPreferences Remote Command Execution"
+name_zh = "Electron WebPreferences 远程命令执行漏洞"
+app = "electron"
+cve = "CVE-2018-15685"
+path = "electron/CVE-2018-15685"
+
+[[containers]]
+name_en = "elFinder ZIP Parameter and Arbitrary Command Injection"
+name_zh = "elFinder ZIP 参数与任意命令注入"
+app = "elFinder"
+cve = "CVE-2021-32682"
+path = "elfinder/CVE-2021-32682"
+
+[[containers]]
+name_en = "Fastjson Deserialization to Arbitrary Command Execution"
+name_zh = "Fastjson 反序列化导致任意命令执行漏洞"
+app = "Fastjson"
+cve = "CVE-2017-18349"
+path = "fastjson/1.2.24-rce"
+
+[[containers]]
+name_en = "Fastjson 1.2.47 Remote Command Execution"
+name_zh = "Fastjson 1.2.47 远程命令执行漏洞"
+app = "Fastjson"
+path = "fastjson/1.2.47-rce"
+
+[[containers]]
+name_en = "FFmpeg Arbitrary File Read/SSRF"
+name_zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
+app = "ffmpeg"
+cve = "CVE-2016-1897,CVE-2016-1898"
+path = "ffmpeg/CVE-2016-1897"
+
+[[containers]]
+name_en = "FFmpeg Arbitrary File Read"
+name_zh = "FFmpeg 任意文件读取漏洞"
+app = "ffmpeg"
+cve = "CVE-2017-9993"
+path = "ffmpeg/phdays"
+
+[[containers]]
+name_en = "Jinja2 SSTI Template Injection"
+name_zh = "Jinja2 SSTI模板注入"
+app = "Jinja2"
+path = "flask/ssti"
+
+[[containers]]
+name_en = "Apache Flink File Upload"
+name_zh = "Apache Flink 文件上传漏洞"
+app = "flink"
+cve = "CVE-2020-17518"
+path = "flink/CVE-2020-17518"
+
+[[containers]]
+name_en = "Apache Flink Jobmanager/Logs Directory Traversal"
+name_zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
+app = "flink"
+cve = "CVE-2020-17519"
+path = "flink/CVE-2020-17519"
+
+[[containers]]
+name_en = "GeoServer OGC Filter SQL Injection"
+name_zh = "GeoServer OGC Filter SQL注入漏洞"
+app = "GeoServer"
+cve = "CVE-2023-25157"
+path = "geoserver/CVE-2023-25157"
+
+[[containers]]
+name_en = "GhostScript Sandbox Bypass (Command Execution)"
+name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
+app = "ghostscript"
+cve = "CVE-2018-16509"
+path = "ghostscript/CVE-2018-16509"
+
+[[containers]]
+name_en = "GhostScript Sandbox Bypass (Command Execution)"
+name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
+app = "ghostscript"
+cve = "CVE-2018-19475"
+path = "ghostscript/CVE-2018-19475"
+
+[[containers]]
+name_en = "GhostScript Sandbox Bypass (Command Execution)"
+name_zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
+app = "ghostscript"
+cve = "CVE-2019-6116"
+path = "ghostscript/CVE-2019-6116"
+
+[[containers]]
+name_en = "GIT-SHELL Sandbox Bypass"
+name_zh = "GIT-SHELL 沙盒绕过"
+app = "git"
+cve = "CVE-2017-8386"
+path = "git/CVE-2017-8386"
+
+[[containers]]
+name_en = "Gitea 1.4.0 Directory Traversal to Command Execution"
+name_zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
+app = "gitea"
+path = "gitea/1.4-rce"
+
+[[containers]]
+name_en = "GitLab Arbitrary File Read"
+name_zh = "GitLab 任意文件读取漏洞"
+app = "gitlab"
+cve = "CVE-2016-9086"
+path = "gitlab/CVE-2016-9086"
+
+[[containers]]
+name_en = "GitLab Remote Command Execution"
+name_zh = "GitLab 远程命令执行漏洞"
+app = "gitlab"
+cve = "CVE-2021-22205"
+path = "gitlab/CVE-2021-22205"
+
+[[containers]]
+name_en = "gitlist 0.6.0 Remote Command Execution"
+name_zh = "gitlist 0.6.0 远程命令执行漏洞"
+app = "gitlist"
+path = "gitlist/0.6.0-rce"
+
+[[containers]]
+name_en = "GlassFish Arbitrary File Read"
+name_zh = "GlassFish 任意文件读取漏洞"
+app = "GlassFish"
+path = "glassfish/4.1.0"
+
+[[containers]]
+name_en = "GoAhead Remote Command Execution"
+name_zh = "GoAhead 远程命令执行漏洞"
+app = "GoAhead"
+cve = "CVE-2017-17562"
+path = "goahead/CVE-2017-17562"
+
+[[containers]]
+name_en = "GoAhead Server Environment Variable Injection"
+name_zh = "GoAhead Server 环境变量注入"
+app = "GoAhead"
+cve = "CVE-2021-42342"
+path = "goahead/CVE-2021-42342"
+
+[[containers]]
+name_en = "Gogs Arbitrary User Login"
+name_zh = "Gogs 任意用户登录漏洞"
+app = "Gogs"
+cve = "CVE-2018-18925"
+path = "gogs/CVE-2018-18925"
+
+[[containers]]
+name_en = "Grafana 8.x Plug-in Module Directory Traversal"
+name_zh = "Grafana 8.x 插件模块目录穿越漏洞"
+app = "Grafana"
+cve = "CVE-2021-43798"
+path = "grafana/CVE-2021-43798"
+
+[[containers]]
+name_en = "Grafana Management Background SSRF"
+name_zh = "Grafana管理后台SSRF"
+app = "Grafana"
+path = "grafana/admin-ssrf"
+
+[[containers]]
+name_en = "H2 Database Console Unauthorized Access"
+name_zh = "H2 Database Console 未授权访问"
+app = "Springboot H2 Database"
+path = "h2database/h2-console-unacc"
+
+[[containers]]
+name_en = "Hadoop YARN ResourceManager Unauthorized Access"
+name_zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
+app = "Hadoop YARN"
+path = "hadoop/unauthorized-yarn"
+
+[[containers]]
+name_en = "Apache HTTPD Newline Parsing"
+name_zh = "Apache HTTPD 换行解析漏洞"
+app = "Apache HTTP Server"
+cve = "CVE-2017-15715"
+path = "httpd/CVE-2017-15715"
+
+[[containers]]
+name_en = "Apache HTTP Server 2.4.48 mod_proxy SSRF"
+name_zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
+app = "Apache HTTP Server"
+cve = "CVE-2021-40438"
+path = "httpd/CVE-2021-40438"
+
+[[containers]]
+name_en = "Apache HTTP Server 2.4.49 Path Traversal"
+name_zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
+app = "Apache HTTP Server"
+cve = "CVE-2021-41773"
+path = "httpd/CVE-2021-41773"
+
+[[containers]]
+name_en = "Apache HTTP Server 2.4.50 Path Traversal"
+name_zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
+app = "Apache HTTP Server"
+cve = "CVE-2021-42013"
+path = "httpd/CVE-2021-42013"
+
+[[containers]]
+name_en = "Apache HTTPD Unknown Suffix Parsing"
+name_zh = "Apache HTTPD 未知后缀解析漏洞"
+app = "Apache HTTP Server"
+path = "httpd/apache_parsing_vulnerability"
+
+[[containers]]
+name_en = "Apache SSI Remote Command Execution"
+name_zh = "Apache SSI 远程命令执行漏洞"
+app = "Apache HTTP Server"
+path = "httpd/ssi-rce"
+
+[[containers]]
+name_en = "Imagetragick Command Execution"
+name_zh = "Imagetragick 命令执行漏洞"
+app = "ImageMagick"
+cve = "CVE-2016-3714"
+path = "imagemagick/imagetragick"
+
+[[containers]]
+name_en = "ImageMagick PDF Password Location Command Injection"
+name_zh = "ImageMagick PDF密码位置命令注入漏洞"
+app = "imagemagick"
+cve = "CVE-2020-29599"
+path = "imagemagick/CVE-2020-29599"
+
+[[containers]]
+name_en = "ImageMagick Arbitrary File Read"
+name_zh = "ImageMagick任意文件读取漏洞"
+app = "imagemagick"
+cve = "CVE-2022-44268"
+path = "imagemagick/CVE-2022-44268"
+
+[[containers]]
+name_en = "InfluxDB Empty JWT Secret Key Authentication Bypass"
+name_zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
+app = "InfluxDB"
+cve = "CVE-2019-20933"
+path = "influxdb/CVE-2019-20933"
+
+[[containers]]
+name_en = "Jackson-databind Deserialization"
+name_zh = "Jackson-databind 反序列化漏洞"
+app = "Jackson-databind"
+cve = "CVE-2017-7525"
+path = "jackson/CVE-2017-7525"
+
+[[containers]]
+name_en = "Java RMI codebase Remote Code Execution"
+name_zh = "Java RMI codebase 远程代码执行漏洞"
+app = "java rmi"
+path = "java/rmi-codebase"
+
+[[containers]]
+name_en = "Java RMI Registry Deserialization Vulnerability (<=jdk8u111)"
+name_zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
+app = "java rmi"
+path = "java/rmi-registry-bind-deserialization"
+
+[[containers]]
+name_en = "Java RMI Registry Deserialization Vulnerability (<jdk8u232_b09)"
+name_zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
+app = "java rmi"
+path = "java/rmi-registry-bind-deserialization-bypass"
+
+[[containers]]
+name_en = "JBoss 5.x/6.x Deserialization"
+name_zh = "JBoss 5.x/6.x 反序列化漏洞"
+app = "jboss"
+cve = "CVE-2017-12149"
+path = "jboss/CVE-2017-12149"
+
+[[containers]]
+name_en = "JBoss 4.x JBossMQ JMS Deserialization"
+name_zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
+app = "jboss"
+cve = "CVE-2017-7504"
+path = "jboss/CVE-2017-7504"
+
+[[containers]]
+name_en = "JBoss JMXInvokerServlet Deserialization"
+name_zh = "JBoss JMXInvokerServlet 反序列化漏洞"
+app = "jboss"
+path = "jboss/JMXInvokerServlet-deserialization"
+
+[[containers]]
+name_en = "Jenkins-CI Remote Code Execution"
+name_zh = "Jenkins-CI 远程代码执行漏洞"
+app = "Jenkins"
+cve = "CVE-2017-1000353"
+path = "jenkins/CVE-2017-1000353"
+
+[[containers]]
+name_en = "Jenkins Remote Command Execution"
+name_zh = "Jenkins远程命令执行漏洞"
+app = "Jenkins"
+cve = "CVE-2018-1000861"
+path = "jenkins/CVE-2018-1000861"
+
+[[containers]]
+name_en = "Jetty WEB-INF Sensitive Information Disclosure"
+name_zh = "Jetty WEB-INF 敏感信息泄露漏洞"
+app = "jetty"
+cve = "CVE-2021-28164"
+path = "jetty/CVE-2021-28164"
+
+[[containers]]
+name_en = "Jetty Common Servlets Component ConcatServlet Information Disclosure"
+name_zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
+app = "jetty"
+cve = "CVE-2021-28169"
+path = "jetty/CVE-2021-28169"
+
+[[containers]]
+name_en = "Jetty WEB-INF Sensitive Information Disclosure"
+name_zh = "Jetty WEB-INF 敏感信息泄露漏洞"
+app = "jetty"
+cve = "CVE-2021-34429"
+path = "jetty/CVE-2021-34429"
+
+[[containers]]
+name_en = "Atlassian Jira Template Injection"
+name_zh = "Atlassian Jira 模板注入漏洞"
+app = "jira"
+cve = "CVE-2019-11581"
+path = "jira/CVE-2019-11581"
+
+[[containers]]
+name_en = "Jmeter RMI Deserialization Command Execution"
+name_zh = "Jmeter RMI 反序列化命令执行漏洞"
+app = "Apache Jmeter"
+cve = "CVE-2018-1297"
+path = "jmeter/CVE-2018-1297"
+
+[[containers]]
+name_en = "Joomla 3.4.5 Deserialization"
+name_zh = "Joomla 3.4.5 反序列化漏洞"
+app = "Joomla"
+cve = "CVE-2015-8562"
+path = "joomla/CVE-2015-8562"
+
+[[containers]]
+name_en = "Joomla 3.7.0 SQL Injection"
+name_zh = "Joomla 3.7.0 SQL注入漏洞"
+app = "Joomla"
+cve = "CVE-2017-8917"
+path = "joomla/CVE-2017-8917"
+
+[[containers]]
+name_en = "Joomla 4.2.7 Permission Bypass"
+name_zh = "Joomla 4.2.7 权限绕过漏洞"
+app = "Joomla"
+cve = "CVE-2023-23752"
+path = "joomla/CVE-2023-23752"
+
+[[containers]]
+name_en = "Jupyter Notebook Unauthorized Access"
+name_zh = "Jupyter Notebook 未授权访问漏洞"
+app = "Jupyter"
+path = "jupyter/notebook-rce"
+
+[[containers]]
+name_en = "Apache Kafka Clients JNDI Injection"
+name_zh = "Apache Kafka Clients JNDI注入漏洞"
+app = "Apache Kafka"
+cve = "CVE-2023-25194"
+path = "kafka/CVE-2023-25194"
+
+[[containers]]
+name_en = "Kibana Local File Inclusion"
+name_zh = "Kibana 本地文件包含漏洞"
+app = "kibana"
+cve = "CVE-2018-17246"
+path = "kibana/CVE-2018-17246"
+
+[[containers]]
+name_en = "Kibana Prototype Chain Pollution to Arbitrary Code Execution"
+name_zh = "Kibana 原型链污染导致任意代码执行漏洞"
+app = "kibana"
+cve = "CVE-2019-7609"
+path = "kibana/CVE-2019-7609"
+
+[[containers]]
+name_en = "Laravel Ignition 2.5.1 Code Execution"
+name_zh = "Laravel Ignition 2.5.1 代码执行漏洞"
+app = "laravel"
+cve = "CVE-2021-3129"
+path = "kibana/CVE-2021-3129"
+
+[[containers]]
+name_en = "libssh Server-side Authentication Bypass"
+name_zh = "libssh 服务端权限认证绕过漏洞"
+app = "libssh"
+cve = "CVE-2018-10933"
+path = "libssh/CVE-2018-10933"
+
+[[containers]]
+name_en = "Liferay Portal CE Deserialization Command Execution"
+name_zh = "Liferay Portal CE 反序列化命令执行漏洞"
+app = "Liferay Portal"
+cve = "CVE-2020-7961"
+path = "liferay-portal/CVE-2020-7961"
+
+[[containers]]
+name_en = "Apache Log4j Server Deserialization Command Execution"
+name_zh = "Apache Log4j Server 反序列化命令执行漏洞"
+app = "Apache Log4j"
+cve = "CVE-2017-5645"
+path = "log4j/CVE-2017-5645"
+
+[[containers]]
+name_en = "Apache Log4j2 lookup JNDI Injection"
+name_zh = "Apache Log4j2 lookup JNDI 注入漏洞"
+app = "Apache Log4j"
+cve = "CVE-2021-44228"
+path = "log4j/CVE-2021-44228"
+
+[[containers]]
+name_en = "Magento 2.2 SQL Injection"
+name_zh = "Magento 2.2 SQL注入漏洞"
+app = "Magento"
+path = "magento/2.2-sqli"
+
+[[containers]]
+name_en = "Metabase Arbitrary File Read"
+name_zh = "Metabase任意文件读取漏洞"
+app = "metabase"
+cve = "CVE-2021-41277"
+path = "metabase/CVE-2021-41277"
+
+[[containers]]
+name_en = "mini_httpd Arbitrary File Read"
+name_zh = "mini_httpd任意文件读取漏洞"
+app = "mini_httpd"
+cve = "CVE-2018-18778"
+path = "mini_httpd/CVE-2018-18778"
+
+[[containers]]
+name_en = "MinIO Cluster Mode Information Disclosure"
+name_zh = "MinIO集群模式信息泄露漏洞"
+app = "MinIO"
+cve = "CVE-2023-28432"
+path = "minio/CVE-2023-28432"
+
+[[containers]]
+name_en = "Mojarra JSF ViewState Deserialization"
+name_zh = "Mojarra JSF ViewState 反序列化漏洞"
+app = "Mojarra JSF"
+path = "mojarra/jsf-viewstate-deserialization"
+
+[[containers]]
+name_en = "Mongo Express Remote Code Execution"
+name_zh = "Mongo Express 远程代码执行漏洞"
+app = "mongo-express"
+cve = "CVE-2019-10758"
+path = "mongo-express/CVE-2019-10758"
+
+[[containers]]
+name_en = "MySQL Authentication Bypass"
+name_zh = "MySQL 身份认证绕过漏洞"
+app = "MySQL"
+cve = "CVE-2012-2122"
+path = "mysql/CVE-2012-2122"
+
+[[containers]]
+name_en = "Nacos Authentication Bypass"
+name_zh = "Nacos 认证绕过漏洞"
+app = "Nacos"
+cve = "CVE-2021-29441"
+path = "nacos/CVE-2021-29441"
+
+[[containers]]
+name_en = "Neo4j Shell Server Deserialization"
+name_zh = "Neo4j Shell Server 反序列化漏洞"
+app = "Neo4j"
+cve = "CVE-2021-34371"
+path = "neo4j/CVE-2021-34371"
+
+[[containers]]
+name_en = "Nexus Repository Manager 3 Remote Command Execution"
+name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
+app = "Nexus Repository Manager"
+cve = "CVE-2019-7238"
+path = "nexus/CVE-2019-7238"
+
+[[containers]]
+name_en = "Nexus Repository Manager 3 Remote Command Execution"
+name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
+app = "Nexus Repository Manager"
+cve = "CVE-2020-10199"
+path = "nexus/CVE-2020-10199"
+
+[[containers]]
+name_en = "Nexus Repository Manager 3 Remote Command Execution"
+name_zh = "Nexus Repository Manager 3 远程命令执行漏洞"
+app = "Nexus Repository Manager"
+cve = "CVE-2020-10204"
+path = "nexus/CVE-2020-10204"
+
+[[containers]]
+name_en = "Nginx Filename Logic"
+name_zh = "Nginx 文件名逻辑漏洞"
+app = "Nginx"
+cve = "CVE-2013-4547"
+path = "nginx/CVE-2013-4547"
+
+[[containers]]
+name_en = "Nginx Out-of-Bounds Read Cache"
+name_zh = "Nginx越界读取缓存漏洞"
+app = "Nginx"
+cve = "CVE-2017-7529"
+path = "nginx/CVE-2017-7529"
+
+[[containers]]
+name_en = "Nginx Configuration Errors"
+name_zh = "Nginx 配置错误三例"
+app = "Nginx"
+path = "nginx/insecure-configuration"
+
+[[containers]]
+name_en = "Nginx Parsing"
+name_zh = "Nginx 解析漏洞"
+app = "Nginx"
+path = "nginx/nginx_parsing_vulnerability"
+
+[[containers]]
+name_en = "NodeJS Directory Traversal"
+name_zh = "NodeJS 目录穿越漏洞"
+app = "node"
+cve = "CVE-2017-14849"
+path = "node/CVE-2017-14849"
+
+[[containers]]
+name_en = "node-postgres Code Execution"
+name_zh = "node-postgres 代码执行漏洞分析"
+app = "node-postgres"
+cve = "CVE-2017-16082"
+path = "node/CVE-2017-16082"
+
+[[containers]]
+name_en = "ntopng Permission Bypass"
+name_zh = "ntopng权限绕过漏洞"
+app = "ntopng"
+cve = "CVE-2021-28073"
+path = "ntopng/CVE-2021-28073"
+
+[[containers]]
+name_en = "Apache OfBiz Deserialization Command Execution"
+name_zh = "Apache OfBiz 反序列化命令执行漏洞"
+app = "Apache OfBiz"
+cve = "CVE-2020-9496"
+path = "ofbiz/CVE-2020-9496"
+
+[[containers]]
+name_en = "Openfire Management Background Authentication Bypass"
+name_zh = "Openfire管理后台认证绕过漏洞"
+app = "Openfire"
+cve = "CVE-2023-32315"
+path = "openfire/CVE-2023-32315"
+
+[[containers]]
+name_en = "OpenSMTPD Remote Command Execution"
+name_zh = "OpenSMTPD 远程命令执行漏洞"
+app = "OpenSMTPD"
+cve = "CVE-2020-7247"
+path = "opensmtpd/CVE-2020-7247"
+
+[[containers]]
+name_en = "OpenSSH Username Enumeration"
+name_zh = "OpenSSH 用户名枚举漏洞"
+app = "OpenSSH"
+cve = "CVE-2018-15473"
+path = "openssh/CVE-2018-15473"
+
+[[containers]]
+name_en = "OpenSSL Heartbleed"
+name_zh = "OpenSSL 心脏出血漏洞"
+app = "OpenSSL"
+cve = "CVE-2014-0160"
+path = "openssl/CVE-2014-0160"
+
+[[containers]]
+name_en = "OpenSSL Infinite Loop DoS"
+name_zh = "OpenSSL无限循环DoS漏洞"
+app = "OpenSSL"
+cve = "CVE-2022-0778"
+path = "openssl/CVE-2022-0778"
+
+[[containers]]
+name_en = "OpenTSDB Command Injection"
+name_zh = "OpenTSDB 命令注入漏洞"
+app = "OpenTSDB"
+cve = "CVE-2020-35476"
+path = "opentsdb/CVE-2020-35476"
+
+[[containers]]
+name_en = "PHP 8.1.0-dev Development Version Backdoor Event"
+name_zh = "PHP 8.1.0-dev 开发版本后门事件"
+app = "PHP"
+path = "php/8.1-backdoor"
+
+[[containers]]
+name_en = "PHP-CGI Remote Code Execution"
+name_zh = "PHP-CGI远程代码执行漏洞"
+app = "PHP-CGI"
+cve = "CVE-2012-1823"
+path = "php/CVE-2012-1823"
+
+[[containers]]
+name_en = "PHP-IMAP Remote Command Execution"
+name_zh = "PHP-IMAP 远程命令执行漏洞"
+app = "PHP-IMAP"
+cve = "CVE-2018-19518"
+path = "php/CVE-2018-19518"
+
+[[containers]]
+name_en = "PHP-FPM Remote Command Execution"
+name_zh = "PHP-FPM 远程代码执行漏洞"
+app = "PHP-FPM"
+cve = "CVE-2019-11043"
+path = "php/CVE-2019-11043"
+
+[[containers]]
+name_en = "PHP-FPM FastCGI Unauthorized Access"
+name_zh = "PHP-FPM FastCGI 未授权访问漏洞"
+app = "PHP-FPM"
+path = "php/fpm"
+
+[[containers]]
+name_en = "PHP Files Vulnerabilities (by phpinfo())"
+name_zh = "PHP文件包含漏洞 (利用phpinfo())"
+app = "PHP"
+path = "php/inclusion"
+
+[[containers]]
+name_en = "PHP XML Entity Injection"
+name_zh = "PHP XML实体注入"
+app = "PHP"
+path = "php/php_xxe"
+
+[[containers]]
+name_en = "XDebug Remote Debugging Code Execution"
+name_zh = "XDebug 远程调试漏洞 (代码执行)"
+app = "PHP"
+path = "php/xdebug-rce"
+
+[[containers]]
+name_en = "PHPMailer Arbitrary File Read"
+name_zh = "PHPMailer 任意文件读取漏洞"
+app = "PHPMailer"
+cve = "CVE-2017-5223"
+path = "phpmailer/CVE-2017-5223"
+
+[[containers]]
+name_en = "phpMyAdmin 4.0.x—4.6.2 Remote Code Execution"
+name_zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
+app = "phpmyadmin"
+cve = "CVE-2016-5734"
+path = "phpmyadmin/CVE-2016-5734"
+
+[[containers]]
+name_en = "phpmyadmin 4.8.1 Remote File Inclusion"
+name_zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
+app = "phpmyadmin"
+cve = "CVE-2018-12613"
+path = "phpmyadmin/CVE-2018-12613"
+
+[[containers]]
+name_en = "phpmyadmin scripts/setup.php Deserialization"
+name_zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
+app = "phpmyadmin"
+path = "phpmyadmin/WooYun-2016-199433"
+
+[[containers]]
+name_en = "phpunit Remote Code Execution"
+name_zh = "phpunit 远程代码执行漏洞"
+app = "phpunit"
+cve = "CVE-2017-9841"
+path = "phpunit/CVE-2017-9841"
+
+[[containers]]
+name_en = "Polkit pkexec Privilege Escalation"
+name_zh = "Polkit pkexec 权限提升漏洞"
+app = "Polkit Pkexec"
+cve = "CVE-2021-4034"
+path = "polkit/CVE-2021-4034"
+
+[[containers]]
+name_en = "PostgreSQL Privilege Escalation"
+name_zh = "PostgreSQL 提权漏洞"
+app = "PostgreSQL"
+cve = "CVE-2018-1058"
+path = "postgres/CVE-2018-1058"
+
+[[containers]]
+name_en = "PostgreSQL High Privilege Command Execution"
+name_zh = "PostgreSQL 高权限命令执行漏洞"
+app = "PostgreSQL"
+cve = "CVE-2019-9193"
+path = "postgres/CVE-2019-9193"
+
+[[containers]]
+name_en = "Python PIL Remote Command Execution (GhostButt)"
+name_zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
+app = "Python"
+cve = "CVE-2017-8291"
+path = "python/PIL-CVE-2017-8291"
+
+[[containers]]
+name_en = "Python PIL Remote Command Execution (via Ghostscript)"
+name_zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
+app = "Python"
+cve = "CVE-2018-16509"
+path = "python/PIL-CVE-2018-16509"
+
+[[containers]]
+name_en = "Python Unpickle Deserialization"
+name_zh = "Python Unpickle 反序列化漏洞"
+app = "Python"
+path = "python/unpickle"
+
+[[containers]]
+name_en = "Ruby on Rails Path Traversal"
+name_zh = "Ruby on Rails 路径穿越漏洞"
+app = "Ruby on Rails"
+cve = "CVE-2018-3760"
+path = "rails/CVE-2018-3760"
+
+[[containers]]
+name_en = "Ruby on Rails Path Traversal and Arbitrary File Read"
+name_zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
+app = "Ruby on Rails"
+cve = "CVE-2019-5418"
+path = "rails/CVE-2019-5418"
+
+[[containers]]
+name_en = "Redis 4.x/5.x Command Execution due to Master-Slave Replication"
+name_zh = "Redis 4.x/5.x 主从复制导致的命令执行"
+app = "redis"
+path = "redis/4-unacc"
+
+[[containers]]
+name_en = "Redis Lua Sandbox Bypass Command Execution"
+name_zh = "Redis Lua沙盒绕过命令执行"
+app = "redis"
+cve = "CVE-2022-0543"
+path = "redis/CVE-2022-0543"
+
+[[containers]]
+name_en = "Rocket Chat MongoDB Injection"
+name_zh = "Rocket Chat MongoDB 注入漏洞"
+app = "rocket chat"
+cve = "CVE-2021-22911"
+path = "rocketchat/CVE-2021-22911"
+
+[[containers]]
+name_en = "Apache RocketMQ Remote Command Execution"
+name_zh = "Apache RocketMQ 远程命令执行漏洞"
+app = "Apache RocketMQ"
+cve = "CVE-2023-33246"
+path = "rocketmq/CVE-2023-33246"
+
+[[containers]]
+name_en = "rsync Unauthorized Access"
+name_zh = "rsync 未授权访问漏洞"
+app = "rsync"
+path = "rsync/common"
+
+[[containers]]
+name_en = "Ruby Net::FTP Module Command Injection"
+name_zh = "Ruby Net::FTP 模块命令注入漏洞"
+app = "ruby"
+cve = "CVE-2017-17405"
+path = "ruby/CVE-2017-17405"
+
+[[containers]]
+name_en = "SaltStack Horizontal Privilege Bypass"
+name_zh = "SaltStack 水平权限绕过漏洞"
+app = "SaltStack"
+cve = "CVE-2020-11651"
+path = "saltstack/CVE-2020-11651"
+
+[[containers]]
+name_en = "SaltStack Arbitrary File Read and Write"
+name_zh = "SaltStack 任意文件读写漏洞"
+app = "SaltStack"
+cve = "CVE-2020-11652"
+path = "saltstack/CVE-2020-11652"
+
+[[containers]]
+name_en = "SaltStack Command Injection"
+name_zh = "SaltStack 命令注入漏洞"
+app = "SaltStack"
+cve = "CVE-2020-16846"
+path = "saltstack/CVE-2020-16846"
+
+[[containers]]
+name_en = "Samba Remote Command Execution"
+name_zh = "Samba 远程命令执行漏洞"
+app = "Samba"
+cve = "CVE-2017-7494"
+path = "samba/CVE-2017-7494"
+
+[[containers]]
+name_en = "Scrapyd Unauthorized Access"
+name_zh = "Scrapyd 未授权访问漏洞"
+app = "Scrapyd"
+path = "scrapy/scrapyd-unacc"
+
+[[containers]]
+name_en = "Apache Shiro Authentication Bypass"
+name_zh = "Apache Shiro 认证绕过漏洞"
+app = "shiro"
+cve = "CVE-2010-3863"
+path = "shiro/CVE-2010-3863"
+
+[[containers]]
+name_en = "Apache Shiro 1.2.4 Deserialization"
+name_zh = "Apache Shiro 1.2.4反序列化漏洞"
+app = "shiro"
+cve = "CVE-2016-4437"
+path = "shiro/CVE-2016-4437"
+
+[[containers]]
+name_en = "Apache Shiro Authentication Bypass"
+name_zh = "Apache Shiro 认证绕过漏洞"
+app = "shiro"
+cve = "CVE-2020-1957"
+path = "shiro/CVE-2020-1957"
+
+[[containers]]
+name_en = "Apache Skywalking 8.3.0 SQL Injection"
+name_zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
+app = "skywalking"
+path = "skywalking/8.3.0-sqli"
+
+[[containers]]
+name_en = "Apache Solr Remote Command Execution"
+name_zh = "Apache Solr 远程命令执行漏洞"
+app = "solr"
+cve = "CVE-2017-12629"
+path = "solr/CVE-2017-12629-RCE"
+
+[[containers]]
+name_en = "Apache Solr XML Entity Injection"
+name_zh = "Apache Solr XML 实体注入漏洞"
+app = "solr"
+cve = "CVE-2017-12629"
+path = "solr/CVE-2017-12629-XXE"
+
+[[containers]]
+name_en = "Apache Solr Remote Command Execution"
+name_zh = "Apache Solr 远程命令执行漏洞"
+app = "solr"
+cve = "CVE-2019-0193"
+path = "solr/CVE-2019-0193"
+
+[[containers]]
+name_en = "Apache Solr Velocity Inject Remote Command Execution"
+name_zh = "Apache Solr Velocity 注入远程命令执行漏洞"
+app = "solr"
+cve = "CVE-2019-17558"
+path = "solr/CVE-2019-17558"
+
+[[containers]]
+name_en = "Apache Solr RemoteStreaming File Reading and SSRF"
+name_zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
+app = "solr"
+path = "solr/Remote-Streaming-Fileread"
+
+[[containers]]
+name_en = "Apache Spark Unauthorized Access Leak"
+name_zh = "Apache Spark 未授权访问漏"
+app = "spark"
+path = "spark/unacc"
+
+[[containers]]
+name_en = "Spring Security Oauth2 Remote Command Execution"
+name_zh = "Spring Security Oauth2 远程命令执行漏洞"
+app = "spring security oauth2"
+cve = "CVE-2016-4977"
+path = "spring/CVE-2016-4977"
+
+[[containers]]
+name_en = "Spring WebFlow Remote Code Execution"
+name_zh = "Spring WebFlow 远程代码执行漏洞"
+app = "spring webflow"
+cve = "CVE-2017-4971"
+path = "spring/CVE-2017-4971"
+
+[[containers]]
+name_en = "Spring Data Rest Remote Command Execution"
+name_zh = "Spring Data Rest 远程命令执行漏洞"
+app = "spring data rest"
+cve = "CVE-2017-8046"
+path = "spring/CVE-2017-8046"
+
+[[containers]]
+name_en = "Spring Messaging Remote Command Execution"
+name_zh = "Spring Messaging 远程命令执行漏洞"
+app = "spring messaging"
+cve = "CVE-2018-1270"
+path = "spring/CVE-2018-1270"
+
+[[containers]]
+name_en = "Spring Data Commons Remote Command Execution"
+name_zh = "Spring Data Commons 远程命令执行漏洞"
+app = "spring data commons"
+cve = "CVE-2018-1273"
+path = "spring/CVE-2018-1273"
+
+[[containers]]
+name_en = "Spring Cloud Gateway Actuator API SpEL Expression Injection Command Execution"
+name_zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
+app = "spring cloud gateway"
+cve = "CVE-2022-22947"
+path = "spring/CVE-2022-22947"
+
+[[containers]]
+name_en = "Spring Cloud Function SpEL Expression Command Injection"
+name_zh = "Spring Cloud Function SpEL表达式命令注入"
+app = "spring cloud function"
+cve = "CVE-2022-22963"
+path = "spring/CVE-2022-22963"
+
+[[containers]]
+name_en = "Remote Code Execution Vulnerability due to Spring Framework Data Binding and JDK 9+"
+name_zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
+app = "Spring"
+cve = "CVE-2022-22965"
+path = "spring/CVE-2022-22965"
+
+[[containers]]
+name_en = "Spring Security Authorization Bypass in RegexRequestMatcher"
+name_zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
+app = "Spring"
+cve = "CVE-2022-22978"
+path = "spring/CVE-2022-22978"
+
+[[containers]]
+name_en = "S2-001 Remote Code Execution"
+name_zh = "S2-001 远程代码执行漏洞"
+app = "Struts2"
+path = "struts2/s2-001"
+
+[[containers]]
+name_en = "S2-005 Remote Code Execution"
+name_zh = "S2-005 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2010-1870"
+path = "struts2/s2-005"
+
+[[containers]]
+name_en = "S2-007 Remote Code Execution"
+name_zh = "S2-007 远程代码执行漏洞"
+app = "Struts2"
+path = "struts2/s2-007"
+
+[[containers]]
+name_en = "S2-008 Remote Code Execution"
+name_zh = "S2-008 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2012-0391"
+path = "struts2/s2-008"
+
+[[containers]]
+name_en = "S2-009 Remote Code Execution"
+name_zh = "S2-009 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2011-3923"
+path = "struts2/s2-009"
+
+[[containers]]
+name_en = "S2-012 Remote Code Execution"
+name_zh = "S2-012 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2013-1965"
+path = "struts2/s2-012"
+
+[[containers]]
+name_en = "S2-013 Remote Code Execution"
+name_zh = "S2-013 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2013-1966"
+path = "struts2/s2-013"
+
+[[containers]]
+name_en = "S2-015 Remote Code Execution"
+name_zh = "S2-015 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2013-2134,CVE-2013-2135"
+path = "struts2/s2-015"
+
+[[containers]]
+name_en = "S2-016 Remote Code Execution"
+name_zh = "S2-016 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2013-2251"
+path = "struts2/s2-016"
+
+[[containers]]
+name_en = "S2-032 Remote Code Execution"
+name_zh = "S2-032 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2016-3081"
+path = "struts2/s2-032"
+
+[[containers]]
+name_en = "S2-045 Remote Code Execution"
+name_zh = "S2-045 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2017-5638"
+path = "struts2/s2-045"
+
+[[containers]]
+name_en = "S2-046 Remote Code Execution"
+name_zh = "S2-046 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2017-5638"
+path = "struts2/s2-046"
+
+[[containers]]
+name_en = "S2-048 Remote Code Execution"
+name_zh = "S2-048 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2017-9791"
+path = "struts2/s2-048"
+
+[[containers]]
+name_en = "S2-052 Remote Code Execution"
+name_zh = "S2-052 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2017-9805"
+path = "struts2/s2-052"
+
+[[containers]]
+name_en = "S2-053 Remote Code Execution"
+name_zh = "S2-053 远程代码执行漏洞"
+app = "Struts2"
+cve = "CVE-2017-12611"
+path = "struts2/s2-053"
+
+[[containers]]
+name_en = "Struts2 S2-057 Remote Command Execution"
+name_zh = "Struts2 S2-057 远程命令执行漏洞"
+app = "Struts2"
+cve = "CVE-2018-11776"
+path = "struts2/s2-057"
+
+[[containers]]
+name_en = "Struts2 S2-059 Remote Command Execution"
+name_zh = "Struts2 S2-059 远程命令执行漏洞"
+app = "Struts2"
+cve = "CVE-2019-0230"
+path = "struts2/s2-059"
+
+[[containers]]
+name_en = "Struts2 S2-061 Remote Command Execution"
+name_zh = "Struts2 S2-061 远程命令执行漏洞"
+app = "Struts2"
+cve = "CVE-2020-17530"
+path = "struts2/s2-061"
+
+[[containers]]
+name_en = "Supervisord Remote Command Execution"
+name_zh = "Supervisord 远程命令执行漏洞"
+app = "Supervisor"
+cve = "CVE-2017-11610"
+path = "supervisor/CVE-2017-11610"
+
+[[containers]]
+name_en = "ThinkPHP 2.x Arbitrary Code Execution"
+name_zh = "ThinkPHP 2.x 任意代码执行漏洞"
+app = "ThinkPHP"
+path = "thinkphp/2-rce"
+
+[[containers]]
+name_en = "ThinkPHP5 5.0.22/5.1.29 Remote Code Execution"
+name_zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
+app = "ThinkPHP"
+path = "thinkphp/5-rce"
+
+[[containers]]
+name_en = "ThinkPHP5 5.0.23 Remote Code Execution"
+name_zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
+app = "ThinkPHP"
+path = "thinkphp/5.0.23-rce"
+
+[[containers]]
+name_en = "ThinkPHP5 SQL Injection Vulnerabilities/Information Leakage"
+name_zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
+app = "ThinkPHP"
+path = "thinkphp/in-sqlinjection"
+
+[[containers]]
+name_en = "ThinkPHP Multilingual Local File Inclusion"
+name_zh = "ThinkPHP 多语言本地文件包含漏洞"
+app = "ThinkPHP"
+path = "thinkphp/lang-rce"
+
+[[containers]]
+name_en = "Tiki Wiki CMS Groupware Authentication Bypass"
+name_zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
+app = "Tiki Wiki"
+cve = "CVE-2020-15906"
+path = "tikiwiki/CVE-2020-15906"
+
+[[containers]]
+name_en = "Tomcat Arbitrary Writing of Files in the PUT Method"
+name_zh = "Tomcat PUT方法任意写文件漏洞"
+app = "Tomcat"
+cve = "CVE-2017-12615"
+path = "tomcat/CVE-2017-12615"
+
+[[containers]]
+name_en = "Apache Tomcat AJP Bug"
+name_zh = "Apache Tomcat AJP 文件包含漏洞"
+app = "Tomcat"
+cve = "CVE-2020-1938"
+path = "tomcat/CVE-2020-1938"
+
+[[containers]]
+name_en = "Tomcat Weak Password"
+name_zh = "Tomcat弱口令"
+app = "Tomcat"
+path = "tomcat/tomcat8"
+
+[[containers]]
+name_en = "Apache Unomi Remote Expression Code Execution"
+name_zh = "Apache Unomi 远程表达式代码执行漏洞"
+app = "unomi"
+cve = "CVE-2020-13942"
+path = "unomi/CVE-2020-13942"
+
+[[containers]]
+name_en = "uWSGI PHP Directory Traversal"
+name_zh = "uWSGI PHP目录穿越漏洞"
+app = "uWSGI"
+cve = "CVE-2018-7490"
+path = "uwsgi/CVE-2018-7490"
+
+[[containers]]
+name_en = "uWSGI Unauthorized Access"
+name_zh = "uWSGI 未授权访问漏洞"
+app = "uWSGI"
+path = "uwsgi/unacc"
+
+[[containers]]
+name_en = "V2board 1.6.1 Privilege Escalation"
+name_zh = "V2board 1.6.1 提权漏洞"
+app = "V2board"
+path = "v2board/1.6-privilege-escalation"
+
+[[containers]]
+name_en = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder Deserialization"
+name_zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
+app = "WebLogic"
+cve = "CVE-2017-10271"
+path = "weblogic/CVE-2017-10271"
+
+[[containers]]
+name_en = "WebLogic WLS Core Components Deserialization Command Execution"
+name_zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
+app = "WebLogic"
+cve = "CVE-2018-2628"
+path = "weblogic/CVE-2018-2628"
+
+[[containers]]
+name_en = "WebLogic Arbitrary File Upload"
+name_zh = "WebLogic 任意文件上传漏洞"
+app = "WebLogic"
+cve = "CVE-2018-2894"
+path = "weblogic/CVE-2018-2894"
+
+[[containers]]
+name_en = "WebLogic Management Console Unauthorized Remote Command Execution"
+name_zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
+app = "WebLogic"
+cve = "CVE-2020-14882"
+path = "weblogic/CVE-2020-14882"
+
+[[containers]]
+name_en = "WebLogic Unauthorized Remote Code Execution"
+name_zh = "WebLogic未授权远程代码执行漏洞"
+app = "WebLogic"
+cve = "CVE-2023-21839"
+path = "weblogic/CVE-2023-21839"
+
+[[containers]]
+name_en = "WebLogic SSRF"
+name_zh = "WebLogic SSRF漏洞"
+app = "WebLogic"
+path = "weblogic/ssrf"
+
+[[containers]]
+name_en = "WebLogic File Read"
+name_zh = "WebLogic 文件读取漏洞"
+app = "WebLogic"
+path = "weblogic/weak_password"
+
+[[containers]]
+name_en = "Webmin Remote Command Execution"
+name_zh = "Webmin 远程命令执行漏洞"
+app = "Webmin"
+cve = "CVE-2019-15107"
+path = "webmin/CVE-2019-15107"
+
+[[containers]]
+name_en = "Wordpress 4.6 Arbitrary Command Execution (PwnScriptum)"
+name_zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
+app = "Wordpress"
+path = "wordpress/pwnscriptum"
+
+[[containers]]
+name_en = "XStream Deserialization Command Execution"
+name_zh = "XStream 反序列化命令执行漏洞"
+app = "XStream"
+cve = "CVE-2021-21351"
+path = "xstream/CVE-2021-21351"
+
+[[containers]]
+name_en = "XStream Deserialization Command Execution"
+name_zh = "XStream 反序列化命令执行漏洞"
+app = "XStream"
+cve = "CVE-2021-29505"
+path = "xstream/CVE-2021-29505"
+
+[[containers]]
+name_en = "XXL-JOB Executor Unauthorized Access"
+name_zh = "XXL-JOB Executor 未授权访问漏洞"
+app = "xxl-job"
+path = "xxl-job/unacc"
+
+[[containers]]
+name_en = "YApi NoSQL Injection to Remote Command Execution"
+name_zh = "YApi NoSQL注入导致远程命令执行漏洞"
+app = "YApi"
+path = "yapi/mongodb-inj"
+
+[[containers]]
+name_en = "YApi Open Registration due to RCE"
+name_zh = "YApi开放注册导致RCE"
+app = "YApi"
+path = "yapi/unacc"
+
+[[containers]]
+name_en = "Zabbix latest.php SQL Injection"
+name_zh = "Zabbix latest.php SQL注入漏洞"
+app = "Zabbix"
+cve = "CVE-2016-10134"
+path = "zabbix/CVE-2016-10134"
+
+[[containers]]
+name_en = "Zabbix Server Trapper Command Injection"
+name_zh = "Zabbix Server Trapper命令注入漏洞"
+app = "Zabbix"
+cve = "CVE-2020-11800"
+path = "zabbix/CVE-2020-11800"

--- a/environments.toml
+++ b/environments.toml
@@ -4,7 +4,7 @@
   zh = "Apache ActiveMQ 反序列化漏洞"
 app = "ActiveMQ"
   [[container.cve]]
-  name = "CVE-2015-5254"
+  id = "CVE-2015-5254"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5254"
 path = "activemq/CVE-2015-5254"
 
@@ -14,7 +14,7 @@ path = "activemq/CVE-2015-5254"
   zh = "Apache ActiveMQ 任意文件写入漏洞"
 app = "ActiveMQ"
   [[container.cve]]
-  name = "CVE-2016-3088"
+  id = "CVE-2016-3088"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3088"
 path = "activemq/CVE-2016-3088"
 
@@ -24,7 +24,7 @@ path = "activemq/CVE-2016-3088"
   zh = "Apache Airflow 示例dag中的命令注入"
 app = "Airflow"
   [[container.cve]]
-  name = "CVE-2020-11978"
+  id = "CVE-2020-11978"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11978"
 path = "airflow/CVE-2020-11978"
 
@@ -34,7 +34,7 @@ path = "airflow/CVE-2020-11978"
   zh = "Apache Airflow Celery 消息中间件命令执行"
 app = "Airflow"
   [[container.cve]]
-  name = "CVE-2020-11981"
+  id = "CVE-2020-11981"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11981"
 path = "airflow/CVE-2020-11981"
 
@@ -44,7 +44,7 @@ path = "airflow/CVE-2020-11981"
   zh = "Apache Airflow 默认密钥导致的权限绕过"
 app = "Airflow"
   [[container.cve]]
-  name = "CVE-2020-17526"
+  id = "CVE-2020-17526"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17526"
 path = "airflow/CVE-2020-17526"
 
@@ -54,7 +54,7 @@ path = "airflow/CVE-2020-17526"
   zh = "Apache Druid 代码执行漏洞"
 app = "Apache Druid"
   [[container.cve]]
-  name = "CVE-2021-25646"
+  id = "CVE-2021-25646"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-25646"
 path = "apache-druid/CVE-2021-25646"
 
@@ -64,7 +64,7 @@ path = "apache-druid/CVE-2021-25646"
   zh = "Apereo CAS 4.1 反序列化命令执行漏洞"
 app = "Apereo CAS"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "apereo-cas/4.1-rce"
 
@@ -74,7 +74,7 @@ path = "apereo-cas/4.1-rce"
   zh = "Apache APISIX 默认密钥漏洞"
 app = "Apache APISIX"
   [[container.cve]]
-  name = "CVE-2020-13945"
+  id = "CVE-2020-13945"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13945"
 path = "apisix/CVE-2020-13945"
 
@@ -84,7 +84,7 @@ path = "apisix/CVE-2020-13945"
   zh = "Apache APISIX Dashboard API权限绕过导致RCE"
 app = "Apache APISIX"
   [[container.cve]]
-  name = "CVE-2021-45232"
+  id = "CVE-2021-45232"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-45232"
 path = "apisix/CVE-2021-45232"
 
@@ -94,7 +94,7 @@ path = "apisix/CVE-2021-45232"
   zh = "AppWeb 认证绕过漏洞"
 app = "AppWeb"
   [[container.cve]]
-  name = "CVE-2018-8715"
+  id = "CVE-2018-8715"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-8715"
 path = "appweb/CVE-2018-8715"
 
@@ -104,7 +104,7 @@ path = "appweb/CVE-2018-8715"
   zh = "Aria2 任意文件写入漏洞"
 app = "Aria2"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "aria2/rce"
 
@@ -114,7 +114,7 @@ path = "aria2/rce"
   zh = "Bash Shellshock 破壳漏洞"
 app = "bash"
   [[container.cve]]
-  name = "CVE-2014-6271"
+  id = "CVE-2014-6271"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-6271"
 path = "bash/CVE-2014-6271"
 
@@ -124,7 +124,7 @@ path = "bash/CVE-2014-6271"
   zh = "Cacti 前台命令注入漏洞"
 app = "cacti"
   [[container.cve]]
-  name = "CVE-2022-46169"
+  id = "CVE-2022-46169"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-46169"
 path = "cacti/CVE-2022-46169"
 
@@ -134,7 +134,7 @@ path = "cacti/CVE-2022-46169"
   zh = "Celery <4.0 Redis未授权访问+Pickle反序列化利用"
 app = "celery"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "celery/celery3_redis_unauth"
 
@@ -144,7 +144,7 @@ path = "celery/celery3_redis_unauth"
   zh = "CGI HTTPoxy 漏洞"
 app = "cgi"
   [[container.cve]]
-  name = "CVE-2016-5385"
+  id = "CVE-2016-5385"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5385"
 path = "cgi/CVE-2016-5385"
 
@@ -154,7 +154,7 @@ path = "cgi/CVE-2016-5385"
   zh = "Adobe ColdFusion 文件读取漏洞"
 app = "Adobe ColdFusion"
   [[container.cve]]
-  name = "CVE-2010-2861"
+  id = "CVE-2010-2861"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-2861"
 path = "coldfusion/CVE-2010-2861"
 
@@ -164,7 +164,7 @@ path = "coldfusion/CVE-2010-2861"
   zh = "Adobe ColdFusion 反序列化漏洞"
 app = "Adobe ColdFusion"
   [[container.cve]]
-  name = "CVE-2017-3066"
+  id = "CVE-2017-3066"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-3066"
 path = "coldfusion/CVE-2017-3066"
 
@@ -174,7 +174,7 @@ path = "coldfusion/CVE-2017-3066"
   zh = "Atlassian Confluence 路径穿越与命令执行漏洞"
 app = "Atlassian Confluence"
   [[container.cve]]
-  name = "CVE-2019-3396"
+  id = "CVE-2019-3396"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-3396"
 path = "confluence/CVE-2019-3396"
 
@@ -184,7 +184,7 @@ path = "confluence/CVE-2019-3396"
   zh = "Atlassian Confluence OGNL 表达式注入代码执行漏洞"
 app = "Atlassian Confluence"
   [[container.cve]]
-  name = "CVE-2021-26084"
+  id = "CVE-2021-26084"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-26084"
 path = "confluence/CVE-2021-26084"
 
@@ -194,7 +194,7 @@ path = "confluence/CVE-2021-26084"
   zh = "Atlassian Confluence OGNL 表达式注入命令执行漏洞"
 app = "Atlassian Confluence"
   [[container.cve]]
-  name = "CVE-2022-26134"
+  id = "CVE-2022-26134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-26134"
 path = "confluence/CVE-2022-26134"
 
@@ -204,7 +204,7 @@ path = "confluence/CVE-2022-26134"
   zh = "CouchDB 垂直权限绕过漏洞"
 app = "CouchDB"
   [[container.cve]]
-  name = "CVE-2017-12635"
+  id = "CVE-2017-12635"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12635"
 path = "couchdb/CVE-2017-12635"
 
@@ -214,7 +214,7 @@ path = "couchdb/CVE-2017-12635"
   zh = "CouchDB 任意命令执行漏洞"
 app = "CouchDB"
   [[container.cve]]
-  name = "CVE-2017-12636"
+  id = "CVE-2017-12636"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12636"
 path = "couchdb/CVE-2017-12636"
 
@@ -224,7 +224,7 @@ path = "couchdb/CVE-2017-12636"
   zh = "CouchDB Erlang 分布式协议代码执行"
 app = "CouchDB"
   [[container.cve]]
-  name = "CVE-2022-24706"
+  id = "CVE-2022-24706"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-24706"
 path = "couchdb/CVE-2022-24706"
 
@@ -234,7 +234,7 @@ path = "couchdb/CVE-2022-24706"
   zh = "Discuz 7.x/6.x 全局变量防御绕过导致代码执行"
 app = "Discuz"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "discuz/wooyun-2010-080723"
 
@@ -244,7 +244,7 @@ path = "discuz/wooyun-2010-080723"
   zh = "Discuz!X ≤3.4 任意文件删除漏洞"
 app = "Discuz"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "discuz/x3.4-arbitrary-file-deletion"
 
@@ -254,7 +254,7 @@ path = "discuz/x3.4-arbitrary-file-deletion"
   zh = "Django debug page XSS 漏洞"
 app = "Django"
   [[container.cve]]
-  name = "CVE-2017-12794"
+  id = "CVE-2017-12794"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12794"
 path = "django/CVE-2017-12794"
 
@@ -264,7 +264,7 @@ path = "django/CVE-2017-12794"
   zh = "Django < 2.0.8 任意URL跳转漏洞"
 app = "Django"
   [[container.cve]]
-  name = "CVE-2018-14574"
+  id = "CVE-2018-14574"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-14574"
 path = "django/CVE-2018-14574"
 
@@ -274,7 +274,7 @@ path = "django/CVE-2018-14574"
   zh = "Django JSONField/HStoreField SQL注入漏洞"
 app = "Django"
   [[container.cve]]
-  name = "CVE-2019-14234"
+  id = "CVE-2019-14234"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-14234"
 path = "django/CVE-2019-14234"
 
@@ -284,7 +284,7 @@ path = "django/CVE-2019-14234"
   zh = "Django GIS SQL注入漏洞"
 app = "Django"
   [[container.cve]]
-  name = "CVE-2020-9402"
+  id = "CVE-2020-9402"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9402"
 path = "django/CVE-2020-9402"
 
@@ -294,7 +294,7 @@ path = "django/CVE-2020-9402"
   zh = "Django QuerySet.order_by() SQL注入漏洞"
 app = "Django"
   [[container.cve]]
-  name = "CVE-2021-35042"
+  id = "CVE-2021-35042"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-35042"
 path = "django/CVE-2021-35042"
 
@@ -304,7 +304,7 @@ path = "django/CVE-2021-35042"
   zh = "Django Trunc(kind) and Extract(lookup_name) SQL注入漏洞"
 app = "Django"
   [[container.cve]]
-  name = "CVE-2022-34265"
+  id = "CVE-2022-34265"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-34265"
 path = "django/CVE-2022-34265"
 
@@ -314,7 +314,7 @@ path = "django/CVE-2022-34265"
   zh = "DNS域传送漏洞"
 app = "dns"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "dns/dns-zone-transfer"
 
@@ -324,7 +324,7 @@ path = "dns/dns-zone-transfer"
   zh = "Docker Daemon API 未授权访问漏洞"
 app = "docker"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "docker/unauthorized-rce"
 
@@ -334,7 +334,7 @@ path = "docker/unauthorized-rce"
   zh = "Drupal < 7.32 'Drupalgeddon' SQL注入漏洞"
 app = "drupal"
   [[container.cve]]
-  name = "CVE-2014-3704"
+  id = "CVE-2014-3704"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3704"
 path = "drupal/CVE-2014-3704"
 
@@ -344,7 +344,7 @@ path = "drupal/CVE-2014-3704"
   zh = "Drupal Core 8 PECL YAML 反序列化任意代码执行漏洞"
 app = "drupal"
   [[container.cve]]
-  name = "CVE-2017-6920"
+  id = "CVE-2017-6920"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-6920"
 path = "drupal/CVE-2017-6920"
 
@@ -354,7 +354,7 @@ path = "drupal/CVE-2017-6920"
   zh = "Drupal Drupalgeddon 2 远程代码执行漏洞"
 app = "drupal"
   [[container.cve]]
-  name = "CVE-2018-7600"
+  id = "CVE-2018-7600"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7600"
 path = "drupal/CVE-2018-7600"
 
@@ -364,7 +364,7 @@ path = "drupal/CVE-2018-7600"
   zh = "Drupal 远程代码执行漏洞"
 app = "drupal"
   [[container.cve]]
-  name = "CVE-2018-7602"
+  id = "CVE-2018-7602"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7602"
 path = "drupal/CVE-2018-7602"
 
@@ -374,7 +374,7 @@ path = "drupal/CVE-2018-7602"
   zh = "Drupal 远程代码执行漏洞"
 app = "drupal"
   [[container.cve]]
-  name = "CVE-2019-6339"
+  id = "CVE-2019-6339"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6339"
 path = "drupal/CVE-2019-6339"
 
@@ -384,7 +384,7 @@ path = "drupal/CVE-2019-6339"
   zh = "Drupal XSS漏洞"
 app = "drupal"
   [[container.cve]]
-  name = "CVE-2019-6341"
+  id = "CVE-2019-6341"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6341"
 path = "drupal/CVE-2019-6341"
 
@@ -394,7 +394,7 @@ path = "drupal/CVE-2019-6341"
   zh = "Apache Dubbo Java反序列化漏洞"
 app = "dubbo"
   [[container.cve]]
-  name = "CVE-2019-17564"
+  id = "CVE-2019-17564"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17564"
 path = "dubbo/CVE-2019-17564"
 
@@ -404,7 +404,7 @@ path = "dubbo/CVE-2019-17564"
   zh = "ECShop 4.x collection_list SQL注入"
 app = "ecshop"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "ecshop/collection_list-sqli"
 
@@ -414,7 +414,7 @@ path = "ecshop/collection_list-sqli"
   zh = "ECShop 2.x/3.x SQL注入/任意代码执行漏洞"
 app = "ecshop"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "ecshop/xianzhi-2017-02-82239600"
 
@@ -424,7 +424,7 @@ path = "ecshop/xianzhi-2017-02-82239600"
   zh = "ElasticSearch 命令执行漏洞"
 app = "ElasticSearch"
   [[container.cve]]
-  name = "CVE-2014-3120"
+  id = "CVE-2014-3120"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-3120"
 path = "elasticsearch/CVE-2014-3120"
 
@@ -434,7 +434,7 @@ path = "elasticsearch/CVE-2014-3120"
   zh = "ElasticSearch Groovy 沙盒绕过/代码执行漏洞"
 app = "ElasticSearch"
   [[container.cve]]
-  name = "CVE-2015-1427"
+  id = "CVE-2015-1427"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-1427"
 path = "elasticsearch/CVE-2015-1427"
 
@@ -444,7 +444,7 @@ path = "elasticsearch/CVE-2015-1427"
   zh = "ElasticSearch 插件目录穿越漏洞"
 app = "ElasticSearch"
   [[container.cve]]
-  name = "CVE-2015-3337"
+  id = "CVE-2015-3337"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-3337"
 path = "elasticsearch/CVE-2015-3337"
 
@@ -454,7 +454,7 @@ path = "elasticsearch/CVE-2015-3337"
   zh = "ElasticSearch 目录穿越漏洞"
 app = "ElasticSearch"
   [[container.cve]]
-  name = "CVE-2015-5531"
+  id = "CVE-2015-5531"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5531"
 path = "elasticsearch/CVE-2015-5531"
 
@@ -464,7 +464,7 @@ path = "elasticsearch/CVE-2015-5531"
   zh = "Elasticsearch 写入webshell漏洞"
 app = "ElasticSearch"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "elasticsearch/WooYun-2015-110216"
 
@@ -474,7 +474,7 @@ path = "elasticsearch/WooYun-2015-110216"
   zh = "Electron 远程命令执行漏洞"
 app = "electron"
   [[container.cve]]
-  name = "CVE-2018-1000006"
+  id = "CVE-2018-1000006"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000006"
 path = "electron/CVE-2018-1000006"
 
@@ -484,7 +484,7 @@ path = "electron/CVE-2018-1000006"
   zh = "Electron WebPreferences 远程命令执行漏洞"
 app = "electron"
   [[container.cve]]
-  name = "CVE-2018-15685"
+  id = "CVE-2018-15685"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15685"
 path = "electron/CVE-2018-15685"
 
@@ -494,7 +494,7 @@ path = "electron/CVE-2018-15685"
   zh = "elFinder ZIP 参数与任意命令注入"
 app = "elFinder"
   [[container.cve]]
-  name = "CVE-2021-32682"
+  id = "CVE-2021-32682"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-32682"
 path = "elfinder/CVE-2021-32682"
 
@@ -504,7 +504,7 @@ path = "elfinder/CVE-2021-32682"
   zh = "Fastjson 反序列化导致任意命令执行漏洞"
 app = "Fastjson"
   [[container.cve]]
-  name = "CVE-2017-18349"
+  id = "CVE-2017-18349"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-18349"
 path = "fastjson/1.2.24-rce"
 
@@ -514,7 +514,7 @@ path = "fastjson/1.2.24-rce"
   zh = "Fastjson 1.2.47 远程命令执行漏洞"
 app = "Fastjson"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "fastjson/1.2.47-rce"
 
@@ -524,7 +524,7 @@ path = "fastjson/1.2.47-rce"
   zh = "FFmpeg 任意文件读取漏洞/SSRF漏洞"
 app = "ffmpeg"
   [[container.cve]]
-  name = "CVE-2016-1897,CVE-2016-1898"
+  id = "CVE-2016-1897,CVE-2016-1898"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-1897,CVE-2016-1898"
 path = "ffmpeg/CVE-2016-1897"
 
@@ -534,7 +534,7 @@ path = "ffmpeg/CVE-2016-1897"
   zh = "FFmpeg 任意文件读取漏洞"
 app = "ffmpeg"
   [[container.cve]]
-  name = "CVE-2017-9993"
+  id = "CVE-2017-9993"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9993"
 path = "ffmpeg/phdays"
 
@@ -544,7 +544,7 @@ path = "ffmpeg/phdays"
   zh = "Jinja2 SSTI模板注入"
 app = "Jinja2"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "flask/ssti"
 
@@ -554,7 +554,7 @@ path = "flask/ssti"
   zh = "Apache Flink 文件上传漏洞"
 app = "flink"
   [[container.cve]]
-  name = "CVE-2020-17518"
+  id = "CVE-2020-17518"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17518"
 path = "flink/CVE-2020-17518"
 
@@ -564,7 +564,7 @@ path = "flink/CVE-2020-17518"
   zh = "Apache Flink Jobmanager/Logs 目录穿越漏洞"
 app = "flink"
   [[container.cve]]
-  name = "CVE-2020-17519"
+  id = "CVE-2020-17519"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17519"
 path = "flink/CVE-2020-17519"
 
@@ -574,7 +574,7 @@ path = "flink/CVE-2020-17519"
   zh = "GeoServer OGC Filter SQL注入漏洞"
 app = "GeoServer"
   [[container.cve]]
-  name = "CVE-2023-25157"
+  id = "CVE-2023-25157"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25157"
 path = "geoserver/CVE-2023-25157"
 
@@ -584,7 +584,7 @@ path = "geoserver/CVE-2023-25157"
   zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
   [[container.cve]]
-  name = "CVE-2018-16509"
+  id = "CVE-2018-16509"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
 path = "ghostscript/CVE-2018-16509"
 
@@ -594,7 +594,7 @@ path = "ghostscript/CVE-2018-16509"
   zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
   [[container.cve]]
-  name = "CVE-2018-19475"
+  id = "CVE-2018-19475"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19475"
 path = "ghostscript/CVE-2018-19475"
 
@@ -604,7 +604,7 @@ path = "ghostscript/CVE-2018-19475"
   zh = "GhostScript 沙箱绕过 (命令执行) 漏洞"
 app = "ghostscript"
   [[container.cve]]
-  name = "CVE-2019-6116"
+  id = "CVE-2019-6116"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-6116"
 path = "ghostscript/CVE-2019-6116"
 
@@ -614,7 +614,7 @@ path = "ghostscript/CVE-2019-6116"
   zh = "GIT-SHELL 沙盒绕过"
 app = "git"
   [[container.cve]]
-  name = "CVE-2017-8386"
+  id = "CVE-2017-8386"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8386"
 path = "git/CVE-2017-8386"
 
@@ -624,7 +624,7 @@ path = "git/CVE-2017-8386"
   zh = "Gitea 1.4.0 目录穿越导致命令执行漏洞"
 app = "gitea"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "gitea/1.4-rce"
 
@@ -634,7 +634,7 @@ path = "gitea/1.4-rce"
   zh = "GitLab 任意文件读取漏洞"
 app = "gitlab"
   [[container.cve]]
-  name = "CVE-2016-9086"
+  id = "CVE-2016-9086"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-9086"
 path = "gitlab/CVE-2016-9086"
 
@@ -644,7 +644,7 @@ path = "gitlab/CVE-2016-9086"
   zh = "GitLab 远程命令执行漏洞"
 app = "gitlab"
   [[container.cve]]
-  name = "CVE-2021-22205"
+  id = "CVE-2021-22205"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22205"
 path = "gitlab/CVE-2021-22205"
 
@@ -654,7 +654,7 @@ path = "gitlab/CVE-2021-22205"
   zh = "gitlist 0.6.0 远程命令执行漏洞"
 app = "gitlist"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "gitlist/0.6.0-rce"
 
@@ -664,7 +664,7 @@ path = "gitlist/0.6.0-rce"
   zh = "GlassFish 任意文件读取漏洞"
 app = "GlassFish"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "glassfish/4.1.0"
 
@@ -674,7 +674,7 @@ path = "glassfish/4.1.0"
   zh = "GoAhead 远程命令执行漏洞"
 app = "GoAhead"
   [[container.cve]]
-  name = "CVE-2017-17562"
+  id = "CVE-2017-17562"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17562"
 path = "goahead/CVE-2017-17562"
 
@@ -684,7 +684,7 @@ path = "goahead/CVE-2017-17562"
   zh = "GoAhead Server 环境变量注入"
 app = "GoAhead"
   [[container.cve]]
-  name = "CVE-2021-42342"
+  id = "CVE-2021-42342"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42342"
 path = "goahead/CVE-2021-42342"
 
@@ -694,7 +694,7 @@ path = "goahead/CVE-2021-42342"
   zh = "Gogs 任意用户登录漏洞"
 app = "Gogs"
   [[container.cve]]
-  name = "CVE-2018-18925"
+  id = "CVE-2018-18925"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18925"
 path = "gogs/CVE-2018-18925"
 
@@ -704,7 +704,7 @@ path = "gogs/CVE-2018-18925"
   zh = "Grafana 8.x 插件模块目录穿越漏洞"
 app = "Grafana"
   [[container.cve]]
-  name = "CVE-2021-43798"
+  id = "CVE-2021-43798"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-43798"
 path = "grafana/CVE-2021-43798"
 
@@ -714,7 +714,7 @@ path = "grafana/CVE-2021-43798"
   zh = "Grafana管理后台SSRF"
 app = "Grafana"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "grafana/admin-ssrf"
 
@@ -724,7 +724,7 @@ path = "grafana/admin-ssrf"
   zh = "H2 Database Console 未授权访问"
 app = "Springboot H2 Database"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "h2database/h2-console-unacc"
 
@@ -734,7 +734,7 @@ path = "h2database/h2-console-unacc"
   zh = "Hadoop YARN ResourceManager 未授权访问漏洞"
 app = "Hadoop YARN"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "hadoop/unauthorized-yarn"
 
@@ -744,7 +744,7 @@ path = "hadoop/unauthorized-yarn"
   zh = "Apache HTTPD 换行解析漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
-  name = "CVE-2017-15715"
+  id = "CVE-2017-15715"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-15715"
 path = "httpd/CVE-2017-15715"
 
@@ -754,7 +754,7 @@ path = "httpd/CVE-2017-15715"
   zh = "Apache HTTP Server 2.4.48 mod_proxy SSRF漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
-  name = "CVE-2021-40438"
+  id = "CVE-2021-40438"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-40438"
 path = "httpd/CVE-2021-40438"
 
@@ -764,7 +764,7 @@ path = "httpd/CVE-2021-40438"
   zh = "Apache HTTP Server 2.4.49 路径穿越漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
-  name = "CVE-2021-41773"
+  id = "CVE-2021-41773"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41773"
 path = "httpd/CVE-2021-41773"
 
@@ -774,7 +774,7 @@ path = "httpd/CVE-2021-41773"
   zh = "Apache HTTP Server 2.4.50 路径穿越漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
-  name = "CVE-2021-42013"
+  id = "CVE-2021-42013"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-42013"
 path = "httpd/CVE-2021-42013"
 
@@ -784,7 +784,7 @@ path = "httpd/CVE-2021-42013"
   zh = "Apache HTTPD 未知后缀解析漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "httpd/apache_parsing_vulnerability"
 
@@ -794,7 +794,7 @@ path = "httpd/apache_parsing_vulnerability"
   zh = "Apache SSI 远程命令执行漏洞"
 app = "Apache HTTP Server"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "httpd/ssi-rce"
 
@@ -804,7 +804,7 @@ path = "httpd/ssi-rce"
   zh = "Imagetragick 命令执行漏洞"
 app = "ImageMagick"
   [[container.cve]]
-  name = "CVE-2016-3714"
+  id = "CVE-2016-3714"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3714"
 path = "imagemagick/imagetragick"
 
@@ -814,7 +814,7 @@ path = "imagemagick/imagetragick"
   zh = "ImageMagick PDF密码位置命令注入漏洞"
 app = "imagemagick"
   [[container.cve]]
-  name = "CVE-2020-29599"
+  id = "CVE-2020-29599"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-29599"
 path = "imagemagick/CVE-2020-29599"
 
@@ -824,7 +824,7 @@ path = "imagemagick/CVE-2020-29599"
   zh = "ImageMagick任意文件读取漏洞"
 app = "imagemagick"
   [[container.cve]]
-  name = "CVE-2022-44268"
+  id = "CVE-2022-44268"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-44268"
 path = "imagemagick/CVE-2022-44268"
 
@@ -834,7 +834,7 @@ path = "imagemagick/CVE-2022-44268"
   zh = "InfluxDB Empty JWT Secret Key Authentication Bypass"
 app = "InfluxDB"
   [[container.cve]]
-  name = "CVE-2019-20933"
+  id = "CVE-2019-20933"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-20933"
 path = "influxdb/CVE-2019-20933"
 
@@ -844,7 +844,7 @@ path = "influxdb/CVE-2019-20933"
   zh = "Jackson-databind 反序列化漏洞"
 app = "Jackson-databind"
   [[container.cve]]
-  name = "CVE-2017-7525"
+  id = "CVE-2017-7525"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7525"
 path = "jackson/CVE-2017-7525"
 
@@ -854,7 +854,7 @@ path = "jackson/CVE-2017-7525"
   zh = "Java RMI codebase 远程代码执行漏洞"
 app = "java rmi"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "java/rmi-codebase"
 
@@ -864,7 +864,7 @@ path = "java/rmi-codebase"
   zh = "Java RMI Registry 反序列化漏洞(<=jdk8u111)"
 app = "java rmi"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "java/rmi-registry-bind-deserialization"
 
@@ -874,7 +874,7 @@ path = "java/rmi-registry-bind-deserialization"
   zh = "Java RMI Registry 反序列化漏洞(<jdk8u232_b09)"
 app = "java rmi"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "java/rmi-registry-bind-deserialization-bypass"
 
@@ -884,7 +884,7 @@ path = "java/rmi-registry-bind-deserialization-bypass"
   zh = "JBoss 5.x/6.x 反序列化漏洞"
 app = "jboss"
   [[container.cve]]
-  name = "CVE-2017-12149"
+  id = "CVE-2017-12149"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12149"
 path = "jboss/CVE-2017-12149"
 
@@ -894,7 +894,7 @@ path = "jboss/CVE-2017-12149"
   zh = "JBoss 4.x JBossMQ JMS 反序列化漏洞"
 app = "jboss"
   [[container.cve]]
-  name = "CVE-2017-7504"
+  id = "CVE-2017-7504"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7504"
 path = "jboss/CVE-2017-7504"
 
@@ -904,7 +904,7 @@ path = "jboss/CVE-2017-7504"
   zh = "JBoss JMXInvokerServlet 反序列化漏洞"
 app = "jboss"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "jboss/JMXInvokerServlet-deserialization"
 
@@ -914,7 +914,7 @@ path = "jboss/JMXInvokerServlet-deserialization"
   zh = "Jenkins-CI 远程代码执行漏洞"
 app = "Jenkins"
   [[container.cve]]
-  name = "CVE-2017-1000353"
+  id = "CVE-2017-1000353"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-1000353"
 path = "jenkins/CVE-2017-1000353"
 
@@ -924,7 +924,7 @@ path = "jenkins/CVE-2017-1000353"
   zh = "Jenkins远程命令执行漏洞"
 app = "Jenkins"
   [[container.cve]]
-  name = "CVE-2018-1000861"
+  id = "CVE-2018-1000861"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1000861"
 path = "jenkins/CVE-2018-1000861"
 
@@ -934,7 +934,7 @@ path = "jenkins/CVE-2018-1000861"
   zh = "Jetty WEB-INF 敏感信息泄露漏洞"
 app = "jetty"
   [[container.cve]]
-  name = "CVE-2021-28164"
+  id = "CVE-2021-28164"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28164"
 path = "jetty/CVE-2021-28164"
 
@@ -944,7 +944,7 @@ path = "jetty/CVE-2021-28164"
   zh = "Jetty 通用 Servlets 组件 ConcatServlet 信息泄露漏洞"
 app = "jetty"
   [[container.cve]]
-  name = "CVE-2021-28169"
+  id = "CVE-2021-28169"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28169"
 path = "jetty/CVE-2021-28169"
 
@@ -954,7 +954,7 @@ path = "jetty/CVE-2021-28169"
   zh = "Jetty WEB-INF 敏感信息泄露漏洞"
 app = "jetty"
   [[container.cve]]
-  name = "CVE-2021-34429"
+  id = "CVE-2021-34429"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34429"
 path = "jetty/CVE-2021-34429"
 
@@ -964,7 +964,7 @@ path = "jetty/CVE-2021-34429"
   zh = "Atlassian Jira 模板注入漏洞"
 app = "jira"
   [[container.cve]]
-  name = "CVE-2019-11581"
+  id = "CVE-2019-11581"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11581"
 path = "jira/CVE-2019-11581"
 
@@ -974,7 +974,7 @@ path = "jira/CVE-2019-11581"
   zh = "Jmeter RMI 反序列化命令执行漏洞"
 app = "Apache Jmeter"
   [[container.cve]]
-  name = "CVE-2018-1297"
+  id = "CVE-2018-1297"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1297"
 path = "jmeter/CVE-2018-1297"
 
@@ -984,7 +984,7 @@ path = "jmeter/CVE-2018-1297"
   zh = "Joomla 3.4.5 反序列化漏洞"
 app = "Joomla"
   [[container.cve]]
-  name = "CVE-2015-8562"
+  id = "CVE-2015-8562"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-8562"
 path = "joomla/CVE-2015-8562"
 
@@ -994,7 +994,7 @@ path = "joomla/CVE-2015-8562"
   zh = "Joomla 3.7.0 SQL注入漏洞"
 app = "Joomla"
   [[container.cve]]
-  name = "CVE-2017-8917"
+  id = "CVE-2017-8917"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8917"
 path = "joomla/CVE-2017-8917"
 
@@ -1004,7 +1004,7 @@ path = "joomla/CVE-2017-8917"
   zh = "Joomla 4.2.7 权限绕过漏洞"
 app = "Joomla"
   [[container.cve]]
-  name = "CVE-2023-23752"
+  id = "CVE-2023-23752"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-23752"
 path = "joomla/CVE-2023-23752"
 
@@ -1014,7 +1014,7 @@ path = "joomla/CVE-2023-23752"
   zh = "Jupyter Notebook 未授权访问漏洞"
 app = "Jupyter"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "jupyter/notebook-rce"
 
@@ -1024,7 +1024,7 @@ path = "jupyter/notebook-rce"
   zh = "Apache Kafka Clients JNDI注入漏洞"
 app = "Apache Kafka"
   [[container.cve]]
-  name = "CVE-2023-25194"
+  id = "CVE-2023-25194"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-25194"
 path = "kafka/CVE-2023-25194"
 
@@ -1034,7 +1034,7 @@ path = "kafka/CVE-2023-25194"
   zh = "Kibana 本地文件包含漏洞"
 app = "kibana"
   [[container.cve]]
-  name = "CVE-2018-17246"
+  id = "CVE-2018-17246"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-17246"
 path = "kibana/CVE-2018-17246"
 
@@ -1044,7 +1044,7 @@ path = "kibana/CVE-2018-17246"
   zh = "Kibana 原型链污染导致任意代码执行漏洞"
 app = "kibana"
   [[container.cve]]
-  name = "CVE-2019-7609"
+  id = "CVE-2019-7609"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7609"
 path = "kibana/CVE-2019-7609"
 
@@ -1054,7 +1054,7 @@ path = "kibana/CVE-2019-7609"
   zh = "Laravel Ignition 2.5.1 代码执行漏洞"
 app = "laravel"
   [[container.cve]]
-  name = "CVE-2021-3129"
+  id = "CVE-2021-3129"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-3129"
 path = "kibana/CVE-2021-3129"
 
@@ -1064,7 +1064,7 @@ path = "kibana/CVE-2021-3129"
   zh = "libssh 服务端权限认证绕过漏洞"
 app = "libssh"
   [[container.cve]]
-  name = "CVE-2018-10933"
+  id = "CVE-2018-10933"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-10933"
 path = "libssh/CVE-2018-10933"
 
@@ -1074,7 +1074,7 @@ path = "libssh/CVE-2018-10933"
   zh = "Liferay Portal CE 反序列化命令执行漏洞"
 app = "Liferay Portal"
   [[container.cve]]
-  name = "CVE-2020-7961"
+  id = "CVE-2020-7961"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7961"
 path = "liferay-portal/CVE-2020-7961"
 
@@ -1084,7 +1084,7 @@ path = "liferay-portal/CVE-2020-7961"
   zh = "Apache Log4j Server 反序列化命令执行漏洞"
 app = "Apache Log4j"
   [[container.cve]]
-  name = "CVE-2017-5645"
+  id = "CVE-2017-5645"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5645"
 path = "log4j/CVE-2017-5645"
 
@@ -1094,7 +1094,7 @@ path = "log4j/CVE-2017-5645"
   zh = "Apache Log4j2 lookup JNDI 注入漏洞"
 app = "Apache Log4j"
   [[container.cve]]
-  name = "CVE-2021-44228"
+  id = "CVE-2021-44228"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
 path = "log4j/CVE-2021-44228"
 
@@ -1104,7 +1104,7 @@ path = "log4j/CVE-2021-44228"
   zh = "Magento 2.2 SQL注入漏洞"
 app = "Magento"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "magento/2.2-sqli"
 
@@ -1114,7 +1114,7 @@ path = "magento/2.2-sqli"
   zh = "Metabase任意文件读取漏洞"
 app = "metabase"
   [[container.cve]]
-  name = "CVE-2021-41277"
+  id = "CVE-2021-41277"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-41277"
 path = "metabase/CVE-2021-41277"
 
@@ -1124,7 +1124,7 @@ path = "metabase/CVE-2021-41277"
   zh = "mini_httpd任意文件读取漏洞"
 app = "mini_httpd"
   [[container.cve]]
-  name = "CVE-2018-18778"
+  id = "CVE-2018-18778"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-18778"
 path = "mini_httpd/CVE-2018-18778"
 
@@ -1134,7 +1134,7 @@ path = "mini_httpd/CVE-2018-18778"
   zh = "MinIO集群模式信息泄露漏洞"
 app = "MinIO"
   [[container.cve]]
-  name = "CVE-2023-28432"
+  id = "CVE-2023-28432"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-28432"
 path = "minio/CVE-2023-28432"
 
@@ -1144,7 +1144,7 @@ path = "minio/CVE-2023-28432"
   zh = "Mojarra JSF ViewState 反序列化漏洞"
 app = "Mojarra JSF"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "mojarra/jsf-viewstate-deserialization"
 
@@ -1154,7 +1154,7 @@ path = "mojarra/jsf-viewstate-deserialization"
   zh = "Mongo Express 远程代码执行漏洞"
 app = "mongo-express"
   [[container.cve]]
-  name = "CVE-2019-10758"
+  id = "CVE-2019-10758"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-10758"
 path = "mongo-express/CVE-2019-10758"
 
@@ -1164,7 +1164,7 @@ path = "mongo-express/CVE-2019-10758"
   zh = "MySQL 身份认证绕过漏洞"
 app = "MySQL"
   [[container.cve]]
-  name = "CVE-2012-2122"
+  id = "CVE-2012-2122"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-2122"
 path = "mysql/CVE-2012-2122"
 
@@ -1174,7 +1174,7 @@ path = "mysql/CVE-2012-2122"
   zh = "Nacos 认证绕过漏洞"
 app = "Nacos"
   [[container.cve]]
-  name = "CVE-2021-29441"
+  id = "CVE-2021-29441"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29441"
 path = "nacos/CVE-2021-29441"
 
@@ -1184,7 +1184,7 @@ path = "nacos/CVE-2021-29441"
   zh = "Neo4j Shell Server 反序列化漏洞"
 app = "Neo4j"
   [[container.cve]]
-  name = "CVE-2021-34371"
+  id = "CVE-2021-34371"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-34371"
 path = "neo4j/CVE-2021-34371"
 
@@ -1194,7 +1194,7 @@ path = "neo4j/CVE-2021-34371"
   zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
   [[container.cve]]
-  name = "CVE-2019-7238"
+  id = "CVE-2019-7238"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-7238"
 path = "nexus/CVE-2019-7238"
 
@@ -1204,7 +1204,7 @@ path = "nexus/CVE-2019-7238"
   zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
   [[container.cve]]
-  name = "CVE-2020-10199"
+  id = "CVE-2020-10199"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10199"
 path = "nexus/CVE-2020-10199"
 
@@ -1214,7 +1214,7 @@ path = "nexus/CVE-2020-10199"
   zh = "Nexus Repository Manager 3 远程命令执行漏洞"
 app = "Nexus Repository Manager"
   [[container.cve]]
-  name = "CVE-2020-10204"
+  id = "CVE-2020-10204"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-10204"
 path = "nexus/CVE-2020-10204"
 
@@ -1224,7 +1224,7 @@ path = "nexus/CVE-2020-10204"
   zh = "Nginx 文件名逻辑漏洞"
 app = "Nginx"
   [[container.cve]]
-  name = "CVE-2013-4547"
+  id = "CVE-2013-4547"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-4547"
 path = "nginx/CVE-2013-4547"
 
@@ -1234,7 +1234,7 @@ path = "nginx/CVE-2013-4547"
   zh = "Nginx越界读取缓存漏洞"
 app = "Nginx"
   [[container.cve]]
-  name = "CVE-2017-7529"
+  id = "CVE-2017-7529"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7529"
 path = "nginx/CVE-2017-7529"
 
@@ -1244,7 +1244,7 @@ path = "nginx/CVE-2017-7529"
   zh = "Nginx 配置错误三例"
 app = "Nginx"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "nginx/insecure-configuration"
 
@@ -1254,7 +1254,7 @@ path = "nginx/insecure-configuration"
   zh = "Nginx 解析漏洞"
 app = "Nginx"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "nginx/nginx_parsing_vulnerability"
 
@@ -1264,7 +1264,7 @@ path = "nginx/nginx_parsing_vulnerability"
   zh = "NodeJS 目录穿越漏洞"
 app = "node"
   [[container.cve]]
-  name = "CVE-2017-14849"
+  id = "CVE-2017-14849"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-14849"
 path = "node/CVE-2017-14849"
 
@@ -1274,7 +1274,7 @@ path = "node/CVE-2017-14849"
   zh = "node-postgres 代码执行漏洞分析"
 app = "node-postgres"
   [[container.cve]]
-  name = "CVE-2017-16082"
+  id = "CVE-2017-16082"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-16082"
 path = "node/CVE-2017-16082"
 
@@ -1284,7 +1284,7 @@ path = "node/CVE-2017-16082"
   zh = "ntopng权限绕过漏洞"
 app = "ntopng"
   [[container.cve]]
-  name = "CVE-2021-28073"
+  id = "CVE-2021-28073"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-28073"
 path = "ntopng/CVE-2021-28073"
 
@@ -1294,7 +1294,7 @@ path = "ntopng/CVE-2021-28073"
   zh = "Apache OfBiz 反序列化命令执行漏洞"
 app = "Apache OfBiz"
   [[container.cve]]
-  name = "CVE-2020-9496"
+  id = "CVE-2020-9496"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-9496"
 path = "ofbiz/CVE-2020-9496"
 
@@ -1304,7 +1304,7 @@ path = "ofbiz/CVE-2020-9496"
   zh = "Openfire管理后台认证绕过漏洞"
 app = "Openfire"
   [[container.cve]]
-  name = "CVE-2023-32315"
+  id = "CVE-2023-32315"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-32315"
 path = "openfire/CVE-2023-32315"
 
@@ -1314,7 +1314,7 @@ path = "openfire/CVE-2023-32315"
   zh = "OpenSMTPD 远程命令执行漏洞"
 app = "OpenSMTPD"
   [[container.cve]]
-  name = "CVE-2020-7247"
+  id = "CVE-2020-7247"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-7247"
 path = "opensmtpd/CVE-2020-7247"
 
@@ -1324,7 +1324,7 @@ path = "opensmtpd/CVE-2020-7247"
   zh = "OpenSSH 用户名枚举漏洞"
 app = "OpenSSH"
   [[container.cve]]
-  name = "CVE-2018-15473"
+  id = "CVE-2018-15473"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-15473"
 path = "openssh/CVE-2018-15473"
 
@@ -1334,7 +1334,7 @@ path = "openssh/CVE-2018-15473"
   zh = "OpenSSL 心脏出血漏洞"
 app = "OpenSSL"
   [[container.cve]]
-  name = "CVE-2014-0160"
+  id = "CVE-2014-0160"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2014-0160"
 path = "openssl/CVE-2014-0160"
 
@@ -1344,7 +1344,7 @@ path = "openssl/CVE-2014-0160"
   zh = "OpenSSL无限循环DoS漏洞"
 app = "OpenSSL"
   [[container.cve]]
-  name = "CVE-2022-0778"
+  id = "CVE-2022-0778"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0778"
 path = "openssl/CVE-2022-0778"
 
@@ -1354,7 +1354,7 @@ path = "openssl/CVE-2022-0778"
   zh = "OpenTSDB 命令注入漏洞"
 app = "OpenTSDB"
   [[container.cve]]
-  name = "CVE-2020-35476"
+  id = "CVE-2020-35476"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-35476"
 path = "opentsdb/CVE-2020-35476"
 
@@ -1364,7 +1364,7 @@ path = "opentsdb/CVE-2020-35476"
   zh = "PHP 8.1.0-dev 开发版本后门事件"
 app = "PHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "php/8.1-backdoor"
 
@@ -1374,7 +1374,7 @@ path = "php/8.1-backdoor"
   zh = "PHP-CGI远程代码执行漏洞"
 app = "PHP-CGI"
   [[container.cve]]
-  name = "CVE-2012-1823"
+  id = "CVE-2012-1823"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-1823"
 path = "php/CVE-2012-1823"
 
@@ -1384,7 +1384,7 @@ path = "php/CVE-2012-1823"
   zh = "PHP-IMAP 远程命令执行漏洞"
 app = "PHP-IMAP"
   [[container.cve]]
-  name = "CVE-2018-19518"
+  id = "CVE-2018-19518"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-19518"
 path = "php/CVE-2018-19518"
 
@@ -1394,7 +1394,7 @@ path = "php/CVE-2018-19518"
   zh = "PHP-FPM 远程代码执行漏洞"
 app = "PHP-FPM"
   [[container.cve]]
-  name = "CVE-2019-11043"
+  id = "CVE-2019-11043"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-11043"
 path = "php/CVE-2019-11043"
 
@@ -1404,7 +1404,7 @@ path = "php/CVE-2019-11043"
   zh = "PHP-FPM FastCGI 未授权访问漏洞"
 app = "PHP-FPM"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "php/fpm"
 
@@ -1414,7 +1414,7 @@ path = "php/fpm"
   zh = "PHP文件包含漏洞 (利用phpinfo())"
 app = "PHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "php/inclusion"
 
@@ -1424,7 +1424,7 @@ path = "php/inclusion"
   zh = "PHP XML实体注入"
 app = "PHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "php/php_xxe"
 
@@ -1434,7 +1434,7 @@ path = "php/php_xxe"
   zh = "XDebug 远程调试漏洞 (代码执行)"
 app = "PHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "php/xdebug-rce"
 
@@ -1444,7 +1444,7 @@ path = "php/xdebug-rce"
   zh = "PHPMailer 任意文件读取漏洞"
 app = "PHPMailer"
   [[container.cve]]
-  name = "CVE-2017-5223"
+  id = "CVE-2017-5223"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5223"
 path = "phpmailer/CVE-2017-5223"
 
@@ -1454,7 +1454,7 @@ path = "phpmailer/CVE-2017-5223"
   zh = "phpMyAdmin 4.0.x—4.6.2 远程代码执行漏洞"
 app = "phpmyadmin"
   [[container.cve]]
-  name = "CVE-2016-5734"
+  id = "CVE-2016-5734"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-5734"
 path = "phpmyadmin/CVE-2016-5734"
 
@@ -1464,7 +1464,7 @@ path = "phpmyadmin/CVE-2016-5734"
   zh = "phpmyadmin 4.8.1 远程文件包含漏洞"
 app = "phpmyadmin"
   [[container.cve]]
-  name = "CVE-2018-12613"
+  id = "CVE-2018-12613"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-12613"
 path = "phpmyadmin/CVE-2018-12613"
 
@@ -1474,7 +1474,7 @@ path = "phpmyadmin/CVE-2018-12613"
   zh = "phpmyadmin scripts/setup.php 反序列化漏洞"
 app = "phpmyadmin"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "phpmyadmin/WooYun-2016-199433"
 
@@ -1484,7 +1484,7 @@ path = "phpmyadmin/WooYun-2016-199433"
   zh = "phpunit 远程代码执行漏洞"
 app = "phpunit"
   [[container.cve]]
-  name = "CVE-2017-9841"
+  id = "CVE-2017-9841"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9841"
 path = "phpunit/CVE-2017-9841"
 
@@ -1494,7 +1494,7 @@ path = "phpunit/CVE-2017-9841"
   zh = "Polkit pkexec 权限提升漏洞"
 app = "Polkit Pkexec"
   [[container.cve]]
-  name = "CVE-2021-4034"
+  id = "CVE-2021-4034"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-4034"
 path = "polkit/CVE-2021-4034"
 
@@ -1504,7 +1504,7 @@ path = "polkit/CVE-2021-4034"
   zh = "PostgreSQL 提权漏洞"
 app = "PostgreSQL"
   [[container.cve]]
-  name = "CVE-2018-1058"
+  id = "CVE-2018-1058"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1058"
 path = "postgres/CVE-2018-1058"
 
@@ -1514,7 +1514,7 @@ path = "postgres/CVE-2018-1058"
   zh = "PostgreSQL 高权限命令执行漏洞"
 app = "PostgreSQL"
   [[container.cve]]
-  name = "CVE-2019-9193"
+  id = "CVE-2019-9193"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-9193"
 path = "postgres/CVE-2019-9193"
 
@@ -1524,7 +1524,7 @@ path = "postgres/CVE-2019-9193"
   zh = "Python PIL 远程命令执行漏洞 (GhostButt)"
 app = "Python"
   [[container.cve]]
-  name = "CVE-2017-8291"
+  id = "CVE-2017-8291"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8291"
 path = "python/PIL-CVE-2017-8291"
 
@@ -1534,7 +1534,7 @@ path = "python/PIL-CVE-2017-8291"
   zh = "Python PIL 远程命令执行漏洞 (via Ghostscript)"
 app = "Python"
   [[container.cve]]
-  name = "CVE-2018-16509"
+  id = "CVE-2018-16509"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-16509"
 path = "python/PIL-CVE-2018-16509"
 
@@ -1544,7 +1544,7 @@ path = "python/PIL-CVE-2018-16509"
   zh = "Python Unpickle 反序列化漏洞"
 app = "Python"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "python/unpickle"
 
@@ -1554,7 +1554,7 @@ path = "python/unpickle"
   zh = "Ruby on Rails 路径穿越漏洞"
 app = "Ruby on Rails"
   [[container.cve]]
-  name = "CVE-2018-3760"
+  id = "CVE-2018-3760"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-3760"
 path = "rails/CVE-2018-3760"
 
@@ -1564,7 +1564,7 @@ path = "rails/CVE-2018-3760"
   zh = "Ruby on Rails 路径穿越与任意文件读取漏洞"
 app = "Ruby on Rails"
   [[container.cve]]
-  name = "CVE-2019-5418"
+  id = "CVE-2019-5418"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-5418"
 path = "rails/CVE-2019-5418"
 
@@ -1574,7 +1574,7 @@ path = "rails/CVE-2019-5418"
   zh = "Redis 4.x/5.x 主从复制导致的命令执行"
 app = "redis"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "redis/4-unacc"
 
@@ -1584,7 +1584,7 @@ path = "redis/4-unacc"
   zh = "Redis Lua沙盒绕过命令执行"
 app = "redis"
   [[container.cve]]
-  name = "CVE-2022-0543"
+  id = "CVE-2022-0543"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-0543"
 path = "redis/CVE-2022-0543"
 
@@ -1594,7 +1594,7 @@ path = "redis/CVE-2022-0543"
   zh = "Rocket Chat MongoDB 注入漏洞"
 app = "rocket chat"
   [[container.cve]]
-  name = "CVE-2021-22911"
+  id = "CVE-2021-22911"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-22911"
 path = "rocketchat/CVE-2021-22911"
 
@@ -1604,7 +1604,7 @@ path = "rocketchat/CVE-2021-22911"
   zh = "Apache RocketMQ 远程命令执行漏洞"
 app = "Apache RocketMQ"
   [[container.cve]]
-  name = "CVE-2023-33246"
+  id = "CVE-2023-33246"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-33246"
 path = "rocketmq/CVE-2023-33246"
 
@@ -1614,7 +1614,7 @@ path = "rocketmq/CVE-2023-33246"
   zh = "rsync 未授权访问漏洞"
 app = "rsync"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "rsync/common"
 
@@ -1624,7 +1624,7 @@ path = "rsync/common"
   zh = "Ruby Net::FTP 模块命令注入漏洞"
 app = "ruby"
   [[container.cve]]
-  name = "CVE-2017-17405"
+  id = "CVE-2017-17405"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-17405"
 path = "ruby/CVE-2017-17405"
 
@@ -1634,7 +1634,7 @@ path = "ruby/CVE-2017-17405"
   zh = "SaltStack 水平权限绕过漏洞"
 app = "SaltStack"
   [[container.cve]]
-  name = "CVE-2020-11651"
+  id = "CVE-2020-11651"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11651"
 path = "saltstack/CVE-2020-11651"
 
@@ -1644,7 +1644,7 @@ path = "saltstack/CVE-2020-11651"
   zh = "SaltStack 任意文件读写漏洞"
 app = "SaltStack"
   [[container.cve]]
-  name = "CVE-2020-11652"
+  id = "CVE-2020-11652"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11652"
 path = "saltstack/CVE-2020-11652"
 
@@ -1654,7 +1654,7 @@ path = "saltstack/CVE-2020-11652"
   zh = "SaltStack 命令注入漏洞"
 app = "SaltStack"
   [[container.cve]]
-  name = "CVE-2020-16846"
+  id = "CVE-2020-16846"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-16846"
 path = "saltstack/CVE-2020-16846"
 
@@ -1664,7 +1664,7 @@ path = "saltstack/CVE-2020-16846"
   zh = "Samba 远程命令执行漏洞"
 app = "Samba"
   [[container.cve]]
-  name = "CVE-2017-7494"
+  id = "CVE-2017-7494"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-7494"
 path = "samba/CVE-2017-7494"
 
@@ -1674,7 +1674,7 @@ path = "samba/CVE-2017-7494"
   zh = "Scrapyd 未授权访问漏洞"
 app = "Scrapyd"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "scrapy/scrapyd-unacc"
 
@@ -1684,7 +1684,7 @@ path = "scrapy/scrapyd-unacc"
   zh = "Apache Shiro 认证绕过漏洞"
 app = "shiro"
   [[container.cve]]
-  name = "CVE-2010-3863"
+  id = "CVE-2010-3863"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-3863"
 path = "shiro/CVE-2010-3863"
 
@@ -1694,7 +1694,7 @@ path = "shiro/CVE-2010-3863"
   zh = "Apache Shiro 1.2.4反序列化漏洞"
 app = "shiro"
   [[container.cve]]
-  name = "CVE-2016-4437"
+  id = "CVE-2016-4437"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4437"
 path = "shiro/CVE-2016-4437"
 
@@ -1704,7 +1704,7 @@ path = "shiro/CVE-2016-4437"
   zh = "Apache Shiro 认证绕过漏洞"
 app = "shiro"
   [[container.cve]]
-  name = "CVE-2020-1957"
+  id = "CVE-2020-1957"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1957"
 path = "shiro/CVE-2020-1957"
 
@@ -1714,7 +1714,7 @@ path = "shiro/CVE-2020-1957"
   zh = "Apache Skywalking 8.3.0 SQL注入漏洞"
 app = "skywalking"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "skywalking/8.3.0-sqli"
 
@@ -1724,7 +1724,7 @@ path = "skywalking/8.3.0-sqli"
   zh = "Apache Solr 远程命令执行漏洞"
 app = "solr"
   [[container.cve]]
-  name = "CVE-2017-12629"
+  id = "CVE-2017-12629"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
 path = "solr/CVE-2017-12629-RCE"
 
@@ -1734,7 +1734,7 @@ path = "solr/CVE-2017-12629-RCE"
   zh = "Apache Solr XML 实体注入漏洞"
 app = "solr"
   [[container.cve]]
-  name = "CVE-2017-12629"
+  id = "CVE-2017-12629"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12629"
 path = "solr/CVE-2017-12629-XXE"
 
@@ -1744,7 +1744,7 @@ path = "solr/CVE-2017-12629-XXE"
   zh = "Apache Solr 远程命令执行漏洞"
 app = "solr"
   [[container.cve]]
-  name = "CVE-2019-0193"
+  id = "CVE-2019-0193"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0193"
 path = "solr/CVE-2019-0193"
 
@@ -1754,7 +1754,7 @@ path = "solr/CVE-2019-0193"
   zh = "Apache Solr Velocity 注入远程命令执行漏洞"
 app = "solr"
   [[container.cve]]
-  name = "CVE-2019-17558"
+  id = "CVE-2019-17558"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-17558"
 path = "solr/CVE-2019-17558"
 
@@ -1764,7 +1764,7 @@ path = "solr/CVE-2019-17558"
   zh = "Apache Solr RemoteStreaming 文件读取与SSRF漏洞"
 app = "solr"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "solr/Remote-Streaming-Fileread"
 
@@ -1774,7 +1774,7 @@ path = "solr/Remote-Streaming-Fileread"
   zh = "Apache Spark 未授权访问漏"
 app = "spark"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "spark/unacc"
 
@@ -1784,7 +1784,7 @@ path = "spark/unacc"
   zh = "Spring Security Oauth2 远程命令执行漏洞"
 app = "spring security oauth2"
   [[container.cve]]
-  name = "CVE-2016-4977"
+  id = "CVE-2016-4977"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-4977"
 path = "spring/CVE-2016-4977"
 
@@ -1794,7 +1794,7 @@ path = "spring/CVE-2016-4977"
   zh = "Spring WebFlow 远程代码执行漏洞"
 app = "spring webflow"
   [[container.cve]]
-  name = "CVE-2017-4971"
+  id = "CVE-2017-4971"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-4971"
 path = "spring/CVE-2017-4971"
 
@@ -1804,7 +1804,7 @@ path = "spring/CVE-2017-4971"
   zh = "Spring Data Rest 远程命令执行漏洞"
 app = "spring data rest"
   [[container.cve]]
-  name = "CVE-2017-8046"
+  id = "CVE-2017-8046"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-8046"
 path = "spring/CVE-2017-8046"
 
@@ -1814,7 +1814,7 @@ path = "spring/CVE-2017-8046"
   zh = "Spring Messaging 远程命令执行漏洞"
 app = "spring messaging"
   [[container.cve]]
-  name = "CVE-2018-1270"
+  id = "CVE-2018-1270"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1270"
 path = "spring/CVE-2018-1270"
 
@@ -1824,7 +1824,7 @@ path = "spring/CVE-2018-1270"
   zh = "Spring Data Commons 远程命令执行漏洞"
 app = "spring data commons"
   [[container.cve]]
-  name = "CVE-2018-1273"
+  id = "CVE-2018-1273"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-1273"
 path = "spring/CVE-2018-1273"
 
@@ -1834,7 +1834,7 @@ path = "spring/CVE-2018-1273"
   zh = "Spring Cloud Gateway Actuator API SpEL表达式注入命令执行"
 app = "spring cloud gateway"
   [[container.cve]]
-  name = "CVE-2022-22947"
+  id = "CVE-2022-22947"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22947"
 path = "spring/CVE-2022-22947"
 
@@ -1844,7 +1844,7 @@ path = "spring/CVE-2022-22947"
   zh = "Spring Cloud Function SpEL表达式命令注入"
 app = "spring cloud function"
   [[container.cve]]
-  name = "CVE-2022-22963"
+  id = "CVE-2022-22963"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22963"
 path = "spring/CVE-2022-22963"
 
@@ -1854,7 +1854,7 @@ path = "spring/CVE-2022-22963"
   zh = "Spring框架Data Binding与JDK 9+导致的远程代码执行漏洞"
 app = "Spring"
   [[container.cve]]
-  name = "CVE-2022-22965"
+  id = "CVE-2022-22965"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22965"
 path = "spring/CVE-2022-22965"
 
@@ -1864,7 +1864,7 @@ path = "spring/CVE-2022-22965"
   zh = "Spring Security Authorization Bypass in RegexRequestMatcher"
 app = "Spring"
   [[container.cve]]
-  name = "CVE-2022-22978"
+  id = "CVE-2022-22978"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2022-22978"
 path = "spring/CVE-2022-22978"
 
@@ -1874,7 +1874,7 @@ path = "spring/CVE-2022-22978"
   zh = "S2-001 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "struts2/s2-001"
 
@@ -1884,7 +1884,7 @@ path = "struts2/s2-001"
   zh = "S2-005 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2010-1870"
+  id = "CVE-2010-1870"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2010-1870"
 path = "struts2/s2-005"
 
@@ -1894,7 +1894,7 @@ path = "struts2/s2-005"
   zh = "S2-007 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "struts2/s2-007"
 
@@ -1904,7 +1904,7 @@ path = "struts2/s2-007"
   zh = "S2-008 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2012-0391"
+  id = "CVE-2012-0391"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2012-0391"
 path = "struts2/s2-008"
 
@@ -1914,7 +1914,7 @@ path = "struts2/s2-008"
   zh = "S2-009 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2011-3923"
+  id = "CVE-2011-3923"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2011-3923"
 path = "struts2/s2-009"
 
@@ -1924,7 +1924,7 @@ path = "struts2/s2-009"
   zh = "S2-012 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2013-1965"
+  id = "CVE-2013-1965"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1965"
 path = "struts2/s2-012"
 
@@ -1934,7 +1934,7 @@ path = "struts2/s2-012"
   zh = "S2-013 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2013-1966"
+  id = "CVE-2013-1966"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-1966"
 path = "struts2/s2-013"
 
@@ -1944,11 +1944,11 @@ path = "struts2/s2-013"
   zh = "S2-015 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2013-2134"
+  id = "CVE-2013-2134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2134"
 
   [[container.cve]]
-  name = "CVE-2013-2135"
+  id = "CVE-2013-2135"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2135"
 path = "struts2/s2-015"
 
@@ -1958,7 +1958,7 @@ path = "struts2/s2-015"
   zh = "S2-016 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2013-2251"
+  id = "CVE-2013-2251"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2251"
 path = "struts2/s2-016"
 
@@ -1968,7 +1968,7 @@ path = "struts2/s2-016"
   zh = "S2-032 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2016-3081"
+  id = "CVE-2016-3081"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-3081"
 path = "struts2/s2-032"
 
@@ -1978,7 +1978,7 @@ path = "struts2/s2-032"
   zh = "S2-045 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2017-5638"
+  id = "CVE-2017-5638"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
 path = "struts2/s2-045"
 
@@ -1988,7 +1988,7 @@ path = "struts2/s2-045"
   zh = "S2-046 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2017-5638"
+  id = "CVE-2017-5638"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-5638"
 path = "struts2/s2-046"
 
@@ -1998,7 +1998,7 @@ path = "struts2/s2-046"
   zh = "S2-048 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2017-9791"
+  id = "CVE-2017-9791"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9791"
 path = "struts2/s2-048"
 
@@ -2008,7 +2008,7 @@ path = "struts2/s2-048"
   zh = "S2-052 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2017-9805"
+  id = "CVE-2017-9805"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-9805"
 path = "struts2/s2-052"
 
@@ -2018,7 +2018,7 @@ path = "struts2/s2-052"
   zh = "S2-053 远程代码执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2017-12611"
+  id = "CVE-2017-12611"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12611"
 path = "struts2/s2-053"
 
@@ -2028,7 +2028,7 @@ path = "struts2/s2-053"
   zh = "Struts2 S2-057 远程命令执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2018-11776"
+  id = "CVE-2018-11776"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-11776"
 path = "struts2/s2-057"
 
@@ -2038,7 +2038,7 @@ path = "struts2/s2-057"
   zh = "Struts2 S2-059 远程命令执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2019-0230"
+  id = "CVE-2019-0230"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-0230"
 path = "struts2/s2-059"
 
@@ -2048,7 +2048,7 @@ path = "struts2/s2-059"
   zh = "Struts2 S2-061 远程命令执行漏洞"
 app = "Struts2"
   [[container.cve]]
-  name = "CVE-2020-17530"
+  id = "CVE-2020-17530"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-17530"
 path = "struts2/s2-061"
 
@@ -2058,7 +2058,7 @@ path = "struts2/s2-061"
   zh = "Supervisord 远程命令执行漏洞"
 app = "Supervisor"
   [[container.cve]]
-  name = "CVE-2017-11610"
+  id = "CVE-2017-11610"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-11610"
 path = "supervisor/CVE-2017-11610"
 
@@ -2068,7 +2068,7 @@ path = "supervisor/CVE-2017-11610"
   zh = "ThinkPHP 2.x 任意代码执行漏洞"
 app = "ThinkPHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "thinkphp/2-rce"
 
@@ -2078,7 +2078,7 @@ path = "thinkphp/2-rce"
   zh = "ThinkPHP5 5.0.22/5.1.29 远程代码执行漏洞"
 app = "ThinkPHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "thinkphp/5-rce"
 
@@ -2088,7 +2088,7 @@ path = "thinkphp/5-rce"
   zh = "ThinkPHP5 5.0.23 远程代码执行漏洞"
 app = "ThinkPHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "thinkphp/5.0.23-rce"
 
@@ -2098,7 +2098,7 @@ path = "thinkphp/5.0.23-rce"
   zh = "ThinkPHP5 SQL注入漏洞/信息泄露"
 app = "ThinkPHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "thinkphp/in-sqlinjection"
 
@@ -2108,7 +2108,7 @@ path = "thinkphp/in-sqlinjection"
   zh = "ThinkPHP 多语言本地文件包含漏洞"
 app = "ThinkPHP"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "thinkphp/lang-rce"
 
@@ -2118,7 +2118,7 @@ path = "thinkphp/lang-rce"
   zh = "Tiki Wiki CMS Groupware 认证绕过漏洞"
 app = "Tiki Wiki"
   [[container.cve]]
-  name = "CVE-2020-15906"
+  id = "CVE-2020-15906"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-15906"
 path = "tikiwiki/CVE-2020-15906"
 
@@ -2128,7 +2128,7 @@ path = "tikiwiki/CVE-2020-15906"
   zh = "Tomcat PUT方法任意写文件漏洞"
 app = "Tomcat"
   [[container.cve]]
-  name = "CVE-2017-12615"
+  id = "CVE-2017-12615"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-12615"
 path = "tomcat/CVE-2017-12615"
 
@@ -2138,7 +2138,7 @@ path = "tomcat/CVE-2017-12615"
   zh = "Apache Tomcat AJP 文件包含漏洞"
 app = "Tomcat"
   [[container.cve]]
-  name = "CVE-2020-1938"
+  id = "CVE-2020-1938"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-1938"
 path = "tomcat/CVE-2020-1938"
 
@@ -2148,7 +2148,7 @@ path = "tomcat/CVE-2020-1938"
   zh = "Tomcat弱口令"
 app = "Tomcat"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "tomcat/tomcat8"
 
@@ -2158,7 +2158,7 @@ path = "tomcat/tomcat8"
   zh = "Apache Unomi 远程表达式代码执行漏洞"
 app = "unomi"
   [[container.cve]]
-  name = "CVE-2020-13942"
+  id = "CVE-2020-13942"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-13942"
 path = "unomi/CVE-2020-13942"
 
@@ -2168,7 +2168,7 @@ path = "unomi/CVE-2020-13942"
   zh = "uWSGI PHP目录穿越漏洞"
 app = "uWSGI"
   [[container.cve]]
-  name = "CVE-2018-7490"
+  id = "CVE-2018-7490"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-7490"
 path = "uwsgi/CVE-2018-7490"
 
@@ -2178,7 +2178,7 @@ path = "uwsgi/CVE-2018-7490"
   zh = "uWSGI 未授权访问漏洞"
 app = "uWSGI"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "uwsgi/unacc"
 
@@ -2188,7 +2188,7 @@ path = "uwsgi/unacc"
   zh = "V2board 1.6.1 提权漏洞"
 app = "V2board"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "v2board/1.6-privilege-escalation"
 
@@ -2198,7 +2198,7 @@ path = "v2board/1.6-privilege-escalation"
   zh = "WebLogic < 10.3.6 'wls-wsat' XMLDecoder 反序列化漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = "CVE-2017-10271"
+  id = "CVE-2017-10271"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2017-10271"
 path = "weblogic/CVE-2017-10271"
 
@@ -2208,7 +2208,7 @@ path = "weblogic/CVE-2017-10271"
   zh = "WebLogic WLS Core Components 反序列化命令执行漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = "CVE-2018-2628"
+  id = "CVE-2018-2628"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2628"
 path = "weblogic/CVE-2018-2628"
 
@@ -2218,7 +2218,7 @@ path = "weblogic/CVE-2018-2628"
   zh = "WebLogic 任意文件上传漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = "CVE-2018-2894"
+  id = "CVE-2018-2894"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2018-2894"
 path = "weblogic/CVE-2018-2894"
 
@@ -2228,7 +2228,7 @@ path = "weblogic/CVE-2018-2894"
   zh = "WebLogic 管理控制台未授权远程命令执行漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = "CVE-2020-14882"
+  id = "CVE-2020-14882"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-14882"
 path = "weblogic/CVE-2020-14882"
 
@@ -2238,7 +2238,7 @@ path = "weblogic/CVE-2020-14882"
   zh = "WebLogic未授权远程代码执行漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = "CVE-2023-21839"
+  id = "CVE-2023-21839"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2023-21839"
 path = "weblogic/CVE-2023-21839"
 
@@ -2248,7 +2248,7 @@ path = "weblogic/CVE-2023-21839"
   zh = "WebLogic SSRF漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "weblogic/ssrf"
 
@@ -2258,7 +2258,7 @@ path = "weblogic/ssrf"
   zh = "WebLogic 文件读取漏洞"
 app = "WebLogic"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "weblogic/weak_password"
 
@@ -2268,7 +2268,7 @@ path = "weblogic/weak_password"
   zh = "Webmin 远程命令执行漏洞"
 app = "Webmin"
   [[container.cve]]
-  name = "CVE-2019-15107"
+  id = "CVE-2019-15107"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2019-15107"
 path = "webmin/CVE-2019-15107"
 
@@ -2278,7 +2278,7 @@ path = "webmin/CVE-2019-15107"
   zh = "Wordpress 4.6 任意命令执行漏洞 (PwnScriptum)"
 app = "Wordpress"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "wordpress/pwnscriptum"
 
@@ -2288,7 +2288,7 @@ path = "wordpress/pwnscriptum"
   zh = "XStream 反序列化命令执行漏洞"
 app = "XStream"
   [[container.cve]]
-  name = "CVE-2021-21351"
+  id = "CVE-2021-21351"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-21351"
 path = "xstream/CVE-2021-21351"
 
@@ -2298,7 +2298,7 @@ path = "xstream/CVE-2021-21351"
   zh = "XStream 反序列化命令执行漏洞"
 app = "XStream"
   [[container.cve]]
-  name = "CVE-2021-29505"
+  id = "CVE-2021-29505"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2021-29505"
 path = "xstream/CVE-2021-29505"
 
@@ -2308,7 +2308,7 @@ path = "xstream/CVE-2021-29505"
   zh = "XXL-JOB Executor 未授权访问漏洞"
 app = "xxl-job"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "xxl-job/unacc"
 
@@ -2318,7 +2318,7 @@ path = "xxl-job/unacc"
   zh = "YApi NoSQL注入导致远程命令执行漏洞"
 app = "YApi"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "yapi/mongodb-inj"
 
@@ -2328,7 +2328,7 @@ path = "yapi/mongodb-inj"
   zh = "YApi开放注册导致RCE"
 app = "YApi"
   [[container.cve]]
-  name = ""
+  id = ""
   nvd = ""
 path = "yapi/unacc"
 
@@ -2338,7 +2338,7 @@ path = "yapi/unacc"
   zh = "Zabbix latest.php SQL注入漏洞"
 app = "Zabbix"
   [[container.cve]]
-  name = "CVE-2016-10134"
+  id = "CVE-2016-10134"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2016-10134"
 path = "zabbix/CVE-2016-10134"
 
@@ -2348,6 +2348,6 @@ path = "zabbix/CVE-2016-10134"
   zh = "Zabbix Server Trapper命令注入漏洞"
 app = "Zabbix"
   [[container.cve]]
-  name = "CVE-2020-11800"
+  id = "CVE-2020-11800"
   nvd = "https://nvd.nist.gov/vuln/detail/CVE-2020-11800"
 path = "zabbix/CVE-2020-11800"


### PR DESCRIPTION
Currently I don't think it is needed to add a description since all the needed info are in the README.md.

@phith0n the structure of each item appears like the following:
```toml
[[container]]
app = "ActiveMQ"
path = "activemq/CVE-2015-5254"

  [[container.name]]
  en = "Apache ActiveMQ Deserialization"
  zh = "Apache ActiveMQ 反序列化漏洞"

  [[container.cve]]
  id = "CVE-2015-5254"
  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2015-5254"
```
In case one lab has more than one CVE, it should appear as:
```toml
[[container]]
app = "Struts2"
path = "struts2/s2-015"

  [[container.name]]
  en = "S2-015 Remote Code Execution"
  zh = "S2-015 远程代码执行漏洞"

  [[container.cve]]
  id = "CVE-2013-2134"
  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2134"
  
  [[container.cve]]
  id = "CVE-2013-2135"
  nvd = "https://nvd.nist.gov/vuln/detail/CVE-2013-2135"
```
So we have a table array named `container` and subtables for each property, for example `container.name` subtable will contain `en` and `zh` languages. Then. `container.cve` contains some info about CVE (currently id and NVD link). For those containers with no CVE, I just set as empty string `""` in order to not break any parsing by a custom script.

The properties outside the subtables should be at the beginning of the main table otherwise they will be seen as part of subtables.

Example of Python code:
```python
import toml

data = toml.load("/home/user/environments.toml")

for cve_lab in data['container']:
    print(cve_lab['name'][0]['en'])
    print(cve_lab['cve'])
    print(cve_lab['cve'][0]['id'])
    print(cve_lab['path'])
```