### PR TITLE
CVE-2023-4220: Vulnerable Chamilo LMS container

### DIFF
--- a/chamilo/CVE-2023-4220/README.md
+++ b/chamilo/CVE-2023-4220/README.md
@@ -1,0 +1,134 @@
+# CVE-2023-4220
+Chamilo LMS is a free software e-learning and content management system. In versions prior to <= v1.11.24
+a webshell can be uploaded via the bigload.php endpoint. If the GET request parameter `action` is set to
+`post-unsupported` file extension checks are skipped allowing for attacker controlled .php files to be uploaded to:
+`/main/inc/lib/javascript/bigupload/files/` if the `/files/` directory already exists - it does not exist by default.
+The required directory `/files`/ has been added to this container for vulnerability testing purposes.
+
+This docker setup was entirely copied from https://github.com/22phuber/docker-compose-chamilo-lms. The original Dockerfile
+had the Chamilo version set to 1.11.12 which is unaffected by the vulnerability as it doesn't have the /bigupload/ endpoint.
+The base version of PHP was updated, as well as some necessary packages to prevent the build from failling. The version of 
+Chamilo was updated to 1.11.18 which is affected by CVE-2023-4220 also as mentioned the necessary dierctory `/files/` has 
+been added as well. Thanks to 22phuber for all the hard work. 
+
+
+# Chamilo LMS docker-compose
+
+A simple docker-compose setup for [Chamilo](https://chamilo.org/) LMS.
+
+Official Docker Hub images used:
+* [php](https://hub.docker.com/_/php/) (7.x-apache)
+* [mariadb](https://hub.docker.com/_/mariadb/) (latest)
+
+Chamilo LMS on Github: https://github.com/chamilo/chamilo-lms
+
+This setup doesn't directly install/configure Chamilo. You have to use the Chamilo installation wizard once the docker containers are up.
+
+*This setup works with Chamilo version 1.11.x
+
+### Optional: Host system config
+
+On the Host system you need to add a `/etc/hosts` entry for the domain name configured in the apache vhost:
+
+```bash
+sudo echo "127.0.0.1 docker.chamilo.net" >> /etc/hosts
+```
+
+##### `.../etc/hosts` on Windows:
+* Open a text editor as administrator (with administrator privileges)
+* Open hosts file: `C:\Windows\System32\Drivers\etc\hosts`
+* Add entry `127.0.0.1 docker.chamilo.net` at the end of the file and **save**.
+
+# ENV Variables
+
+### `environment` variables for MYSQL
+You can define mysql username, password and database name in the docker-compose config:
+
+```yaml
+    ...
+    environment:
+      - MYSQL_ROOT_PASSWORD=pass
+      - MYSQL_USER=chamilo
+      - MYSQL_PASSWORD=chamilo
+      - MYSQL_DATABASE=chamilo
+    ...
+```
+
+### `args` variables for building Chamilo
+You can define the Version for Chamilo with `CHAMILO_VERSION`.
+And you have to set the `CHAMILO_TAR` filename due to incosistent naming.
+Check for `.tar.gz` filenames here: https://github.com/chamilo/chamilo-lms/releases
+
+Example in `docker-compose.yml`:
+```yaml
+      args:
+        - CHAMILO_VERSION=1.11.10
+        - CHAMILO_TAR=chamilo-1.11.10-php7.3.tar.gz
+```
+
+The `args` settings in `docker-compose.yml` will override the `ARG` settings in the `Dockerfile`.
+If you remove the `args` in `docker-compose.yml`, the "fallback" values from the `Dockerfile` will be used.
+
+### Build & Run
+
+##### Build:
+Build chamilo docker image
+```bash
+docker-compose -f docker-compose.yml build
+```
+
+##### Run:
+```bash
+docker-compose -f docker-compose.yml up
+```
+
+## Database connection step in web installation wizard
+The "Database Host" in step 4 of the mysql connections settings has to be the name of the docker image defined in the appropriate `docker-compose.yml`.
+
+Database Host: `mariadb`
+
+## Access Chamilo Website
+Access Chamilo URL with `/etc/hosts` entry:
+
+```
+http://docker.chamilo.net:8080/
+```
+
+Without `/etc/hosts` entry:
+```
+http://localhost:8080
+```
+
+# Selenium grid tests with jest
+
+[Selenium grid](https://www.selenium.dev/documentation/en/grid/) tests using [jest](https://jestjs.io/) (javascript) and Docker e.g. docker-compose
+
+Selenium provides docker images ([docker-selenium on github](https://github.com/SeleniumHQ/docker-selenium)) to run the Selenium grid with docker-compose
+
+
+### Install packages
+
+Install needed node packages:
+```bash
+cd "selenium-with-jest"
+npm install
+```
+
+
+### Run tests
+
+Start chamilo lms and selenium grid:
+```bash
+docker-compose -f docker-compose.yml -f docker-compose-selenium.yml up -d
+```
+
+Run tests with jest:
+```bash
+cd "selenium-with-jest"
+./wait-for-selenium-grid.sh npm test
+```
+
+## Github action with Selenium grid, jest and docker-compose
+
+A Github Action to run **jest** tests on a Selenium grid with docker-compose when creating a pull request or pushing into the `master` branch:
+[docker-compose-ci.yml](.github/workflows/docker-compose-ci.yml)

--- a/chamilo/CVE-2023-4220/chamilo-php7/Dockerfile
+++ b/chamilo/CVE-2023-4220/chamilo-php7/Dockerfile
@@ -1,0 +1,73 @@
+FROM php:7.4-apache as php7_apache_base
+
+# install packages
+RUN apt update && apt install -yq --no-install-recommends \
+    msmtp \
+    curl \
+    git \
+    wget \
+    parallel \
+    libzip-dev \
+    zlib1g-dev \
+    libpng-dev \
+    libicu-dev \
+    libxslt-dev \
+    libjpeg-dev \
+    libgd3 \
+    libgd-dev \
+    libfreetype6-dev \
+    libmemcached-dev \
+    libwebp-dev \
+    libxpm-dev \
+    libjpeg62-turbo-dev \
+    g++ \
+    && apt autoclean \
+    && apt autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install APCu
+RUN pecl install apcu && \
+    pecl install memcached
+
+# install and configure extensions
+RUN docker-php-ext-install -j$(nproc) opcache pdo_mysql zip xsl
+RUN docker-php-ext-configure intl && \
+    docker-php-ext-install -j$(nproc) intl
+RUN docker-php-ext-configure gd --with-jpeg --with-freetype && \
+    docker-php-ext-install -j$(nproc) gd
+RUN docker-php-ext-enable memcached apcu
+
+WORKDIR /var/www
+
+FROM php7_apache_base as php7_apache_chamilo_lms
+
+ARG CHAMILO_VERSION="1.11.18"
+ARG CHAMILO_TAR="chamilo-${CHAMILO_VERSION}-php74.tar.gz"
+
+# download and install chamilo
+ADD "https://github.com/chamilo/chamilo-lms/releases/download/v${CHAMILO_VERSION}/${CHAMILO_TAR}" "/var/www/chamilo.tar.gz"
+# unpack, delete archive, rename folders
+RUN tar -zxf chamilo.tar.gz \
+    && rm chamilo.tar.gz \
+    && mv chamilo* chamilo
+# delete unneeded files
+RUN find . -iname ".git*" -exec rm -rf {} + \
+    && rm -rf chamilo/tests chamilo/.htac*
+
+WORKDIR /var/www/chamilo
+
+RUN bash -c 'mkdir main/inc/lib/javascript/bigupload/files/'
+RUN bash -c 'chown www-data:www-data main/inc/lib/javascript/bigupload/files/'
+
+RUN bash -c 'set -o pipefail; ls -d app main/default_course_document/images main/lang vendor web | parallel chown -R www-data:www-data "{}"'
+
+# Configure and start Apache
+RUN a2dissite 000-default; rm -rf /etc/apache2/sites-enabled/000-default.conf
+COPY files/security.conf /etc/apache2/conf-available/
+COPY files/chamilo.conf /etc/apache2/sites-available/chamilo.conf
+RUN a2ensite chamilo; a2enmod remoteip rewrite headers
+
+# configure /etc/hosts
+# RUN echo "127.0.0.1 docker.chamilo.net" >> /etc/hosts
+
+EXPOSE 80

--- a/chamilo/CVE-2023-4220/chamilo-php7/files/chamilo.conf
+++ b/chamilo/CVE-2023-4220/chamilo-php7/files/chamilo.conf
@@ -1,0 +1,135 @@
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  ServerName docker.chamilo.net
+
+  DocumentRoot /var/www/chamilo
+
+  <Directory />
+    AllowOverride All
+    Require all granted
+  </Directory>
+
+  <Directory ~/.>
+    AllowOverride None
+    Options -Indexes
+  </Directory>
+
+  <Directory /var/www/chamilo>
+    AllowOverride All
+    Require all granted
+  </Directory>
+
+  <Directory /var/www/chamilo>
+    # Rewrites
+    RewriteEngine On
+    
+    # Prevent execution of PHP from directories used for different types of uploads
+    RedirectMatch 403 ^/app/(cache|courses|home|logs|upload|Resources/public/css)/.*\.ph(p[3457]?|t|tml|ar)$
+    RedirectMatch 403 ^/main/default_course_document/images/.*\.ph(p[3457]?|t|tml|ar)$
+    RedirectMatch 403 ^/main/lang/.*\.ph(p[3457]?|t|tml|ar)$
+    RedirectMatch 403 ^/web/css/.*\.ph(p[3457]?|t|tml|ar)$
+
+    # http://my.chamilo.net/certificates/?id=123 to http://my.chamilo.net/certificates/index.php?id=123
+    RewriteCond %{QUERY_STRING} ^id=(.*)$
+    RewriteRule ^certificates/$ certificates/index.php?id=%1 [L]
+
+    # Course redirection
+    RewriteRule ^courses/([^/]+)/?$ main/course_home/course_home.php?cDir=$1 [QSA,L]
+    RewriteRule ^courses/([^/]+)/index.php$ main/course_home/course_home.php?cDir=$1 [QSA,L]
+
+    # Rewrite everything in the scorm folder of a course to the download script
+    RewriteRule ^courses/([^/]+)/scorm/(.*)$ main/document/download_scorm.php?doc_url=/$2&cDir=$1 [QSA,L]
+
+    # Rewrite everything in the document folder of a course to the download script
+    # Except certificate resources, which might need to be accessible publicly to all
+    RewriteRule ^courses/([^/]+)/document/certificates/(.*)$ app/courses/$1/document/certificates/$2 [QSA,L]
+    RewriteRule ^courses/([^/]+)/document/(.*)$ main/document/download.php?doc_url=/$2&cDir=$1 [QSA,L]
+
+    # Course upload files
+    RewriteRule ^courses/([^/]+)/upload/([^/]+)/(.*)$ main/document/download_uploaded_files.php?code=$1&type=$2&file=$3 [QSA,L]
+
+    # Rewrite everything in the work folder
+    RewriteRule ^courses/([^/]+)/work/(.*)$ main/work/download.php?file=work/$2&cDir=$1 [QSA,L]
+
+    RewriteRule ^courses/([^/]+)/course-pic85x85.png$ main/inc/ajax/course.ajax.php?a=get_course_image&code=$1&image=course_image_source [QSA,L]
+    RewriteRule ^courses/([^/]+)/course-pic.png$ main/inc/ajax/course.ajax.php?a=get_course_image&code=$1&image=course_image_large_source [QSA,L]
+
+    # Redirect all courses/ to app/courses/
+    RewriteRule ^courses/([^/]+)/(.*)$ app/courses/$1/$2 [QSA,L]
+
+    # About session
+    RewriteRule ^session/(\d{1,})/about/?$ main/session/about.php?session_id=$1 [L]
+
+    # About course
+    RewriteRule ^course/(\d{1,})/about/?$ main/course_info/about.php?course_id=$1 [L]
+
+    # Issued individual badge friendly URL
+    RewriteRule ^badge/(\d{1,}) main/badge/issued.php?issue=$1 [L]
+
+    # Issued badges friendly URL
+    RewriteRule ^skill/(\d{1,})/user/(\d{1,}) main/badge/issued_all.php?skill=$1&user=$2 [L]
+    # Support deprecated URL (avoid 404)
+    RewriteRule ^badge/(\d{1,})/user/(\d{1,}) main/badge/issued_all.php?skill=$1&user=$2 [L]
+
+    # Support old URLs using the exercice (with a c) folder rather than exercise
+    RewriteRule ^main/exercice/(.*)$ main/exercise/$1 [QSA,L]
+    # Support old URLs using the newscorm folder rather than lp
+    RewriteRule ^main/newscorm/(.*)$ main/lp/$1 [QSA,L]
+
+    # service Information
+    RewriteRule ^service/(\d{1,})$ plugin/buycourses/src/service_information.php?service_id=$1 [L]
+
+    # This rule is very generic and should always remain at the bottom of .htaccess
+    # http://my.chamilo.net/jdoe to http://my.chamilo.net/user.php?jdoe
+    RewriteRule ^([^/.]+)/?$ user.php?$1 [L]
+
+    # Deny access
+    RewriteRule ^(tests|.git|.env|.env.dist|config) - [F,L,NC]
+  </Directory>
+
+  AddType application/font-woff .woff .woff2
+  <IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType application/font-woff "access plus 1 month"
+  </IfModule>
+
+  # php values
+  php_value expose_php Off
+  php_value error_logging On
+  php_value error_reporting 6143
+  php_value display_errors On
+  php_value xdebug.enable On
+
+  #php_value memory_limit 256 
+  php_value upload_max_filesize 100M
+  php_value post_max_size 100M
+  php_value max_execution_time 300
+  php_value max_input_time 600
+  php_value session.cookie_httponly 1
+
+  php_value safe_mode Off
+  php_value short_open_tag Off
+  php_value magic_quotes_gpc Off
+  php_value magic_quotes_runtime Off
+  php_value allow_url_fopen Off
+  php_value date.timezone Europe/Zurich
+  php_value variables_order GPCS
+  php_value output_buffering On
+
+  php_value sendmail_path "/usr/sbin/sendmail -t -i"
+  php_value mail.add_x_header On
+
+  php_value opcache.interned_strings_buffer 16
+  php_value opcache.max_accelerated_files 100000
+  php_value opcache.validate_timestamps 0
+  php_value apc.enabled 1
+  php_value apc.enable_cli 1
+  php_value request_terminate_timeout 50
+
+  php_value session.gc_maxlifetime 4320
+
+  # logging
+  LogLevel warn
+  #ErrorLog ${APACHE_LOG_DIR}/docker.chamilo-error.log
+  #CustomLog ${APACHE_LOG_DIR}/docker.chamilo-access.log combined
+</VirtualHost>

--- a/chamilo/CVE-2023-4220/chamilo-php7/files/security.conf
+++ b/chamilo/CVE-2023-4220/chamilo-php7/files/security.conf
@@ -1,0 +1,79 @@
+# Disable access to the entire file system except for the directories that
+# are explicitly allowed later.
+#
+# This currently breaks the configurations that come with some web application
+# Debian packages.
+#
+#<Directory />
+#   AllowOverride None
+#   Require all denied
+#</Directory>
+
+
+# Changing the following options will not really affect the security of the
+# server, but might make attacks slightly more difficult in some cases.
+
+#
+# ServerTokens
+# This directive configures what you return as the Server HTTP response
+# Header. The default is 'Full' which sends information about the OS-Type
+# and compiled in modules.
+# Set to one of:  Full | OS | Minimal | Minor | Major | Prod
+# where Full conveys the most information, and Prod the least.
+#ServerTokens Minimal
+ServerTokens Prod
+#ServerTokens Full
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (internal error documents, FTP directory
+# listings, mod_status and mod_info output etc., but not CGI generated
+# documents or custom error documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+#ServerSignature Off
+ServerSignature Off
+
+#
+# Allow TRACE method
+#
+# Set to "extended" to also reflect the request body (only for testing and
+# diagnostic purposes).
+#
+# Set to one of:  On | Off | extended
+TraceEnable Off
+#TraceEnable On
+
+#
+# Forbid access to version control directories
+#
+# If you use version control systems in your document root, you should
+# probably deny access to their directories. For example, for subversion:
+#
+#<DirectoryMatch "/\.svn">
+#   Require all denied
+#</DirectoryMatch>
+
+#
+# Setting this header will prevent MSIE from interpreting files as something
+# else than declared by the content type in the HTTP headers.
+# Requires mod_headers to be enabled.
+#
+#Header set X-Content-Type-Options: "nosniff"
+
+#
+# Setting this header will prevent other sites from embedding pages from this
+# site as frames. This defends against clickjacking attacks.
+# Requires mod_headers to be enabled.
+#
+#Header set X-Frame-Options: "sameorigin"
+
+# X-XSS-Protection
+#Header set X-XSS-Protection "1; mode=block"
+
+# X-Powered-By
+Header always unset "X-Powered-By"
+Header unset "X-Powered-By"
+
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/chamilo/CVE-2023-4220/docker-compose.yml
+++ b/chamilo/CVE-2023-4220/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.5"
+services:
+  mariadb:
+    image: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=pass
+      - MYSQL_USER=chamilo
+      - MYSQL_PASSWORD=chamilo
+      - MYSQL_DATABASE=chamilo
+    labels:
+      "project.id": "docker.compose.mariadb"
+      "project.github.url": "https://github.com/22phuber/docker-compose-chamilo-lms"
+  chamilo_php7:
+    build:
+      context: ./chamilo-php7
+      target: php7_apache_chamilo_lms
+      args:
+        - CHAMILO_VERSION=1.11.18
+        - CHAMILO_TAR=chamilo-1.11.18-php74.tar.gz
+    links:
+      - mariadb
+    ports:
+      - "8080:80"
+    extra_hosts:
+      - "docker.chamilo.net:127.0.0.1"
+    labels:
+      "project.id": "docker.compose.chamilo_lms"
+      "project.github.url": "https://github.com/22phuber/docker-compose-chamilo-lms"


### PR DESCRIPTION
# CVE-2023-4220
Chamilo LMS is a free software e-learning and content management system. In versions prior to <= v1.11.24 a webshell can be uploaded via the bigload.php endpoint. If the GET request parameter `action` is set to `post-unsupported` file extension checks are skipped allowing for attacker controlled .php files to be uploaded to: `/main/inc/lib/javascript/bigupload/files/` if the `/files/` directory already exists - it does not exist by default. The required directory `/files`/ has been added to this container for vulnerability testing purposes.

This docker setup was entirely copied from https://github.com/22phuber/docker-compose-chamilo-lms. The original Dockerfile had the Chamilo version set to 1.11.12 which is unaffected by the vulnerability as it doesn't have the /bigupload/ endpoint. The base version of PHP was updated, as well as some necessary packages to prevent the build from failling. The version of Chamilo was updated to 1.11.18 which is affected by CVE-2023-4220 also as mentioned the necessary dierctory `/files/` has been added as well. Thanks to 22phuber for all the hard work.


# Chamilo LMS docker-compose

A simple docker-compose setup for [Chamilo](https://chamilo.org/) LMS.

Official Docker Hub images used:
* [php](https://hub.docker.com/_/php/) (7.x-apache)
* [mariadb](https://hub.docker.com/_/mariadb/) (latest)

Chamilo LMS on Github: https://github.com/chamilo/chamilo-lms

This setup doesn't directly install/configure Chamilo. You have to use the Chamilo installation wizard once the docker containers are up.

*This setup works with Chamilo version 1.11.x

### Optional: Host system config

On the Host system you need to add a `/etc/hosts` entry for the domain name configured in the apache vhost:

```bash
sudo echo "127.0.0.1 docker.chamilo.net" >> /etc/hosts
```

##### `.../etc/hosts` on Windows:
* Open a text editor as administrator (with administrator privileges)
* Open hosts file: `C:\Windows\System32\Drivers\etc\hosts`
* Add entry `127.0.0.1 docker.chamilo.net` at the end of the file and **save**.

# ENV Variables

### `environment` variables for MYSQL
You can define mysql username, password and database name in the docker-compose config:

```yaml
    ...
    environment:
      - MYSQL_ROOT_PASSWORD=pass
      - MYSQL_USER=chamilo
      - MYSQL_PASSWORD=chamilo
      - MYSQL_DATABASE=chamilo
    ...
```

### `args` variables for building Chamilo
You can define the Version for Chamilo with `CHAMILO_VERSION`.
And you have to set the `CHAMILO_TAR` filename due to incosistent naming.
Check for `.tar.gz` filenames here: https://github.com/chamilo/chamilo-lms/releases

Example in `docker-compose.yml`:
```yaml
      args:
        - CHAMILO_VERSION=1.11.10
        - CHAMILO_TAR=chamilo-1.11.10-php7.3.tar.gz
```

The `args` settings in `docker-compose.yml` will override the `ARG` settings in the `Dockerfile`.
If you remove the `args` in `docker-compose.yml`, the "fallback" values from the `Dockerfile` will be used.

### Build & Run

##### Build:
Build chamilo docker image
```bash
docker-compose -f docker-compose.yml build
```

##### Run:
```bash
docker-compose -f docker-compose.yml up
```

## Database connection step in web installation wizard
The "Database Host" in step 4 of the mysql connections settings has to be the name of the docker image defined in the appropriate `docker-compose.yml`.

Database Host: `mariadb`

## Access Chamilo Website
Access Chamilo URL with `/etc/hosts` entry:

```
http://docker.chamilo.net:8080/
```

Without `/etc/hosts` entry:
```
http://localhost:8080
```