### PR TITLE
CVE-2025-24813: 镜像缺少commons-collections-3.2.1.jar

### DIFF
--- a/tomcat/CVE-2025-24813/Dockerfile
+++ b/tomcat/CVE-2025-24813/Dockerfile
@@ -4,4 +4,6 @@ LABEL maintainer="phithon <root@leavesongs.com>"
 
 RUN set -ex \
     && sed -i '/<load-on-startup>1<\/load-on-startup>/i \        <init-param>\n            <param-name>readonly</param-name>\n            <param-value>false</param-value>\n        </init-param>' /usr/local/tomcat/conf/web.xml \
-    && sed -i '/<\/Context>/i \    <Manager className="org.apache.catalina.session.PersistentManager">\n        <Store className="org.apache.catalina.session.FileStore"/>\n    </Manager>' /usr/local/tomcat/conf/context.xml
+    && sed -i '/<\/Context>/i \    <Manager className="org.apache.catalina.session.PersistentManager">\n        <Store className="org.apache.catalina.session.FileStore"/>\n    </Manager>' /usr/local/tomcat/conf/context.xml  \
+    && wget --no-check-certificate -O /usr/local/tomcat/lib/commons-collections-3.2.1.jar https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar
+


### PR DESCRIPTION
镜像缺少commons-collections-3.2.1.jar。无法执行命令。