### PR TITLE
perf: speed up spring-boot-jetty:3.2.4 start

### DIFF
--- a/base/spring/spring-boot-jetty/3.2.4/Dockerfile
+++ b/base/spring/spring-boot-jetty/3.2.4/Dockerfile
@@ -1,15 +1,23 @@
-FROM maven:3.9-eclipse-temurin-17
-
-LABEL maintainer="phithon <root@leavesongs.com>"
-
-COPY pom.xml /usr/src/pom.xml
+FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /usr/src
 
+COPY pom.xml .
 RUN mvn -U dependency:resolve dependency:resolve-plugins
 
-COPY src /usr/src/src
+COPY src ./src
+RUN mvn package -DskipTests
+
+FROM eclipse-temurin:17-jre
+
+LABEL maintainer="phithon <root@leavesongs.com>"
+
+WORKDIR /app
+
+COPY --from=builder /usr/src/target/*.jar app.jar
 
 EXPOSE 8080 5005
 
-CMD ["mvn", "spring-boot:run", "-Dspring-boot.run.jvmArguments=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"]
+ENV JAVA_OPTS=""
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -jar app.jar"]

--- a/base/spring/spring-boot-jetty/3.2.4/Dockerfile
+++ b/base/spring/spring-boot-jetty/3.2.4/Dockerfile
@@ -9,8 +9,10 @@ FROM eclipse-temurin:17-jre
 
 LABEL maintainer="phithon <root@leavesongs.com>"
 
-COPY --from=builder /usr/src/target/app.jar /app.jar
+WORKDIR /app
+
+COPY --from=builder /usr/src/target/app.jar /app/app.jar
 
 EXPOSE 8080 5005
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-jar", "/app.jar"]
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-jar", "/app/app.jar"]

--- a/base/spring/spring-boot-jetty/3.2.4/Dockerfile
+++ b/base/spring/spring-boot-jetty/3.2.4/Dockerfile
@@ -1,23 +1,16 @@
 FROM maven:3.9-eclipse-temurin-17 AS builder
 
-WORKDIR /usr/src
+COPY ./ /usr/src
 
-COPY pom.xml .
-RUN mvn -U dependency:resolve dependency:resolve-plugins
-
-COPY src ./src
-RUN mvn package -DskipTests
+RUN cd /usr/src; \
+    mvn -U clean package -Dmaven.test.skip=true -Dmaven.artifact.threads=10
 
 FROM eclipse-temurin:17-jre
 
 LABEL maintainer="phithon <root@leavesongs.com>"
 
-WORKDIR /app
-
-COPY --from=builder /usr/src/target/*.jar app.jar
+COPY --from=builder /usr/src/target/app.jar /app.jar
 
 EXPOSE 8080 5005
 
-ENV JAVA_OPTS=""
-
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -jar app.jar"]
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-jar", "/app.jar"]


### PR DESCRIPTION
优化 spring-boot-jetty:3.2.4 容器启动速度，之前启动构建 maven 还需要下载构建所需的环境，在部分网络不通畅的环境会出现启动缓慢的问题，使用分层构建之后，启动时直接启动 jar 包能加快启动速度

```
[INFO] Scanning for projects...
2026-05-21T19:35:57.152685088Z Downloading from central: https://repo.maven.apache.org/maven2/org/flywaydb/maven-metadata.xml
2026-05-21T19:35:57.152997883Z Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/maven-metadata.xml
2026-05-21T19:35:57.153702349Z Downloading from central: https://repo.maven.apache.org/maven2/org/jooq/maven-metadata.xml
2026-05-21T19:35:57.153894976Z Downloading from central: https://repo.maven.apache.org/maven2/io/github/git-commit-id/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/maven-metadata.xml (249 B at 78 B/s)
2026-05-21T19:36:00.337941937Z Downloaded from central: https://repo.maven.apache.org/maven2/org/jooq/maven-metadata.xml (398 B at 124 B/s)
2026-05-21T19:36:00.339712457Z Downloaded from central: https://repo.maven.apache.org/maven2/org/flywaydb/maven-metadata.xml (234 B at 73 B/s)
2026-05-21T19:36:00.339831250Z Downloaded from central: https://repo.maven.apache.org/maven2/io/github/git-commit-id/maven-metadata.xml (255 B at 79 B/s)
2026-05-21T19:36:00.346031569Z Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml
2026-05-21T19:36:00.346166737Z Downloading from central: https://repo.maven.apache.org/maven2/org/graalvm/buildtools/maven-metadata.xml
2026-05-21T19:36:00.346170237Z Downloading from central: https://repo.maven.apache.org/maven2/org/liquibase/maven-metadata.xml
2026-05-21T19:36:00.346171654Z Downloading from central: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/graalvm/buildtools/maven-metadata.xml (242 B at 558 B/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/maven-metadata.xml (375 B at 833 B/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/liquibase/maven-metadata.xml (394 B at 869 B/s)
2026-05-21T19:36:00.799100775Z Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-metadata.xml (14 kB at 32 kB/s)
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/mojo/maven-metadata.xml (21 kB at 23 kB/s)
2026-05-21T19:36:01.803275862Z [INFO] 
2026-05-21T19:36:01.803467615Z [INFO] --------------------< org.vulhub:spring-boot-jetty >--------------------
2026-05-21T19:36:01.803557824Z [INFO] Building spring-boot-jetty 1.0-SNAPSHOT
2026-05-21T19:36:01.803748493Z [INFO]   from pom.xml
2026-05-21T19:36:01.803846619Z [INFO] --------------------------------[ jar ]---------------------------------
2026-05-21T19:36:01.882169782Z [INFO] 
2026-05-21T19:36:01.882327742Z [INFO] >>> spring-boot:3.2.4:run (default-cli) > test-compile @ spring-boot-jetty >>>
2026-05-21T19:36:02.621638883Z [INFO] 
2026-05-21T19:36:02.621656966Z [INFO] --- resources:3.3.1:resources (default-resources) @ spring-boot-jetty ---
2026-05-21T19:36:02.933659228Z [INFO] Copying 1 resource from src/main/resources to target/classes
2026-05-21T19:36:02.943690465Z [INFO] Copying 1 resource from src/main/resources to target/classes
2026-05-21T19:36:02.944690393Z [INFO] 
2026-05-21T19:36:02.944761560Z [INFO] --- compiler:3.11.0:compile (default-compile) @ spring-boot-jetty ---
2026-05-21T19:36:03.111097911Z [INFO] Changes detected - recompiling the module! :source
2026-05-21T19:36:03.113408645Z [INFO] Compiling 1 source file with javac [debug release 17] to target/classes
2026-05-21T19:36:03.884394638Z [INFO] 
2026-05-21T19:36:03.884668599Z [INFO] --- resources:3.3.1:testResources (default-testResources) @ spring-boot-jetty ---
2026-05-21T19:36:03.917429047Z [INFO] skip non existing resourceDirectory /usr/src/src/test/resources
2026-05-21T19:36:03.917696550Z [INFO] 
2026-05-21T19:36:03.917701300Z [INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ spring-boot-jetty ---
2026-05-21T19:36:03.926814610Z [INFO] No sources to compile
2026-05-21T19:36:03.926832902Z [INFO] 
2026-05-21T19:36:03.926834443Z [INFO] <<< spring-boot:3.2.4:run (default-cli) < test-compile @ spring-boot-jetty <<<
2026-05-21T19:36:03.926836152Z [INFO] 
2026-05-21T19:36:03.928788215Z [INFO] 
2026-05-21T19:36:03.928798882Z [INFO] --- spring-boot:3.2.4:run (default-cli) @ spring-boot-jetty ---
2026-05-21T19:36:04.339313948Z [INFO] Attaching agents: []
2026-05-21T19:36:04.562332013Z Listening for transport dt_socket at address: 5005
2026-05-21T19:36:05.226118480Z 
2026-05-21T19:36:05.226140480Z   .   ____          _            __ _ _
2026-05-21T19:36:05.226143772Z  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
2026-05-21T19:36:05.226145063Z ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
2026-05-21T19:36:05.226279023Z  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
2026-05-21T19:36:05.226283232Z   '  |____| .__|_| |_|_| |_\__, | / / / /
2026-05-21T19:36:05.226284482Z  =========|_|==============|___/=/_/_/_/
2026-05-21T19:36:05.227066574Z  :: Spring Boot ::                (v3.2.4)
2026-05-21T19:36:05.227079157Z 
2026-05-21T19:36:05.294149278Z 2026-05-21T19:36:05.292Z  INFO 95 --- [           main] org.vulhub.springbootjetty.Application   : Starting Application using Java 17.0.18 with PID 95 (/usr/src/target/classes started by root in /usr/src)
2026-05-21T19:36:05.295415876Z 2026-05-21T19:36:05.295Z  INFO 95 --- [           main] org.vulhub.springbootjetty.Application   : No active profile set, falling back to 1 default profile: "default"
2026-05-21T19:36:06.307468925Z 2026-05-21T19:36:06.306Z  INFO 95 --- [           main] o.s.b.w.e.j.JettyServletWebServerFactory : Server initialized with port: 8080
2026-05-21T19:36:06.311080466Z 2026-05-21T19:36:06.310Z  INFO 95 --- [           main] org.eclipse.jetty.server.Server          : jetty-12.0.7; built: 2024-02-29T21:19:41.771Z; git: c89aca8fd34083befd79f328a3b8b6ffff04347e; jvm 17.0.18+8
2026-05-21T19:36:06.342221437Z 2026-05-21T19:36:06.341Z  INFO 95 --- [           main] o.e.j.s.h.ContextHandler.application     : Initializing Spring embedded WebApplicationContext
2026-05-21T19:36:06.343524202Z 2026-05-21T19:36:06.343Z  INFO 95 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 972 ms
2026-05-21T19:36:06.390890687Z 2026-05-21T19:36:06.390Z  INFO 95 --- [           main] o.e.j.session.DefaultSessionIdManager    : Session workerName=node0
2026-05-21T19:36:06.394738605Z 2026-05-21T19:36:06.394Z  INFO 95 --- [           main] o.e.jetty.server.handler.ContextHandler  : Started osbwej.JettyEmbeddedWebAppContext@6ba30587{application,/,b=file:/tmp/jetty-docbase.8080.12385141260278738524/,a=AVAILABLE,h=oeje10s.SessionHandler@35764bef{STARTED}}
2026-05-21T19:36:06.395019858Z 2026-05-21T19:36:06.394Z  INFO 95 --- [           main] o.e.j.e.servlet.ServletContextHandler    : Started osbwej.JettyEmbeddedWebAppContext@6ba30587{application,/,b=file:/tmp/jetty-docbase.8080.12385141260278738524/,a=AVAILABLE,h=oeje10s.SessionHandler@35764bef{STARTED}}
2026-05-21T19:36:06.396435623Z 2026-05-21T19:36:06.396Z  INFO 95 --- [           main] org.eclipse.jetty.server.Server          : Started oejs.Server@7e94d093{STARTING}[12.0.7,sto=0] @1989ms
2026-05-21T19:36:06.495646519Z 2026-05-21T19:36:06.495Z  INFO 95 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page: class path resource [static/index.html]
2026-05-21T19:36:06.699849790Z 2026-05-21T19:36:06.698Z  INFO 95 --- [           main] o.e.j.s.h.ContextHandler.application     : Initializing Spring DispatcherServlet 'dispatcherServlet'
2026-05-21T19:36:06.699867999Z 2026-05-21T19:36:06.699Z  INFO 95 --- [           main] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2026-05-21T19:36:06.700425797Z 2026-05-21T19:36:06.700Z  INFO 95 --- [           main] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms
2026-05-21T19:36:06.720542104Z 2026-05-21T19:36:06.718Z  INFO 95 --- [           main] o.e.jetty.server.AbstractConnector       : Started ServerConnector@2604837d{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
2026-05-21T19:36:06.724853860Z 2026-05-21T19:36:06.724Z  INFO 95 --- [           main] o.s.b.web.embedded.jetty.JettyWebServer  : Jetty started on port 8080 (http/1.1) with context path '/'
2026-05-21T19:36:06.739240103Z 2026-05-21T19:36:06.738Z  INFO 95 --- [           main] org.vulhub.springbootjetty.Application   : Started Application in 1.879 seconds (process running for 2.332)
```