### PR TITLE
Remove obsolete version field from struts2/s2-045 and struts2/s2-057

### DIFF
--- a/struts2/s2-045/docker-compose.yml
+++ b/struts2/s2-045/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  struts2:
    image: vulhub/struts2:2.3.30

--- a/struts2/s2-057/docker-compose.yml
+++ b/struts2/s2-057/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
  struts2:
    image: vulhub/struts2:2.3.34-showcase


### PR DESCRIPTION
`docker compose` warns that the top-level `version` key is obsolete and ignored:

```
WARN: struts2/s2-045/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

Per #545, @phith0n already confirmed this is the intended direction ("我正在逐渐推进删除 docker compose 文件中的 `version` 字段"). This removes the field from the two environments I was using (`struts2/s2-045`, `struts2/s2-057`), matching the format already used by migrated environments (e.g. `spring/CVE-2022-22963`). No functional change — `version` was already ignored by current `docker compose`.

Closes part of #545.
