### PR TITLE
Update Dockerfile

### DIFF
--- a/rsync/common/Dockerfile
+++ b/rsync/common/Dockerfile
@@ -6,8 +6,10 @@ COPY rsyncd.conf /etc/rsyncd.conf
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+RUN RUN echo "deb http://snapshot.debian.org/archive/debian/20210326T030000Z jessie main" > /etc/apt/sources.list
+
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y cron \
+    && apt-get install --no-install-recommends -y cron --force-yes \
     && mkdir /data/ \
     && chmod +x /docker-entrypoint.sh \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION

仓库的 Dockerfile 已经无法构建，原因在于 [Dibian 8 官方源](https://www.debian.org/distrib/archive.zh-cn.html)删除相关软件包。
使用 https://snapshot.debian.org/ 指向快照的仓库，使得仓库中 Dockefile 在当前环境下正常工作