### PR TITLE
fix base image of CVE-2018-14574

### DIFF
--- a/django/CVE-2018-14574/Dockerfile
+++ b/django/CVE-2018-14574/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.7.3-alpine3.8
 
 LABEL maintainer="phithon <root@leavesongs.com>"
 


### PR DESCRIPTION
The original base image was updated later, preventing the CVE from being reproducible. A specific version of the image needs to be pinned.


