### PR TITLE
Translate Hadoop YARN Unauthorized Access vulnerability documentation

### DIFF
--- a/hadoop/unauthorized-yarn/README.md
+++ b/hadoop/unauthorized-yarn/README.md
@@ -1,28 +1,32 @@
-# Hadoop YARN ResourceManager 未授权访问
+# Hadoop YARN ResourceManager Unauthorized Access
 
-## 原理
+[中文版本(Chinese version)](README.zh-cn.md)
 
-参考 http://archive.hack.lu/2016/Wavestone%20-%20Hack.lu%202016%20-%20Hadoop%20safari%20-%20Hunting%20for%20vulnerabilities%20-%20v1.0.pdf
+Hadoop YARN (Yet Another Resource Negotiator) is Apache Hadoop's cluster resource management system. If the YARN ResourceManager is exposed to the public internet without proper access controls, an attacker can submit and execute arbitrary applications on the cluster.
 
-## 测试环境
+References:
 
-运行测试环境
+- <http://archive.hack.lu/2016/Wavestone%20-%20Hack.lu%202016%20-%20Hadoop%20safari%20-%20Hunting%20for%20vulnerabilities%20-%20v1.0.pdf>
+- <https://hadoop.apache.org/docs/r2.7.3/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html>
+
+## Environment Setup
+
+Execute the following command to start vulnerable Hadoop YARN environment:
 
 ```
 docker compose up -d
 ```
 
-环境启动后，访问`http://your-ip:8088`即可看到Hadoop YARN ResourceManager WebUI页面。
+After the environment starts, visit `http://your-ip:8088` to access the Hadoop YARN ResourceManager WebUI.
 
-## 利用
+## Vulnerability Reproduction
 
-利用方法和原理中有一些不同。在没有 hadoop client 的情况下，直接通过 REST API
- (https://hadoop.apache.org/docs/r2.7.3/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html) 也可以提交任务执行。
+The exploitation method differs slightly from the original presentation. Even without a Hadoop client, you can submit tasks directly through the REST API (https://hadoop.apache.org/docs/r2.7.3/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html).
 
-利用过程如下：
+The exploitation process is as follows:
 
-1. 在本地监听等待反弹 shell 连接
-1. 调用 New Application API 创建 Application
-1. 调用 Submit Application API 提交
+1. Set up a listener on your local machine to receive the reverse shell connection
+2. Call the New Application API to create an Application
+3. Call the Submit Application API to submit the malicious application
 
-参考 [exp 脚本](exploit.py)
+For detailed implementation, refer to the [exploit script](exploit.py).

--- a/hadoop/unauthorized-yarn/README.zh-cn.md
+++ b/hadoop/unauthorized-yarn/README.zh-cn.md
@@ -1,0 +1,30 @@
+# Hadoop YARN ResourceManager 未授权访问漏洞
+
+Hadoop YARN（Yet Another Resource Negotiator）是Apache Hadoop的集群资源管理系统。YARN ResourceManager中存在一个未授权访问漏洞，由于缺少访问控制，未经授权的用户可以在集群上提交并执行任意应用程序。
+
+参考链接：
+
+- <http://archive.hack.lu/2016/Wavestone%20-%20Hack.lu%202016%20-%20Hadoop%20safari%20-%20Hunting%20for%20vulnerabilities%20-%20v1.0.pdf>
+- <https://hadoop.apache.org/docs/r2.7.3/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html>
+
+## 环境搭建
+
+执行如下命令启动环境：
+
+```
+docker compose up -d
+```
+
+环境启动后，访问`http://your-ip:8088`即可看到Hadoop YARN ResourceManager的Web管理界面。
+
+## 漏洞复现
+
+漏洞利用方法与原始演示文稿中的方法略有不同。即使没有Hadoop客户端，也可以直接通过REST API（https://hadoop.apache.org/docs/r2.7.3/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html）提交任务执行。
+
+漏洞利用过程如下：
+
+1. 在本地机器上设置监听器，等待反弹shell连接
+2. 调用New Application API创建应用程序
+3. 调用Submit Application API提交恶意应用程序
+
+具体实现请参考[漏洞利用脚本](exploit.py)。

--- a/hadoop/unauthorized-yarn/docker-compose.yml
+++ b/hadoop/unauthorized-yarn/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   namenode:
     image: vulhub/hadoop:2.8.1


### PR DESCRIPTION
- Remove Docker Compose version specification
- Translate README to English
- Add Chinese version README (README.zh-cn.md)
- Enhance documentation with detailed explanation of YARN ResourceManager unauthorized access vulnerability